### PR TITLE
Partition CommandStores by contiguous ranges

### DIFF
--- a/accord-core/src/main/java/accord/coordinate/CheckOn.java
+++ b/accord-core/src/main/java/accord/coordinate/CheckOn.java
@@ -216,10 +216,7 @@ public class CheckOn extends CheckShards
             if (!merged.durability.isDurable() || homeKey == null)
                 return null;
 
-            if (!safeStore.ranges().owns(txnId.epoch, homeKey))
-                return null;
-
-            if (!safeStore.commandStore().hashIntersects(homeKey))
+            if (!safeStore.ranges().at(txnId.epoch).contains(homeKey))
                 return null;
 
             Timestamp executeAt = merged.saveStatus.known.executeAt.isDecisionKnown() ? merged.executeAt : null;

--- a/accord-core/src/main/java/accord/coordinate/Execute.java
+++ b/accord-core/src/main/java/accord/coordinate/Execute.java
@@ -104,6 +104,9 @@ class Execute extends ReadCoordinator<ReadReply>
         switch (nack)
         {
             default: throw new IllegalStateException();
+            case Error:
+                // TODO (expected): report content of error
+                return Action.Reject;
             case Redundant:
                 callback.accept(null, new Preempted(txnId, route.homeKey()));
                 return Action.Abort;

--- a/accord-core/src/main/java/accord/impl/InMemoryCommandStores.java
+++ b/accord-core/src/main/java/accord/impl/InMemoryCommandStores.java
@@ -23,7 +23,6 @@ import accord.api.Agent;
 import accord.api.DataStore;
 import accord.api.ProgressLog;
 import accord.local.CommandStore;
-import accord.local.Node;
 import accord.primitives.Routables;
 import accord.utils.MapReduce;
 
@@ -34,9 +33,9 @@ public class InMemoryCommandStores
 {
     public static class Synchronized extends SyncCommandStores
     {
-        public Synchronized(int num, Node node, Agent agent, DataStore store, ProgressLog.Factory progressLogFactory)
+        public Synchronized(NodeTimeService time, Agent agent, DataStore store, ShardDistributor shardDistributor, ProgressLog.Factory progressLogFactory)
         {
-            super(num, node, agent, store, progressLogFactory, InMemoryCommandStore.Synchronized::new);
+            super(time, agent, store, shardDistributor, progressLogFactory, InMemoryCommandStore.Synchronized::new);
         }
 
         public <T> T mapReduce(PreLoadContext context, Routables<?, ?> keys, long minEpoch, long maxEpoch, MapReduce<? super SafeCommandStore, T> map)
@@ -64,22 +63,22 @@ public class InMemoryCommandStores
 
     public static class SingleThread extends AsyncCommandStores
     {
-        public SingleThread(int num, NodeTimeService time, Agent agent, DataStore store, ProgressLog.Factory progressLogFactory)
+        public SingleThread(NodeTimeService time, Agent agent, DataStore store, ShardDistributor shardDistributor, ProgressLog.Factory progressLogFactory)
         {
-            super(num, time, agent, store, progressLogFactory, InMemoryCommandStore.SingleThread::new);
+            super(time, agent, store, shardDistributor, progressLogFactory, InMemoryCommandStore.SingleThread::new);
         }
 
-        public SingleThread(int num, NodeTimeService time, Agent agent, DataStore store, ProgressLog.Factory progressLogFactory, CommandStore.Factory shardFactory)
+        public SingleThread(NodeTimeService time, Agent agent, DataStore store, ShardDistributor shardDistributor, ProgressLog.Factory progressLogFactory, CommandStore.Factory shardFactory)
         {
-            super(num, time, agent, store, progressLogFactory, shardFactory);
+            super(time, agent, store, shardDistributor, progressLogFactory, shardFactory);
         }
     }
 
     public static class Debug extends InMemoryCommandStores.SingleThread
     {
-        public Debug(int num, NodeTimeService time, Agent agent, DataStore store, ProgressLog.Factory progressLogFactory)
+        public Debug(NodeTimeService time, Agent agent, DataStore store, ShardDistributor shardDistributor, ProgressLog.Factory progressLogFactory)
         {
-            super(num, time, agent, store, progressLogFactory, InMemoryCommandStore.Debug::new);
+            super(time, agent, store, shardDistributor, progressLogFactory, InMemoryCommandStore.Debug::new);
         }
     }
 }

--- a/accord-core/src/main/java/accord/impl/SimpleProgressLog.java
+++ b/accord-core/src/main/java/accord/impl/SimpleProgressLog.java
@@ -29,10 +29,11 @@ import java.util.function.BiConsumer;
 
 import javax.annotation.Nullable;
 
+import accord.utils.IntrusiveLinkedList;
+import accord.utils.IntrusiveLinkedListNode;
 import accord.api.ProgressLog;
 import accord.api.RoutingKey;
 import accord.coordinate.*;
-import accord.impl.SimpleProgressLog.Instance.State.Monitoring;
 import accord.local.*;
 import accord.local.Node.Id;
 import accord.local.Status.Known;
@@ -41,8 +42,6 @@ import accord.messages.InformDurable;
 import accord.messages.SimpleReply;
 import accord.primitives.*;
 import accord.topology.Topologies;
-import accord.utils.IntrusiveLinkedList;
-import accord.utils.IntrusiveLinkedListNode;
 import accord.utils.Invariants;
 import org.apache.cassandra.utils.concurrent.Future;
 
@@ -94,7 +93,7 @@ public class SimpleProgressLog implements ProgressLog.Factory
         this.node = node;
     }
 
-    class Instance extends IntrusiveLinkedList<Monitoring> implements ProgressLog, Runnable
+    class Instance extends IntrusiveLinkedList<Instance.State.Monitoring> implements ProgressLog, Runnable
     {
         class State
         {
@@ -104,7 +103,9 @@ public class SimpleProgressLog implements ProgressLog.Factory
 
                 void setProgress(Progress newProgress)
                 {
-                    this.progress = newProgress;
+                    Invariants.checkState(progress != Done);
+
+                    progress = newProgress;
                     switch (newProgress)
                     {
                         default: throw new AssertionError();
@@ -112,6 +113,7 @@ public class SimpleProgressLog implements ProgressLog.Factory
                         case Done:
                         case Investigating:
                             remove();
+                            Invariants.paranoid(isFree());
                             break;
                         case Expected:
                         case NoProgress:
@@ -130,8 +132,7 @@ public class SimpleProgressLog implements ProgressLog.Factory
                         case Investigating:
                             throw new IllegalStateException();
                         case Expected:
-                            if (isFree())
-                                throw new IllegalStateException();
+                            Invariants.paranoid(!isFree());
                             progress = NoProgress;
                             return false;
                         case NoProgress:
@@ -197,7 +198,7 @@ public class SimpleProgressLog implements ProgressLog.Factory
                         case Committed:
                         case ReadyToExecute:
                             status = CoordinateStatus.Done;
-                            setProgress(NoneExpected);
+                            setProgress(Done);
                         case Done:
                     }
                 }
@@ -224,9 +225,11 @@ public class SimpleProgressLog implements ProgressLog.Factory
                                 // if the home shard is at an earlier phase, it must run recovery
                                 long epoch = command.executeAt().epoch;
                                 node.withEpoch(epoch, () -> debugInvestigating = FetchData.fetch(PreApplied.minKnown, node, txnId, command.route(), epoch, (success, fail) -> {
-                                    // should have found enough information to apply the result, but in case we did not reset progress
-                                    if (progress() == Investigating)
-                                        setProgress(Expected);
+                                    commandStore.execute(PreLoadContext.empty(), ignore -> {
+                                        // should have found enough information to apply the result, but in case we did not reset progress
+                                        if (progress() == Investigating)
+                                            setProgress(Expected);
+                                    });
                                 }));
                             }
                             else
@@ -236,25 +239,27 @@ public class SimpleProgressLog implements ProgressLog.Factory
 
                                     Future<? extends Outcome> recover = node.maybeRecover(txnId, homeKey, command.route(), token);
                                     recover.addCallback((success, fail) -> {
-                                        if (status.isAtMostReadyToExecute() && progress() == Investigating)
-                                        {
-                                            setProgress(Expected);
-                                            if (fail != null)
-                                                return;
-
-                                            ProgressToken token = success.asProgressToken();
-                                            // TODO: avoid returning null (need to change semantics here in this case, though, as Recover doesn't return CheckStatusOk)
-                                            if (token.durability.isDurable())
+                                        commandStore.execute(PreLoadContext.empty(), ignore -> {
+                                            if (status.isAtMostReadyToExecute() && progress() == Investigating)
                                             {
-                                                commandStore.execute(contextFor(txnId), safeStore -> {
-                                                    Command cmd = safeStore.command(txnId);
-                                                    cmd.setDurability(safeStore, token.durability, homeKey, null);
-                                                    safeStore.progressLog().durable(txnId, cmd.maxUnseekables(), null);
-                                                }).addCallback(commandStore.agent());
-                                            }
+                                                setProgress(Expected);
+                                                if (fail != null)
+                                                    return;
 
-                                            updateMax(token);
-                                        }
+                                                ProgressToken token = success.asProgressToken();
+                                                // TODO: avoid returning null (need to change semantics here in this case, though, as Recover doesn't return CheckStatusOk)
+                                                if (token.durability.isDurable())
+                                                {
+                                                    commandStore.execute(contextFor(txnId), safeStore -> {
+                                                        Command cmd = safeStore.command(txnId);
+                                                        cmd.setDurability(safeStore, token.durability, homeKey, null);
+                                                        safeStore.progressLog().durable(txnId, cmd.maxUnseekables(), null);
+                                                    }).addCallback(commandStore.agent());
+                                                }
+
+                                                updateMax(token);
+                                            }
+                                        });
                                     });
 
                                     debugInvestigating = recover;
@@ -281,6 +286,9 @@ public class SimpleProgressLog implements ProgressLog.Factory
                     {
                         // TODO: callbacks should be associated with a commandStore for processing to avoid this
                         commandStore.execute(PreLoadContext.empty(), ignore -> {
+                            if (progress() == Done)
+                                return;
+
                             notAwareOfDurability.remove(from);
                             maybeDone();
                         });
@@ -359,7 +367,7 @@ public class SimpleProgressLog implements ProgressLog.Factory
 
                 private void maybeDone()
                 {
-                    if (notAwareOfDurability.isEmpty())
+                    if (progress() != Done && notAwareOfDurability.isEmpty())
                     {
                         status = DisseminateStatus.Done;
                         setProgress(Done);
@@ -480,15 +488,17 @@ public class SimpleProgressLog implements ProgressLog.Factory
                     Unseekables<?, ?> someKeys = unseekables(command);
 
                     BiConsumer<Known, Throwable> callback = (success, fail) -> {
-                        if (progress() != Investigating)
-                            return;
+                        commandStore.execute(PreLoadContext.empty(), ignore -> {
+                            if (progress() != Investigating)
+                                return;
 
-                        setProgress(Expected);
-                        if (fail == null)
-                        {
-                            if (!success.isDefinitionKnown()) invalidate(node, txnId, someKeys);
-                            else record(success);
-                        }
+                            setProgress(Expected);
+                            if (fail == null)
+                            {
+                                if (!success.isDefinitionKnown()) invalidate(node, txnId, someKeys);
+                                else record(success);
+                            }
+                        });
                     };
 
                     node.withEpoch(toEpoch, () -> {
@@ -508,12 +518,14 @@ public class SimpleProgressLog implements ProgressLog.Factory
                     RoutingKey someKey = Route.isRoute(someKeys) ? (Route.castToRoute(someKeys)).homeKey() : someKeys.get(0).someIntersectingRoutingKey();
                     someKeys = someKeys.with(someKey);
                     debugInvestigating = Invalidate.invalidate(node, txnId, someKeys, (success, fail) -> {
-                        if (progress() != Investigating)
-                            return;
+                        commandStore.execute(PreLoadContext.empty(), ignore -> {
+                            if (progress() != Investigating)
+                                return;
 
-                        setProgress(Expected);
-                        if (fail == null && success.asProgressToken().durability.isDurable())
-                            setProgress(Done);
+                            setProgress(Expected);
+                            if (fail == null && success.asProgressToken().durability.isDurable())
+                                setProgress(Done);
+                        });
                     });
                 }
 
@@ -533,7 +545,8 @@ public class SimpleProgressLog implements ProgressLog.Factory
 
                 void setSafe()
                 {
-                    setProgress(Done);
+                    if (progress() != Done)
+                        setProgress(Done);
                 }
 
                 @Override
@@ -542,10 +555,12 @@ public class SimpleProgressLog implements ProgressLog.Factory
                     // make sure a quorum of the home shard is aware of the transaction, so we can rely on it to ensure progress
                     Future<Void> inform = inform(node, txnId, command.homeKey());
                     inform.addCallback((success, fail) -> {
-                        if (progress() == Done)
-                            return;
+                        commandStore.execute(PreLoadContext.empty(), ignore -> {
+                            if (progress() == Done)
+                                return;
 
-                        setProgress(fail != null ? Expected : Done);
+                            setProgress(fail != null ? Expected : Done);
+                        });
                     });
                 }
 
@@ -778,14 +793,14 @@ public class SimpleProgressLog implements ProgressLog.Factory
         }
 
         @Override
-        public void addFirst(Monitoring add)
+        public void addFirst(State.Monitoring add)
         {
             super.addFirst(add);
             ensureScheduled();
         }
 
         @Override
-        public void addLast(Monitoring add)
+        public void addLast(State.Monitoring add)
         {
             throw new UnsupportedOperationException();
         }
@@ -805,12 +820,13 @@ public class SimpleProgressLog implements ProgressLog.Factory
             isScheduled = false;
             try
             {
-                for (Monitoring run : this)
+                for (State.Monitoring run : this)
                 {
                     if (run.shouldRun())
                     {
                         commandStore.execute(contextFor(run.txnId()), safeStore -> {
-                            run.run(safeStore.command(run.txnId()));
+                            if (run.shouldRun()) // could have been completed by a callback
+                                run.run(safeStore.command(run.txnId()));
                         });
                     }
                 }

--- a/accord-core/src/main/java/accord/local/AsyncCommandStores.java
+++ b/accord-core/src/main/java/accord/local/AsyncCommandStores.java
@@ -55,9 +55,9 @@ public class AsyncCommandStores extends CommandStores<CommandStore>
         }
     }
 
-    public AsyncCommandStores(int num, NodeTimeService time, Agent agent, DataStore store, ProgressLog.Factory progressLogFactory, CommandStore.Factory shardFactory)
+    public AsyncCommandStores(NodeTimeService time, Agent agent, DataStore store, ShardDistributor shardDistributor, ProgressLog.Factory progressLogFactory, CommandStore.Factory shardFactory)
     {
-        super(num, time, agent, store, progressLogFactory, shardFactory);
+        super(time, agent, store, shardDistributor, progressLogFactory, shardFactory);
     }
 
     @Override

--- a/accord-core/src/main/java/accord/local/Node.java
+++ b/accord-core/src/main/java/accord/local/Node.java
@@ -127,7 +127,7 @@ public class Node implements ConfigurationService.Listener, NodeTimeService
     private final Map<TxnId, Future<? extends Outcome>> coordinating = new ConcurrentHashMap<>();
 
     public Node(Id id, MessageSink messageSink, ConfigurationService configService, LongSupplier nowSupplier,
-                Supplier<DataStore> dataSupplier, Agent agent, Random random, Scheduler scheduler, TopologySorter.Supplier topologySorter,
+                Supplier<DataStore> dataSupplier, ShardDistributor shardDistributor, Agent agent, Random random, Scheduler scheduler, TopologySorter.Supplier topologySorter,
                 Function<Node, ProgressLog.Factory> progressLogFactory, CommandStores.Factory factory)
     {
         this.id = id;
@@ -140,7 +140,7 @@ public class Node implements ConfigurationService.Listener, NodeTimeService
         this.agent = agent;
         this.random = random;
         this.scheduler = scheduler;
-        this.commandStores = factory.create(numCommandShards(), this, agent, dataSupplier.get(), progressLogFactory.apply(this));
+        this.commandStores = factory.create(this, agent, dataSupplier.get(), shardDistributor, progressLogFactory.apply(this));
 
         configService.registerListener(this);
         onTopologyUpdate(topology, false);
@@ -530,7 +530,7 @@ public class Node implements ConfigurationService.Listener, NodeTimeService
 
     public CommandStore unsafeByIndex(int index)
     {
-        return commandStores.current.ranges[0].shards[index];
+        return commandStores.current.shards[index].store;
     }
 
     public LongSupplier unsafeGetNowSupplier()

--- a/accord-core/src/main/java/accord/local/SafeCommandStore.java
+++ b/accord-core/src/main/java/accord/local/SafeCommandStore.java
@@ -67,7 +67,7 @@ public interface SafeCommandStore
     Agent agent();
     ProgressLog progressLog();
     NodeTimeService time();
-    CommandStore.RangesForEpoch ranges();
+    CommandStores.RangesForEpoch ranges();
     long latestEpoch();
     Timestamp preaccept(TxnId txnId, Seekables<?, ?> keys);
 

--- a/accord-core/src/main/java/accord/local/ShardDistributor.java
+++ b/accord-core/src/main/java/accord/local/ShardDistributor.java
@@ -1,0 +1,123 @@
+package accord.local;
+
+import accord.primitives.Range;
+import accord.primitives.Ranges;
+import accord.utils.Invariants;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public interface ShardDistributor
+{
+    // TODO: this is overly simplistic: need to supply existing distribution,
+    //  and support gradual local redistribution to keep number of shards eventually the same
+    List<Ranges> split(Ranges ranges);
+
+    class EvenSplit<T> implements ShardDistributor
+    {
+        public interface Splitter<T>
+        {
+            T sizeOf(Range range);
+            Range subRange(Range range, T start, T end);
+
+            T zero();
+            T add(T a, T b);
+            T subtract(T a, T b);
+            T divide(T a, int i);
+            T multiply(T a, int i);
+            int min(T v, int i);
+            int compare(T a, T b);
+        }
+
+        final int numberOfShards;
+        final Splitter<T> splitter;
+
+        public EvenSplit(int numberOfShards, Splitter<T> splitter)
+        {
+            this.numberOfShards = numberOfShards;
+            this.splitter = splitter;
+        }
+
+        @Override
+        public List<Ranges> split(Ranges ranges)
+        {
+            if (ranges.isEmpty())
+                return Collections.emptyList();
+
+            T totalSize = zero();
+            for (int i = 0 ; i < ranges.size() ; ++i)
+                totalSize = add(totalSize, splitter.sizeOf(ranges.get(i)));
+
+            if (compare(totalSize, zero()) <= 0)
+                throw new IllegalStateException();
+
+            int numberOfShards = splitter.min(totalSize, this.numberOfShards);
+            T shardSize = divide(totalSize, numberOfShards);
+            List<Range> buffer = new ArrayList<>(ranges.size());
+            List<Ranges> result = new ArrayList<>(numberOfShards);
+            int ri = 0;
+            T rOffset = zero();
+            T rSize = splitter.sizeOf(ranges.get(0));
+            while (result.size() < numberOfShards)
+            {
+                T required = result.size() < numberOfShards - 1 ? shardSize : subtract(totalSize, multiply(shardSize, (numberOfShards - 1)));
+                while (true)
+                {
+                    if (compare(subtract(rSize, rOffset), required) >= 0)
+                    {
+                        buffer.add(splitter.subRange(ranges.get(ri), rOffset, add(rOffset, required)));
+                        result.add(Ranges.ofSortedAndDeoverlapped(buffer.toArray(new Range[0])));
+                        buffer.clear();
+                        rOffset = add(rOffset, required);
+                        if (compare(rOffset, rSize) >= 0 && ++ri < ranges.size())
+                        {
+                            Invariants.checkState(compare(rOffset, rSize) == 0);
+                            rOffset = zero();
+                            rSize = splitter.sizeOf(ranges.get(ri));
+                        }
+                        break;
+                    }
+                    else
+                    {
+                        buffer.add(splitter.subRange(ranges.get(ri), rOffset, rSize));
+                        required = subtract(required, subtract(rSize, rOffset));
+                        rOffset = zero();
+                        rSize = splitter.sizeOf(ranges.get(++ri));
+                    }
+                }
+            }
+            return result;
+        }
+
+        private int compare(T a, T b)
+        {
+            return splitter.compare(a, b);
+        }
+
+        private T add(T a, T b)
+        {
+            return splitter.add(a, b);
+        }
+
+        private T subtract(T a, T b)
+        {
+            return splitter.subtract(a, b);
+        }
+
+        private T multiply(T a, int constant)
+        {
+            return splitter.multiply(a, constant);
+        }
+
+        private T divide(T a, int constant)
+        {
+            return splitter.divide(a, constant);
+        }
+
+        private T zero()
+        {
+            return splitter.zero();
+        }
+    }
+}

--- a/accord-core/src/main/java/accord/local/SyncCommandStores.java
+++ b/accord-core/src/main/java/accord/local/SyncCommandStores.java
@@ -19,16 +19,16 @@ public class SyncCommandStores extends CommandStores<SyncCommandStores.SyncComma
 
     public static abstract class SyncCommandStore extends CommandStore
     {
-        public SyncCommandStore(int id, int generation, int shardIndex, int numShards)
+        public SyncCommandStore(int id)
         {
-            super(id, generation, shardIndex, numShards);
+            super(id);
         }
         protected abstract <T> T executeSync(PreLoadContext context, Function<? super SafeCommandStore, T> function);
     }
 
-    public SyncCommandStores(int num, Node node, Agent agent, DataStore store, ProgressLog.Factory progressLogFactory, CommandStore.Factory shardFactory)
+    public SyncCommandStores(NodeTimeService time, Agent agent, DataStore store, ShardDistributor shardDistributor, ProgressLog.Factory progressLogFactory, CommandStore.Factory shardFactory)
     {
-        super(num, node, agent, store, progressLogFactory, shardFactory);
+        super(time, agent, store, shardDistributor, progressLogFactory, shardFactory);
     }
 
     protected static class SyncMapReduceAdapter<O> implements MapReduceAdapter<SyncCommandStore, O, O, O>

--- a/accord-core/src/main/java/accord/messages/ReadData.java
+++ b/accord-core/src/main/java/accord/messages/ReadData.java
@@ -146,8 +146,6 @@ public class ReadData extends AbstractEpochRequest<ReadData.ReadNack> implements
             default:
                 throw new AssertionError();
             case Committed:
-                if (!Iterables.any(command.partialTxn().keys(), safeStore.commandStore()::hashIntersects))
-                    throw new IllegalStateException();
             case NotWitnessed:
             case PreAccepted:
             case Accepted:

--- a/accord-core/src/main/java/accord/primitives/AbstractKeys.java
+++ b/accord-core/src/main/java/accord/primitives/AbstractKeys.java
@@ -165,20 +165,12 @@ public abstract class AbstractKeys<K extends RoutableKey, KS extends Routables<K
         return !any(predicate);
     }
 
-    /**
-     * Count the number of keys matching the predicate and intersecting with the given ranges.
-     * If terminateAfter is greater than 0, the method will return once terminateAfter matches are encountered
-     */
     @Inline
     public final <V> V foldl(Ranges rs, IndexedFold<? super K, V> fold, V accumulator)
     {
         return Routables.foldl(this, rs, fold, accumulator);
     }
 
-    /**
-     * Count the number of keys matching the predicate and intersecting with the given ranges.
-     * If terminateAfter is greater than 0, the method will return once terminateAfter matches are encountered
-     */
     @Inline
     public final void forEach(Ranges rs, Consumer<? super K> forEach)
     {

--- a/accord-core/src/main/java/accord/primitives/AbstractRanges.java
+++ b/accord-core/src/main/java/accord/primitives/AbstractRanges.java
@@ -28,9 +28,9 @@ import javax.annotation.Nonnull;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import java.util.function.Predicate;
 
 import static accord.utils.ArrayBuffers.cachedRanges;
+import static accord.utils.SortedArrays.Search.CEIL;
 import static accord.utils.SortedArrays.Search.FAST;
 import static accord.utils.SortedArrays.swapHighLow32b;
 
@@ -113,28 +113,19 @@ public abstract class AbstractRanges<RS extends Routables<Range, ?>> implements 
         return size() == 0;
     }
 
+    public final boolean intersects(Routables<?, ?> keysOrRanges)
+    {
+        switch (keysOrRanges.kindOfContents())
+        {
+            default: throw new AssertionError();
+            case Key: return intersects((AbstractKeys<?, ?>) keysOrRanges);
+            case Range: return intersects((AbstractRanges<?>) keysOrRanges);
+        }
+    }
+
     public final boolean intersects(AbstractKeys<?, ?> keys)
     {
         return findNextIntersection(0, keys, 0) >= 0;
-    }
-
-    public final <K extends RoutableKey> boolean intersects(AbstractKeys<K, ?> keys, Predicate<? super K> matches)
-    {
-        int ri = 0, ki = 0;
-        while (true)
-        {
-            long rki = findNextIntersection(ri, keys, ki);
-            if (rki < 0)
-                return false;
-
-            ri = (int) (rki);
-            ki = (int) (rki >>> 32);
-
-            if (matches.test(keys.get(ki)))
-                return true;
-
-            ki++;
-        }
     }
 
     public boolean intersects(AbstractRanges<?> that)

--- a/accord-core/src/main/java/accord/primitives/Deps.java
+++ b/accord-core/src/main/java/accord/primitives/Deps.java
@@ -1070,10 +1070,9 @@ public class Deps implements Iterable<Map.Entry<Key, TxnId>>
     /**
      * For each {@link TxnId} that references a key within the {@link Ranges}; the {@link TxnId} will be seen exactly once.
      * @param ranges to match on
-     * @param include function to say if a key should be used or not
      * @param forEach function to call on each unique {@link TxnId}
      */
-    public void forEachOn(Ranges ranges, Predicate<? super Key> include, Consumer<TxnId> forEach)
+    public void forEachOn(Ranges ranges, Consumer<TxnId> forEach)
     {
         // Find all keys within the ranges, but record existence within an int64 bitset.  Since the bitset is limited
         // to 64, this search must be called multiple times searching for different TxnIds in txnIds; this also has
@@ -1083,9 +1082,6 @@ public class Deps implements Iterable<Map.Entry<Key, TxnId>>
         for (int offset = 0 ; offset < txnIds.length ; offset += 64)
         {
             long bitset = Routables.foldl(keys, ranges, (key, off, value, keyIndex) -> {
-                if (!include.test(key))
-                    return value;
-
                 int index = startOffset(keyIndex);
                 int end = endOffset(keyIndex);
                 if (off > 0)

--- a/accord-core/src/main/java/accord/primitives/FullKeyRoute.java
+++ b/accord-core/src/main/java/accord/primitives/FullKeyRoute.java
@@ -46,9 +46,9 @@ public class FullKeyRoute extends KeyRoute implements FullRoute<RoutingKey>
     }
 
     @Override
-    public PartialKeyRoute slice(Ranges ranges)
+    public PartialKeyRoute slice(Ranges newRanges)
     {
-        return new PartialKeyRoute(ranges, homeKey, slice(ranges, RoutingKey[]::new));
+        return new PartialKeyRoute(newRanges, homeKey, slice(newRanges, RoutingKey[]::new));
     }
 
     @Override

--- a/accord-core/src/main/java/accord/primitives/Keys.java
+++ b/accord-core/src/main/java/accord/primitives/Keys.java
@@ -74,7 +74,7 @@ public class Keys extends AbstractKeys<Key, Keys> implements Seekables<Key, Keys
     @Override
     public Keys slice(Ranges ranges)
     {
-        return wrap(SortedArrays.sliceWithMultipleMatches(keys, ranges.ranges, Key[]::new, (k, r) -> -r.compareTo(k), Range::compareTo));
+        return wrap(slice(ranges, Key[]::new));
     }
 
     public Keys with(Key key)

--- a/accord-core/src/main/java/accord/primitives/PartialKeyRoute.java
+++ b/accord-core/src/main/java/accord/primitives/PartialKeyRoute.java
@@ -26,13 +26,13 @@ public class PartialKeyRoute extends KeyRoute implements PartialRoute<RoutingKey
         this.covering = covering;
     }
 
-    public PartialKeyRoute sliceStrict(Ranges newRange)
+    public PartialKeyRoute sliceStrict(Ranges newRanges)
     {
-        if (!covering.containsAll(newRange))
+        if (!covering.containsAll(newRanges))
             throw new IllegalArgumentException("Not covered");
 
-        RoutingKey[] keys = slice(newRange, RoutingKey[]::new);
-        return new PartialKeyRoute(newRange, homeKey, keys);
+        RoutingKey[] keys = slice(newRanges, RoutingKey[]::new);
+        return new PartialKeyRoute(newRanges, homeKey, keys);
     }
 
     @Override
@@ -70,9 +70,9 @@ public class PartialKeyRoute extends KeyRoute implements PartialRoute<RoutingKey
         return new RoutingKeys(toRoutingKeysArray(withKey));
     }
 
-    public PartialKeyRoute slice(Ranges newRange)
+    public PartialKeyRoute slice(Ranges newRanges)
     {
-        if (newRange.containsAll(covering))
+        if (newRanges.containsAll(covering))
             return this;
 
         RoutingKey[] keys = slice(covering, RoutingKey[]::new);

--- a/accord-core/src/main/java/accord/primitives/PartialRangeRoute.java
+++ b/accord-core/src/main/java/accord/primitives/PartialRangeRoute.java
@@ -65,12 +65,12 @@ public class PartialRangeRoute extends RangeRoute implements PartialRoute<Range>
         throw new UnsupportedOperationException();
     }
 
-    public PartialRangeRoute slice(Ranges newRange)
+    public PartialRangeRoute slice(Ranges newRanges)
     {
-        if (newRange.containsAll(covering))
+        if (newRanges.containsAll(covering))
             return this;
 
-        return slice(newRange, this, homeKey, PartialRangeRoute::new);
+        return slice(newRanges, this, homeKey, PartialRangeRoute::new);
     }
 
     public Unseekables<Range, ?> with(RoutingKey withKey)

--- a/accord-core/src/main/java/accord/primitives/Range.java
+++ b/accord-core/src/main/java/accord/primitives/Range.java
@@ -212,7 +212,7 @@ public abstract class Range implements Comparable<RoutableKey>, Unseekable, Seek
      */
     public abstract int compareTo(RoutableKey key);
 
-    public boolean containsKey(RoutableKey key)
+    public boolean contains(RoutableKey key)
     {
         return compareTo(key) == 0;
     }
@@ -232,12 +232,12 @@ public abstract class Range implements Comparable<RoutableKey>, Unseekable, Seek
         return 0;
     }
 
-    public boolean fullyContains(Range that)
+    public boolean contains(Range that)
     {
         return that.start.compareTo(this.start) >= 0 && that.end.compareTo(this.end) <= 0;
     }
 
-    public boolean intersects(Keys keys)
+    public boolean intersects(AbstractKeys<?, ?> keys)
     {
         return SortedArrays.binarySearch(keys.keys, 0, keys.size(), this, Range::compareTo, FAST) >= 0;
     }
@@ -287,7 +287,7 @@ public abstract class Range implements Comparable<RoutableKey>, Unseekable, Seek
     public static Range slice(Range bound, Range toSlice)
     {
         Invariants.checkArgument(bound.compareIntersecting(toSlice) == 0);
-        if (bound.fullyContains(toSlice))
+        if (bound.contains(toSlice))
             return toSlice;
 
         return toSlice.subRange(

--- a/accord-core/src/main/java/accord/primitives/RoutableKey.java
+++ b/accord-core/src/main/java/accord/primitives/RoutableKey.java
@@ -33,9 +33,6 @@ public interface RoutableKey extends Routable, Comparable<RoutableKey>
         }
 
         @Override
-        public int routingHash() { throw new UnsupportedOperationException(); }
-
-        @Override
         public RoutingKey toUnseekable() { throw new UnsupportedOperationException(); }
 
         @Override
@@ -48,13 +45,6 @@ public interface RoutableKey extends Routable, Comparable<RoutableKey>
      * @return
      */
     int compareTo(@Nonnull RoutableKey that);
-
-    /**
-     * Returns a hash code of a key to support accord internal sharding. Hash values for equal keys must be equal.
-     *
-     * TODO (now): can we remove this if we remove hashIntersects et al?
-     */
-    int routingHash();
 
     default Kind kind() { return Kind.Key; }
 

--- a/accord-core/src/main/java/accord/primitives/RoutingKeys.java
+++ b/accord-core/src/main/java/accord/primitives/RoutingKeys.java
@@ -47,7 +47,7 @@ public class RoutingKeys extends AbstractRoutableKeys<AbstractRoutableKeys<?>> i
 
     public RoutingKeys slice(Ranges ranges)
     {
-        return wrap(SortedArrays.sliceWithMultipleMatches(keys, ranges.ranges, RoutingKey[]::new, (k, r) -> -r.compareTo(k), Range::compareTo));
+        return wrap(slice(ranges, RoutingKey[]::new));
     }
 
     private RoutingKeys wrap(RoutingKey[] wrap, AbstractKeys<RoutingKey, ?> that)

--- a/accord-core/src/main/java/accord/primitives/Txn.java
+++ b/accord-core/src/main/java/accord/primitives/Txn.java
@@ -176,9 +176,6 @@ public interface Txn
     {
         Ranges ranges = safeStore.ranges().at(command.executeAt().epoch);
         List<Future<Data>> futures = read().keys().foldl(ranges, (key, accumulate, index) -> {
-            if (!safeStore.commandStore().hashIntersects(key))
-                return accumulate;
-
             Future<Data> result = read().read(key, kind(), safeStore, command.executeAt(), safeStore.dataStore());
             accumulate.add(result);
             return accumulate;

--- a/accord-core/src/main/java/accord/primitives/Writes.java
+++ b/accord-core/src/main/java/accord/primitives/Writes.java
@@ -72,8 +72,7 @@ public class Writes
             return SUCCESS;
 
         List<Future<Void>> futures = keys.foldl(ranges, (key, accumulate, index) -> {
-            if (safeStore.commandStore().hashIntersects(key))
-                accumulate.add(write.apply(key, safeStore, executeAt, safeStore.dataStore()));
+            accumulate.add(write.apply(key, safeStore, executeAt, safeStore.dataStore()));
             return accumulate;
         }, new ArrayList<>());
         return ReducingFuture.reduce(futures, (l, r) -> null);

--- a/accord-core/src/main/java/accord/topology/Shard.java
+++ b/accord-core/src/main/java/accord/topology/Shard.java
@@ -97,7 +97,7 @@ public class Shard
 
     public boolean contains(Key key)
     {
-        return range.containsKey(key);
+        return range.contains(key);
     }
 
     public String toString(boolean extendedInfo)

--- a/accord-core/src/main/java/accord/utils/IntrusiveLinkedListNode.java
+++ b/accord-core/src/main/java/accord/utils/IntrusiveLinkedListNode.java
@@ -40,5 +40,6 @@ public abstract class IntrusiveLinkedListNode
             next = null;
             prev = null;
         }
+        Invariants.paranoid(prev == null);
     }
 }

--- a/accord-core/src/main/java/accord/utils/Invariants.java
+++ b/accord-core/src/main/java/accord/utils/Invariants.java
@@ -6,6 +6,8 @@ import java.util.function.Predicate;
 
 public class Invariants
 {
+    private static final boolean PARANOID = true;
+
     public static <T1, T2 extends T1> T2 checkType(T1 cast)
     {
         return (T2)cast;
@@ -23,6 +25,12 @@ public class Invariants
         if (cast != null && !to.isInstance(cast))
             throw new IllegalStateException(msg);
         return (T2)cast;
+    }
+
+    public static void paranoid(boolean condition)
+    {
+        if (PARANOID && !condition)
+            throw new IllegalStateException();
     }
 
     public static void checkState(boolean condition)

--- a/accord-core/src/test/java/accord/impl/basic/Cluster.java
+++ b/accord-core/src/test/java/accord/impl/basic/Cluster.java
@@ -38,15 +38,13 @@ import java.util.function.Supplier;
 import accord.api.MessageSink;
 import accord.burn.BurnTestConfigurationService;
 import accord.burn.TopologyUpdates;
-import accord.impl.SimpleProgressLog;
-import accord.impl.InMemoryCommandStores;
-import accord.impl.SizeOfIntersectionSorter;
+import accord.impl.*;
 import accord.local.Node;
 import accord.local.Node.Id;
 import accord.api.Scheduler;
-import accord.impl.TopologyFactory;
 import accord.impl.list.ListAgent;
 import accord.impl.list.ListStore;
+import accord.local.ShardDistributor;
 import accord.messages.Callback;
 import accord.messages.Reply;
 import accord.messages.Request;
@@ -224,8 +222,9 @@ public class Cluster implements Scheduler
             {
                 MessageSink messageSink = sinks.create(node, randomSupplier.get());
                 BurnTestConfigurationService configService = new BurnTestConfigurationService(node, messageSink, randomSupplier, topology, lookup::get, topologyUpdates);
-                lookup.put(node, new Node(node, messageSink, configService,
-                                          nowSupplier.get(), () -> new ListStore(node), new ListAgent(30L, onFailure),
+                lookup.put(node, new Node(node, messageSink, configService, nowSupplier.get(),
+                                          () -> new ListStore(node), new ShardDistributor.EvenSplit(8, new IntHashKey.Splitter()),
+                                          new ListAgent(30L, onFailure),
                                           randomSupplier.get(), sinks, SizeOfIntersectionSorter.SUPPLIER,
                                           SimpleProgressLog::new, InMemoryCommandStores.Synchronized::new));
             }

--- a/accord-core/src/test/java/accord/impl/mock/MockCluster.java
+++ b/accord-core/src/test/java/accord/impl/mock/MockCluster.java
@@ -24,6 +24,7 @@ import accord.coordinate.Timeout;
 import accord.impl.*;
 import accord.local.Node;
 import accord.local.Node.Id;
+import accord.local.ShardDistributor;
 import accord.primitives.Ranges;
 import accord.utils.EpochFunction;
 import accord.utils.ThreadPoolScheduler;
@@ -104,6 +105,7 @@ public class MockCluster implements Network, AutoCloseable, Iterable<Node>
                         configurationService,
                         nowSupplier,
                         () -> store,
+                        new ShardDistributor.EvenSplit(8, new IntKey.Splitter()),
                         new TestAgent(),
                         new Random(random.nextLong()),
                         new ThreadPoolScheduler(),

--- a/accord-core/src/test/java/accord/local/CommandTest.java
+++ b/accord-core/src/test/java/accord/local/CommandTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -52,7 +53,7 @@ public class CommandTest
     private static final Node.Id ID1 = id(1);
     private static final Node.Id ID2 = id(2);
     private static final Node.Id ID3 = id(3);
-    private static final List<Node.Id> IDS = List.of(ID1, ID2, ID3);
+    private static final List<Node.Id> IDS = Arrays.asList(ID1, ID2, ID3);
     private static final Range FULL_RANGE = IntKey.range(0, 100);
     private static final Ranges FULL_RANGES = Ranges.single(FULL_RANGE);
     private static final Topology TOPOLOGY = TopologyFactory.toTopology(IDS, 3, FULL_RANGE);
@@ -137,7 +138,7 @@ public class CommandTest
     private static Node createNode(Id id, CommandStoreSupport storeSupport)
     {
         return new Node(id, null, new MockConfigurationService(null, (epoch, service) -> { }, storeSupport.local.get()),
-                        new MockCluster.Clock(100), () -> storeSupport.data, new TestAgent(), new Random(), null,
+                        new MockCluster.Clock(100), () -> storeSupport.data, new ShardDistributor.EvenSplit(8, new IntKey.Splitter()), new TestAgent(), new Random(), null,
                         SizeOfIntersectionSorter.SUPPLIER, ignore -> ignore2 -> new NoOpProgressLog(), InMemoryCommandStores.Synchronized::new);
     }
 

--- a/accord-core/src/test/java/accord/messages/PreAcceptTest.java
+++ b/accord-core/src/test/java/accord/messages/PreAcceptTest.java
@@ -67,6 +67,7 @@ public class PreAcceptTest
                         new MockConfigurationService(messageSink, EpochFunction.noop(), TOPOLOGY),
                         clock,
                         () -> store,
+                        new ShardDistributor.EvenSplit(8, new IntKey.Splitter()),
                         new TestAgent(),
                         new Random(),
                         scheduler,

--- a/accord-core/src/test/java/accord/topology/TopologyTest.java
+++ b/accord-core/src/test/java/accord/topology/TopologyTest.java
@@ -40,13 +40,13 @@ public class TopologyTest
         Key expectedKey = key(key);
         Shard shard = topology.forKey(routing(key));
         Range expectedRange = range(start, end);
-        Assertions.assertTrue(expectedRange.containsKey(expectedKey));
-        Assertions.assertTrue(shard.range.containsKey(expectedKey));
+        Assertions.assertTrue(expectedRange.contains(expectedKey));
+        Assertions.assertTrue(shard.range.contains(expectedKey));
         Assertions.assertEquals(expectedRange, shard.range);
 
         Topology subTopology = topology.forSelection(Keys.of(expectedKey).toUnseekables());
         shard = Iterables.getOnlyElement(subTopology.shards());
-        Assertions.assertTrue(shard.range.containsKey(expectedKey));
+        Assertions.assertTrue(shard.range.contains(expectedKey));
         Assertions.assertEquals(expectedRange, shard.range);
     }
 

--- a/accord-core/src/test/java/accord/txn/DepsTest.java
+++ b/accord-core/src/test/java/accord/txn/DepsTest.java
@@ -181,7 +181,7 @@ public class DepsTest
                 throw new AssertionError(start + " == " + end);
 
             TreeSet<TxnId> seen = new TreeSet<>();
-            deps.test.forEachOn(Ranges.of(Range.range(start.toUnseekable(), end.toUnseekable(), false, true)), ignore -> true, txnId -> {
+            deps.test.forEachOn(Ranges.of(Range.range(start.toUnseekable(), end.toUnseekable(), false, true)), txnId -> {
                 if (!seen.add(txnId))
                     throw new AssertionError("Seen " + txnId + " multiple times");
             });
@@ -205,7 +205,7 @@ public class DepsTest
             Key end = keys.get(keys.size() - 1);
 
             TreeSet<TxnId> seen = new TreeSet<>();
-            deps.test.forEachOn(Ranges.of(Range.range(start.toUnseekable(), end.toUnseekable(), true, false)), ignore -> true, txnId -> {
+            deps.test.forEachOn(Ranges.of(Range.range(start.toUnseekable(), end.toUnseekable(), true, false)), txnId -> {
                 if (!seen.add(txnId))
                     throw new AssertionError("Seen " + txnId + " multiple times");
             });
@@ -229,7 +229,7 @@ public class DepsTest
             Key end = keys.get(0);
 
             TreeSet<TxnId> seen = new TreeSet<>();
-            deps.test.forEachOn(Ranges.of(Range.range(start.toUnseekable(), end.toUnseekable(), true, false)), ignore -> true, txnId -> {
+            deps.test.forEachOn(Ranges.of(Range.range(start.toUnseekable(), end.toUnseekable(), true, false)), txnId -> {
                 if (!seen.add(txnId))
                     throw new AssertionError("Seen " + txnId + " multiple times");
             });
@@ -542,7 +542,7 @@ public class DepsTest
                         if (ranges.contains(key))
                             canonical.addAll(deps.canonical.get(key));
                     }
-                    deps.test.forEachOn(ranges, ignore -> true, txnId -> test.add(txnId));
+                    deps.test.forEachOn(ranges, test::add);
                     test.sort(Timestamp::compareTo);
                     Assertions.assertEquals(new ArrayList<>(canonical), test);
                 }

--- a/accord-core/src/test/java/accord/utils/RangeTest.java
+++ b/accord-core/src/test/java/accord/utils/RangeTest.java
@@ -97,22 +97,22 @@ public class RangeTest
     void containsTest()
     {
         Range endInclRange = rangeEndIncl(10, 20);
-        Assertions.assertFalse(endInclRange.containsKey(k(10)));
+        Assertions.assertFalse(endInclRange.contains(k(10)));
         Assertions.assertFalse(endInclRange.startInclusive());
-        Assertions.assertTrue(endInclRange.containsKey(k(20)));
+        Assertions.assertTrue(endInclRange.contains(k(20)));
         Assertions.assertTrue(endInclRange.endInclusive());
 
         Range startInclRange = rangeStartIncl(10, 20);
-        Assertions.assertTrue(startInclRange.containsKey(k(10)));
+        Assertions.assertTrue(startInclRange.contains(k(10)));
         Assertions.assertTrue(startInclRange.startInclusive());
-        Assertions.assertFalse(startInclRange.containsKey(k(20)));
+        Assertions.assertFalse(startInclRange.contains(k(20)));
         Assertions.assertFalse(startInclRange.endInclusive());
     }
 
     private static void assertHigherKeyIndex(int expectedIdx, Range range, Keys keys)
     {
         if (expectedIdx > 0 && expectedIdx < keys.size())
-            Assertions.assertTrue(range.containsKey(keys.get(expectedIdx - 1)));
+            Assertions.assertTrue(range.contains(keys.get(expectedIdx - 1)));
         int actualIdx = range.nextHigherKeyIndex(keys, 0);
         Assertions.assertEquals(expectedIdx, actualIdx);
     }
@@ -143,12 +143,12 @@ public class RangeTest
     {
         if (expectedIdx >= 0 && expectedIdx < keys.size())
         {
-            Assertions.assertTrue(range.containsKey(keys.get(expectedIdx)));
+            Assertions.assertTrue(range.contains(keys.get(expectedIdx)));
         }
         else
         {
-            Assertions.assertFalse(range.containsKey(keys.get(lowerBound)));
-            Assertions.assertFalse(range.containsKey(keys.get(keys.size() - 1)));
+            Assertions.assertFalse(range.contains(keys.get(lowerBound)));
+            Assertions.assertFalse(range.contains(keys.get(keys.size() - 1)));
         }
 
         int actualIdx = range.nextCeilKeyIndex(keys, lowerBound);
@@ -190,17 +190,17 @@ public class RangeTest
     @Test
     void fullyContainsTest()
     {
-        Assertions.assertTrue(r(100, 200).fullyContains(r(100, 200)));
-        Assertions.assertTrue(r(100, 200).fullyContains(r(150, 200)));
-        Assertions.assertTrue(r(100, 200).fullyContains(r(100, 150)));
-        Assertions.assertTrue(r(100, 200).fullyContains(r(125, 175)));
+        Assertions.assertTrue(r(100, 200).contains(r(100, 200)));
+        Assertions.assertTrue(r(100, 200).contains(r(150, 200)));
+        Assertions.assertTrue(r(100, 200).contains(r(100, 150)));
+        Assertions.assertTrue(r(100, 200).contains(r(125, 175)));
 
-        Assertions.assertFalse(r(100, 200).fullyContains(r(50, 60)));
-        Assertions.assertFalse(r(100, 200).fullyContains(r(100, 250)));
-        Assertions.assertFalse(r(100, 200).fullyContains(r(150, 250)));
-        Assertions.assertFalse(r(100, 200).fullyContains(r(50, 200)));
-        Assertions.assertFalse(r(100, 200).fullyContains(r(50, 150)));
-        Assertions.assertFalse(r(100, 200).fullyContains(r(250, 260)));
+        Assertions.assertFalse(r(100, 200).contains(r(50, 60)));
+        Assertions.assertFalse(r(100, 200).contains(r(100, 250)));
+        Assertions.assertFalse(r(100, 200).contains(r(150, 250)));
+        Assertions.assertFalse(r(100, 200).contains(r(50, 200)));
+        Assertions.assertFalse(r(100, 200).contains(r(50, 150)));
+        Assertions.assertFalse(r(100, 200).contains(r(250, 260)));
     }
 
     @Test

--- a/accord-maelstrom/src/main/java/accord/maelstrom/Cluster.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/Cluster.java
@@ -39,6 +39,7 @@ import accord.impl.InMemoryCommandStores;
 import accord.local.Node;
 import accord.local.Node.Id;
 import accord.api.MessageSink;
+import accord.local.ShardDistributor;
 import accord.messages.Callback;
 import accord.messages.Reply;
 import accord.messages.ReplyContext;
@@ -133,6 +134,9 @@ public class Cluster implements Scheduler
 
     private void add(Packet packet)
     {
+        if (packet == null)
+            throw new IllegalArgumentException();
+
         err.println(clock++ + " SEND " + packet);
         err.flush();
         if (lookup.apply(packet.dest) == null) responseSink.accept(packet);
@@ -296,7 +300,8 @@ public class Cluster implements Scheduler
             {
                 MessageSink messageSink = sinks.create(node, randomSupplier.get());
                 lookup.put(node, new Node(node, messageSink, new SimpleConfigService(topology),
-                                          nowSupplier.get(), MaelstromStore::new, MaelstromAgent.INSTANCE,
+                                          nowSupplier.get(), MaelstromStore::new, new ShardDistributor.EvenSplit(8, new MaelstromKey.Splitter()),
+                                          MaelstromAgent.INSTANCE,
                                           randomSupplier.get(), sinks, SizeOfIntersectionSorter.SUPPLIER,
                                           SimpleProgressLog::new, InMemoryCommandStores.SingleThread::new));
             }

--- a/accord-maelstrom/src/main/java/accord/maelstrom/Json.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/Json.java
@@ -124,6 +124,11 @@ public class Json
 
     private static <T> T readTimestamp(JsonReader in, TimestampFactory<T> factory) throws IOException
     {
+        if (in.peek() == JsonToken.NULL)
+        {
+            in.nextNull();
+            return null;
+        }
         in.beginArray();
         long epoch = in.nextLong();
         long real = in.nextLong();
@@ -135,6 +140,11 @@ public class Json
 
     private static void writeTimestamp(JsonWriter out, Timestamp timestamp) throws IOException
     {
+        if (timestamp == null)
+        {
+            out.nullValue();
+            return;
+        }
         out.beginArray();
         out.value(timestamp.epoch);
         out.value(timestamp.real);

--- a/accord-maelstrom/src/main/java/accord/maelstrom/Main.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/Main.java
@@ -38,6 +38,7 @@ import accord.impl.SizeOfIntersectionSorter;
 import accord.local.Node;
 import accord.local.Node.Id;
 import accord.api.Scheduler;
+import accord.local.ShardDistributor;
 import accord.messages.ReplyContext;
 import accord.topology.Topology;
 import accord.utils.ThreadPoolScheduler;
@@ -160,8 +161,9 @@ public class Main
             topology = topologyFactory.toTopology(init.cluster);
             sink = new StdoutSink(System::currentTimeMillis, scheduler, start, init.self, out, err);
             on = new Node(init.self, sink, new SimpleConfigService(topology), System::currentTimeMillis,
-                          MaelstromStore::new, MaelstromAgent.INSTANCE, new Random(), scheduler,
-                          SizeOfIntersectionSorter.SUPPLIER, SimpleProgressLog::new, InMemoryCommandStores.SingleThread::new);
+                          MaelstromStore::new, new ShardDistributor.EvenSplit(8, new MaelstromKey.Splitter()),
+                          MaelstromAgent.INSTANCE, new Random(), scheduler, SizeOfIntersectionSorter.SUPPLIER,
+                          SimpleProgressLog::new, InMemoryCommandStores.SingleThread::new);
             err.println("Initialized node " + init.self);
             err.flush();
             sink.send(packet.src, new Body(Type.init_ok, Body.SENTINEL_MSG_ID, init.msg_id));


### PR DESCRIPTION
Round-robin hash splits create some extra impediments for process transactions, and some duplication of work. This patch modifies partitioning to operate on contiguous ranges only.