### PR TITLE
TxnId should be more succinct and more useful

### DIFF
--- a/accord-core/src/main/java/accord/coordinate/CheckOn.java
+++ b/accord-core/src/main/java/accord/coordinate/CheckOn.java
@@ -136,7 +136,7 @@ public class CheckOn extends CheckShards
 
         public OnDone()
         {
-            Ranges localRanges = node.topology().localRangesForEpochs(txnId.epoch, untilLocalEpoch);
+            Ranges localRanges = node.topology().localRangesForEpochs(txnId.epoch(), untilLocalEpoch);
             PartialRoute<?> selfRoute = route().slice(localRanges);
             full = (CheckStatusOkFull) merged;
             sufficientFor = full.sufficientFor(selfRoute);
@@ -165,7 +165,7 @@ public class CheckOn extends CheckShards
                 txnIds = Iterables.concat(txnIds, partialDeps.txnIds());
 
             PreLoadContext loadContext = contextFor(txnIds, keys);
-            node.mapReduceConsumeLocal(loadContext, route, txnId.epoch, untilLocalEpoch, this);
+            node.mapReduceConsumeLocal(loadContext, route, txnId.epoch(), untilLocalEpoch, this);
         }
 
         @Override
@@ -187,7 +187,7 @@ public class CheckOn extends CheckShards
 
                 case Applied:
                 case PreApplied:
-                    if (untilLocalEpoch >= full.executeAt.epoch)
+                    if (untilLocalEpoch >= full.executeAt.epoch())
                     {
                         confirm(command.commit(safeStore, maxRoute, progressKey, partialTxn, full.executeAt, partialDeps));
                         confirm(command.apply(safeStore, untilLocalEpoch, maxRoute, full.executeAt, partialDeps, full.writes, full.result));
@@ -216,7 +216,7 @@ public class CheckOn extends CheckShards
             if (!merged.durability.isDurable() || homeKey == null)
                 return null;
 
-            if (!safeStore.ranges().at(txnId.epoch).contains(homeKey))
+            if (!safeStore.ranges().at(txnId.epoch()).contains(homeKey))
                 return null;
 
             Timestamp executeAt = merged.saveStatus.known.executeAt.isDecisionKnown() ? merged.executeAt : null;

--- a/accord-core/src/main/java/accord/coordinate/CheckShards.java
+++ b/accord-core/src/main/java/accord/coordinate/CheckShards.java
@@ -36,13 +36,13 @@ public abstract class CheckShards extends ReadCoordinator<CheckStatusReply>
 
     private static Topologies topologyFor(Node node, TxnId txnId, Unseekables<?, ?> contact, long epoch)
     {
-        return node.topology().preciseEpochs(contact, txnId.epoch, epoch);
+        return node.topology().preciseEpochs(contact, txnId.epoch(), epoch);
     }
 
     @Override
     protected void contact(Id id)
     {
-        node.send(id, new CheckStatus(txnId, contact.slice(topologies().computeRangesForNode(id)), txnId.epoch, untilRemoteEpoch, includeInfo), this);
+        node.send(id, new CheckStatus(txnId, contact.slice(topologies().computeRangesForNode(id)), txnId.epoch(), untilRemoteEpoch, includeInfo), this);
     }
 
     protected boolean isSufficient(Id from, CheckStatusOk ok) { return isSufficient(ok); }

--- a/accord-core/src/main/java/accord/coordinate/FindHomeKey.java
+++ b/accord-core/src/main/java/accord/coordinate/FindHomeKey.java
@@ -17,7 +17,7 @@ public class FindHomeKey extends CheckShards
     final BiConsumer<RoutingKey, Throwable> callback;
     FindHomeKey(Node node, TxnId txnId, Unseekables<?, ?> unseekables, BiConsumer<RoutingKey, Throwable> callback)
     {
-        super(node, txnId, unseekables, txnId.epoch, IncludeInfo.No);
+        super(node, txnId, unseekables, txnId.epoch(), IncludeInfo.No);
         this.callback = callback;
     }
 

--- a/accord-core/src/main/java/accord/coordinate/FindRoute.java
+++ b/accord-core/src/main/java/accord/coordinate/FindRoute.java
@@ -37,7 +37,7 @@ public class FindRoute extends CheckShards
     final BiConsumer<Result, Throwable> callback;
     FindRoute(Node node, TxnId txnId, RoutingKey homeKey, BiConsumer<Result, Throwable> callback)
     {
-        super(node, txnId, RoutingKeys.of(homeKey), txnId.epoch, IncludeInfo.Route);
+        super(node, txnId, RoutingKeys.of(homeKey), txnId.epoch(), IncludeInfo.Route);
         this.callback = callback;
     }
 

--- a/accord-core/src/main/java/accord/coordinate/InformHomeOfTxn.java
+++ b/accord-core/src/main/java/accord/coordinate/InformHomeOfTxn.java
@@ -49,8 +49,8 @@ public class InformHomeOfTxn extends AsyncFuture<Void> implements Callback<Simpl
 
     public static Future<Void> inform(Node node, TxnId txnId, RoutingKey homeKey)
     {
-        return node.withEpoch(txnId.epoch, () -> {
-            Shard homeShard = node.topology().forEpoch(homeKey, txnId.epoch);
+        return node.withEpoch(txnId.epoch(), () -> {
+            Shard homeShard = node.topology().forEpoch(homeKey, txnId.epoch());
             InformHomeOfTxn inform = new InformHomeOfTxn(txnId, homeKey, homeShard);
             node.send(homeShard.nodes, new InformOfTxnId(txnId, homeKey), inform);
             return inform;

--- a/accord-core/src/main/java/accord/coordinate/Invalidate.java
+++ b/accord-core/src/main/java/accord/coordinate/Invalidate.java
@@ -68,7 +68,7 @@ public class Invalidate implements Callback<InvalidateReply>
         this.txnId = txnId;
         this.transitivelyInvokedByPriorInvalidation = transitivelyInvokedByPriorInvalidation;
         this.invalidateWith = invalidateWith;
-        Topologies topologies = node.topology().forEpoch(invalidateWith, txnId.epoch);
+        Topologies topologies = node.topology().forEpoch(invalidateWith, txnId.epoch());
         this.tracker = new InvalidationTracker(topologies);
     }
 
@@ -195,7 +195,7 @@ public class Invalidate implements Callback<InvalidateReply>
                         Preconditions.checkState(maxReply.status.hasBeen(Accepted) || tracker.all(InvalidationShardTracker::isPromised));
                         // if we included the home shard, and we have either a recoverable status OR have not rejected the fast path,
                         // we must have at least one response that should contain the Route
-                        if (invalidateWith.contains(homeKey) && tracker.isPromisedForKey(homeKey, txnId.epoch))
+                        if (invalidateWith.contains(homeKey) && tracker.isPromisedForKey(homeKey, txnId.epoch()))
                             throw new IllegalStateException("Received replies from a node that must have known the route, but that did not include it");
 
                         // if < Accepted, we should have short-circuited to invalidation above. This guarantees no Invaldate/Recover loop, as any later status will forbid invoking Invalidate

--- a/accord-core/src/main/java/accord/coordinate/MaybeRecover.java
+++ b/accord-core/src/main/java/accord/coordinate/MaybeRecover.java
@@ -47,7 +47,7 @@ public class MaybeRecover extends CheckShards
     MaybeRecover(Node node, TxnId txnId, RoutingKey homeKey, @Nullable Route<?> route, ProgressToken prevProgress, BiConsumer<Outcome, Throwable> callback)
     {
         // we only want to enquire with the home shard, but we prefer maximal route information for running Invalidation against, if necessary
-        super(node, txnId, RoutingKeys.of(homeKey), txnId.epoch, IncludeInfo.Route);
+        super(node, txnId, RoutingKeys.of(homeKey), txnId.epoch(), IncludeInfo.Route);
         this.homeKey = homeKey;
         this.route = route;
         this.prevProgress = prevProgress;

--- a/accord-core/src/main/java/accord/coordinate/Propose.java
+++ b/accord-core/src/main/java/accord/coordinate/Propose.java
@@ -152,7 +152,7 @@ class Propose implements Callback<AcceptReply>
 
         public static Invalidate proposeInvalidate(Node node, Ballot ballot, TxnId txnId, RoutingKey invalidateWithKey, BiConsumer<Void, Throwable> callback)
         {
-            Shard shard = node.topology().forEpochIfKnown(invalidateWithKey, txnId.epoch);
+            Shard shard = node.topology().forEpochIfKnown(invalidateWithKey, txnId.epoch());
             Invalidate invalidate = new Invalidate(node, shard, ballot, txnId, invalidateWithKey, callback);
             node.send(shard.nodes, to -> new Accept.Invalidate(ballot, txnId, invalidateWithKey), invalidate);
             return invalidate;

--- a/accord-core/src/main/java/accord/coordinate/RecoverWithHomeKey.java
+++ b/accord-core/src/main/java/accord/coordinate/RecoverWithHomeKey.java
@@ -26,7 +26,7 @@ public class RecoverWithHomeKey extends CheckShards implements BiConsumer<Object
 
     RecoverWithHomeKey(Node node, TxnId txnId, RoutingKey homeKey, Status witnessedByInvalidation, BiConsumer<Outcome, Throwable> callback)
     {
-        super(node, txnId, RoutingKeys.of(homeKey), txnId.epoch, IncludeInfo.Route);
+        super(node, txnId, RoutingKeys.of(homeKey), txnId.epoch(), IncludeInfo.Route);
         this.witnessedByInvalidation = witnessedByInvalidation;
         // if witnessedByInvalidation == AcceptedInvalidate then we cannot assume its definition was known, and our comparison with the status is invalid
         Preconditions.checkState(witnessedByInvalidation != Status.AcceptedInvalidate);

--- a/accord-core/src/main/java/accord/coordinate/RecoverWithRoute.java
+++ b/accord-core/src/main/java/accord/coordinate/RecoverWithRoute.java
@@ -31,7 +31,7 @@ public class RecoverWithRoute extends CheckShards
 
     private RecoverWithRoute(Node node, Topologies topologies, @Nullable Ballot promisedBallot, TxnId txnId, FullRoute<?> route, Status witnessedByInvalidation, BiConsumer<Outcome, Throwable> callback)
     {
-        super(node, txnId, route, txnId.epoch, IncludeInfo.All);
+        super(node, txnId, route, txnId.epoch(), IncludeInfo.All);
         // if witnessedByInvalidation == AcceptedInvalidate then we cannot assume its definition was known, and our comparison with the status is invalid
         Invariants.checkState(witnessedByInvalidation != Status.AcceptedInvalidate);
         // if witnessedByInvalidation == Invalidated we should anyway not be recovering
@@ -40,12 +40,12 @@ public class RecoverWithRoute extends CheckShards
         this.route = route;
         this.callback = callback;
         this.witnessedByInvalidation = witnessedByInvalidation;
-        assert topologies.oldestEpoch() == topologies.currentEpoch() && topologies.currentEpoch() == txnId.epoch;
+        assert topologies.oldestEpoch() == topologies.currentEpoch() && topologies.currentEpoch() == txnId.epoch();
     }
 
     public static RecoverWithRoute recover(Node node, TxnId txnId, FullRoute<?> route, @Nullable Status witnessedByInvalidation, BiConsumer<Outcome, Throwable> callback)
     {
-        return recover(node, node.topology().forEpoch(route, txnId.epoch), txnId, route, witnessedByInvalidation, callback);
+        return recover(node, node.topology().forEpoch(route, txnId.epoch()), txnId, route, witnessedByInvalidation, callback);
     }
 
     public static RecoverWithRoute recover(Node node, Topologies topologies, TxnId txnId, FullRoute<?> route, @Nullable Status witnessedByInvalidation, BiConsumer<Outcome, Throwable> callback)
@@ -55,7 +55,7 @@ public class RecoverWithRoute extends CheckShards
 
     public static RecoverWithRoute recover(Node node, @Nullable Ballot promisedBallot, TxnId txnId, FullRoute<?> route, @Nullable Status witnessedByInvalidation, BiConsumer<Outcome, Throwable> callback)
     {
-        return recover(node, node.topology().forEpoch(route, txnId.epoch), promisedBallot, txnId, route, witnessedByInvalidation, callback);
+        return recover(node, node.topology().forEpoch(route, txnId.epoch()), promisedBallot, txnId, route, witnessedByInvalidation, callback);
     }
 
     public static RecoverWithRoute recover(Node node, Topologies topologies, Ballot ballot, TxnId txnId, FullRoute<?> route, Status witnessedByInvalidation, BiConsumer<Outcome, Throwable> callback)
@@ -79,7 +79,7 @@ public class RecoverWithRoute extends CheckShards
     @Override
     protected boolean isSufficient(Id from, CheckStatusOk ok)
     {
-        Ranges rangesForNode = topologies().forEpoch(txnId.epoch).rangesForNode(from);
+        Ranges rangesForNode = topologies().forEpoch(txnId.epoch()).rangesForNode(from);
         PartialRoute<?> route = this.route.slice(rangesForNode);
         return isSufficient(route, ok);
     }
@@ -141,7 +141,7 @@ public class RecoverWithRoute extends CheckShards
                 if (known.deps.isDecisionKnown())
                 {
                     Deps deps = merged.committedDeps.reconstitute(route());
-                    node.withEpoch(merged.executeAt.epoch, () -> {
+                    node.withEpoch(merged.executeAt.epoch(), () -> {
                         Persist.persistAndCommit(node, txnId, route(), txn, merged.executeAt, deps, merged.writes, merged.result);
                     });
                     callback.accept(APPLIED, null);

--- a/accord-core/src/main/java/accord/impl/InMemoryCommand.java
+++ b/accord-core/src/main/java/accord/impl/InMemoryCommand.java
@@ -24,7 +24,6 @@ import accord.local.*;
 import accord.local.Status.Durability;
 import accord.local.Status.Known;
 import accord.primitives.*;
-import accord.primitives.Txn.Kind;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -40,7 +39,6 @@ public class InMemoryCommand extends Command
     private Route<?> route;
     private RoutingKey homeKey, progressKey;
     private PartialTxn partialTxn;
-    private Kind kind;
     private Ballot promised = Ballot.ZERO, accepted = Ballot.ZERO;
     private Timestamp executeAt;
     private @Nullable PartialDeps partialDeps = null;
@@ -102,18 +100,6 @@ public class InMemoryCommand extends Command
     public RoutingKey homeKey()
     {
         return homeKey;
-    }
-
-    @Override
-    public Kind kind()
-    {
-        return kind;
-    }
-
-    @Override
-    public void setKind(Kind kind)
-    {
-        this.kind = kind;
     }
 
     @Override

--- a/accord-core/src/main/java/accord/impl/InMemoryCommandsForKey.java
+++ b/accord-core/src/main/java/accord/impl/InMemoryCommandsForKey.java
@@ -37,7 +37,6 @@ import static accord.local.CommandsForKey.CommandTimeseries.TestDep.*;
 import static accord.local.CommandsForKey.CommandTimeseries.TestKind.RorWs;
 import static accord.local.Status.KnownDeps.DepsUnknown;
 import static accord.local.Status.PreAccepted;
-import static accord.primitives.Txn.Kind.WRITE;
 
 public class InMemoryCommandsForKey extends CommandsForKey
 {
@@ -78,7 +77,7 @@ public class InMemoryCommandsForKey extends CommandsForKey
         public Stream<T> before(@Nonnull Timestamp timestamp, @Nonnull TestKind testKind, @Nonnull TestDep testDep, @Nullable TxnId depId, @Nonnull TestStatus testStatus, @Nullable Status status)
         {
             return commands.headMap(timestamp, false).values().stream()
-                    .filter(cmd -> testKind == RorWs || cmd.kind() == WRITE)
+                    .filter(cmd -> testKind == RorWs || cmd.txnId().isWrite())
                     // If we don't have any dependencies, we treat a dependency filter as a mismatch
                     .filter(cmd -> testDep == ANY_DEPS || (cmd.known().deps != DepsUnknown && (cmd.partialDeps().contains(depId) ^ (testDep == WITHOUT))))
                     .filter(cmd -> TestStatus.test(cmd.status(), testStatus, status))
@@ -89,7 +88,7 @@ public class InMemoryCommandsForKey extends CommandsForKey
         public Stream<T> after(@Nonnull Timestamp timestamp, @Nonnull TestKind testKind, @Nonnull TestDep testDep, @Nullable TxnId depId, @Nonnull TestStatus testStatus, @Nullable Status status)
         {
             return commands.tailMap(timestamp, false).values().stream()
-                    .filter(cmd -> testKind == RorWs || cmd.kind() == WRITE)
+                    .filter(cmd -> testKind == RorWs || cmd.txnId().isWrite())
                     // If we don't have any dependencies, we treat a dependency filter as a mismatch
                     .filter(cmd -> testDep == ANY_DEPS || (cmd.known().deps != DepsUnknown && (cmd.partialDeps().contains(depId) ^ (testDep == WITHOUT))))
                     .filter(cmd -> TestStatus.test(cmd.status(), testStatus, status))

--- a/accord-core/src/main/java/accord/messages/Accept.java
+++ b/accord-core/src/main/java/accord/messages/Accept.java
@@ -92,7 +92,7 @@ public class Accept extends TxnRequest.WithUnsynced<Accept.AcceptReply>
                 return new AcceptReply(command.promised());
             case Success:
                 // TODO (desirable, efficiency): we don't need to calculate deps if executeAt == txnId
-                return new AcceptReply(calculatePartialDeps(safeStore, txnId, keys, kind, executeAt, safeStore.ranges().between(minEpoch, executeAt.epoch)));
+                return new AcceptReply(calculatePartialDeps(safeStore, txnId, keys, kind, executeAt, safeStore.ranges().between(minEpoch, executeAt.epoch())));
         }
     }
 
@@ -116,7 +116,7 @@ public class Accept extends TxnRequest.WithUnsynced<Accept.AcceptReply>
 
     public void process()
     {
-        node.mapReduceConsumeLocal(this, minEpoch, executeAt.epoch, this);
+        node.mapReduceConsumeLocal(this, minEpoch, executeAt.epoch(), this);
     }
 
     @Override
@@ -222,7 +222,7 @@ public class Accept extends TxnRequest.WithUnsynced<Accept.AcceptReply>
 
         public void process()
         {
-            node.mapReduceConsumeLocal(this, someKey, txnId.epoch, this);
+            node.mapReduceConsumeLocal(this, someKey, txnId.epoch(), this);
         }
 
         @Override
@@ -256,7 +256,7 @@ public class Accept extends TxnRequest.WithUnsynced<Accept.AcceptReply>
         @Override
         public long waitForEpoch()
         {
-            return txnId.epoch;
+            return txnId.epoch();
         }
     }
 }

--- a/accord-core/src/main/java/accord/messages/Apply.java
+++ b/accord-core/src/main/java/accord/messages/Apply.java
@@ -73,7 +73,7 @@ public class Apply extends TxnRequest<ApplyReply>
     public void process()
     {
         // note, we do not also commit here if txnId.epoch != executeAt.epoch, as the scope() for a commit would be different
-        node.mapReduceConsumeLocal(this, txnId.epoch, untilEpoch, this);
+        node.mapReduceConsumeLocal(this, txnId.epoch(), untilEpoch, this);
     }
 
     public ApplyReply apply(SafeCommandStore safeStore)
@@ -101,8 +101,8 @@ public class Apply extends TxnRequest<ApplyReply>
     {
         if (reply == ApplyReply.Applied)
         {
-            node.ifLocal(empty(), scope.homeKey(), txnId.epoch, instance -> {
-                node.withEpoch(executeAt.epoch, () -> instance.progressLog().durableLocal(txnId));
+            node.ifLocal(empty(), scope.homeKey(), txnId.epoch(), instance -> {
+                node.withEpoch(executeAt.epoch(), () -> instance.progressLog().durableLocal(txnId));
             }).addCallback(node.agent());
         }
         node.reply(replyTo, replyContext, reply);

--- a/accord-core/src/main/java/accord/messages/BeginInvalidation.java
+++ b/accord-core/src/main/java/accord/messages/BeginInvalidation.java
@@ -33,9 +33,10 @@ public class BeginInvalidation extends AbstractEpochRequest<BeginInvalidation.In
         this.ballot = ballot;
     }
 
+    @Override
     public void process()
     {
-        node.mapReduceConsumeLocal(this, someUnseekables, txnId.epoch, txnId.epoch, this);
+        node.mapReduceConsumeLocal(this, someUnseekables, txnId.epoch(), txnId.epoch(), this);
     }
 
     @Override
@@ -79,7 +80,7 @@ public class BeginInvalidation extends AbstractEpochRequest<BeginInvalidation.In
     @Override
     public long waitForEpoch()
     {
-        return txnId.epoch;
+        return txnId.epoch();
     }
 
     @Override

--- a/accord-core/src/main/java/accord/messages/BeginRecovery.java
+++ b/accord-core/src/main/java/accord/messages/BeginRecovery.java
@@ -79,7 +79,7 @@ public class BeginRecovery extends TxnRequest<BeginRecovery.RecoverReply>
     @Override
     protected void process()
     {
-        node.mapReduceConsumeLocal(this, txnId.epoch, txnId.epoch, this);
+        node.mapReduceConsumeLocal(this, txnId.epoch(), txnId.epoch(), this);
     }
 
     @Override
@@ -105,7 +105,7 @@ public class BeginRecovery extends TxnRequest<BeginRecovery.RecoverReply>
         PartialDeps deps = command.partialDeps();
         if (!command.known().deps.isProposalKnown())
         {
-            deps = calculatePartialDeps(safeStore, txnId, partialTxn.keys(), partialTxn.kind(), txnId, safeStore.ranges().at(txnId.epoch));
+            deps = calculatePartialDeps(safeStore, txnId, partialTxn.keys(), partialTxn.kind(), txnId, safeStore.ranges().at(txnId.epoch()));
         }
 
         boolean rejectsFastPath;
@@ -118,7 +118,7 @@ public class BeginRecovery extends TxnRequest<BeginRecovery.RecoverReply>
         }
         else
         {
-            Ranges ranges = safeStore.ranges().at(txnId.epoch);
+            Ranges ranges = safeStore.ranges().at(txnId.epoch());
             rejectsFastPath = acceptedStartedAfterWithoutWitnessing(safeStore, txnId, ranges, partialTxn.keys()).anyMatch(ignore -> true);
             if (!rejectsFastPath)
                 rejectsFastPath = committedExecutesAfterWithoutWitnessing(safeStore, txnId, ranges, partialTxn.keys()).anyMatch(ignore -> true);

--- a/accord-core/src/main/java/accord/messages/GetDeps.java
+++ b/accord-core/src/main/java/accord/messages/GetDeps.java
@@ -44,13 +44,13 @@ public class GetDeps extends TxnRequest.WithUnsynced<PartialDeps>
 
     public void process()
     {
-        node.mapReduceConsumeLocal(this, minEpoch, executeAt.epoch, this);
+        node.mapReduceConsumeLocal(this, minEpoch, executeAt.epoch(), this);
     }
 
     @Override
     public PartialDeps apply(SafeCommandStore instance)
     {
-        Ranges ranges = instance.ranges().between(minEpoch, executeAt.epoch);
+        Ranges ranges = instance.ranges().between(minEpoch, executeAt.epoch());
         return calculatePartialDeps(instance, txnId, keys, kind, executeAt, ranges);
     }
 

--- a/accord-core/src/main/java/accord/messages/InformDurable.java
+++ b/accord-core/src/main/java/accord/messages/InformDurable.java
@@ -55,7 +55,7 @@ public class InformDurable extends TxnRequest<Reply> implements PreLoadContext
             // TODO (required, consider): We might not replicate either txnId.epoch OR executeAt.epoch, but some inbetween.
             //                            Do we need to receive this message in that case? If so, we need to account for this when selecting a progress key
             at = executeAt;
-            progressKey = node.selectProgressKey(executeAt.epoch, scope, scope.homeKey());
+            progressKey = node.selectProgressKey(executeAt.epoch(), scope, scope.homeKey());
             shard = Adhoc;
         }
         else
@@ -64,7 +64,7 @@ public class InformDurable extends TxnRequest<Reply> implements PreLoadContext
         }
 
         // TODO (expected, efficiency): do not load from disk to perform this update
-        node.mapReduceConsumeLocal(contextFor(txnId), progressKey, at.epoch, this);
+        node.mapReduceConsumeLocal(contextFor(txnId), progressKey, at.epoch(), this);
     }
 
     @Override

--- a/accord-core/src/main/java/accord/messages/InformHomeDurable.java
+++ b/accord-core/src/main/java/accord/messages/InformHomeDurable.java
@@ -32,7 +32,7 @@ public class InformHomeDurable implements Request
     public void process(Node node, Id replyToNode, ReplyContext replyContext)
     {
         // TODO (expected, efficiency): do not load txnId first
-        node.ifLocal(contextFor(txnId), homeKey, txnId.epoch, safeStore -> {
+        node.ifLocal(contextFor(txnId), homeKey, txnId.epoch(), safeStore -> {
             Command command = safeStore.command(txnId);
             command.setDurability(safeStore, durability, homeKey, executeAt);
             safeStore.progressLog().durable(command, persistedOn);

--- a/accord-core/src/main/java/accord/messages/InformOfTxnId.java
+++ b/accord-core/src/main/java/accord/messages/InformOfTxnId.java
@@ -2,8 +2,6 @@ package accord.messages;
 
 import accord.api.RoutingKey;
 import accord.local.*;
-import accord.primitives.Keys;
-import accord.primitives.Seekables;
 import accord.primitives.TxnId;
 
 import java.util.Collections;
@@ -22,10 +20,11 @@ public class InformOfTxnId extends AbstractEpochRequest<Reply> implements Reques
         this.homeKey = homeKey;
     }
 
+    @Override
     public void process()
     {
         // TODO (expected, efficiency): do not first load txnId
-        node.mapReduceConsumeLocal(this, homeKey, txnId.epoch, this);
+        node.mapReduceConsumeLocal(this, homeKey, txnId.epoch(), this);
     }
 
     @Override
@@ -64,7 +63,7 @@ public class InformOfTxnId extends AbstractEpochRequest<Reply> implements Reques
     @Override
     public long waitForEpoch()
     {
-        return txnId.epoch;
+        return txnId.epoch();
     }
 
     @Override

--- a/accord-core/src/main/java/accord/messages/PreAccept.java
+++ b/accord-core/src/main/java/accord/messages/PreAccept.java
@@ -99,7 +99,7 @@ public class PreAccept extends WithUnsynced<PreAccept.PreAcceptReply>
             default:
             case Success:
             case Redundant:
-                return new PreAcceptOk(txnId, command.executeAt(), calculatePartialDeps(safeStore, txnId, partialTxn.keys(), partialTxn.kind(), txnId, safeStore.ranges().between(minEpoch, txnId.epoch)));
+                return new PreAcceptOk(txnId, command.executeAt(), calculatePartialDeps(safeStore, txnId, partialTxn.keys(), partialTxn.kind(), txnId, safeStore.ranges().between(minEpoch, txnId.epoch())));
 
             case RejectedBallot:
                 return PreAcceptNack.INSTANCE;

--- a/accord-core/src/main/java/accord/messages/ReadData.java
+++ b/accord-core/src/main/java/accord/messages/ReadData.java
@@ -65,7 +65,7 @@ public class ReadData extends AbstractEpochRequest<ReadData.ReadNack> implements
     public ReadData(Node.Id to, Topologies topologies, TxnId txnId, Seekables<?, ?> readScope, Timestamp executeAt)
     {
         super(txnId);
-        this.executeAtEpoch = executeAt.epoch;
+        this.executeAtEpoch = executeAt.epoch();
         int startIndex = latestRelevantEpochIndex(to, topologies, readScope);
         this.readScope = computeScope(to, topologies, (Seekables)readScope, startIndex, Seekables::slice, Seekables::union);
         this.waitForEpoch = computeWaitForEpoch(to, topologies, startIndex);

--- a/accord-core/src/main/java/accord/messages/WaitOnCommit.java
+++ b/accord-core/src/main/java/accord/messages/WaitOnCommit.java
@@ -70,7 +70,7 @@ public class WaitOnCommit implements Request, MapReduceConsume<SafeCommandStore,
         this.node = node;
         this.replyTo = replyToNode;
         this.replyContext = replyContext;
-        node.mapReduceConsumeLocal(this, scope, txnId.epoch, txnId.epoch, this);
+        node.mapReduceConsumeLocal(this, scope, txnId.epoch(), txnId.epoch(), this);
     }
 
     @Override
@@ -189,6 +189,6 @@ public class WaitOnCommit implements Request, MapReduceConsume<SafeCommandStore,
     @Override
     public long waitForEpoch()
     {
-        return txnId.epoch;
+        return txnId.epoch();
     }
 }

--- a/accord-core/src/main/java/accord/primitives/AbstractKeys.java
+++ b/accord-core/src/main/java/accord/primitives/AbstractKeys.java
@@ -13,7 +13,7 @@ import accord.api.RoutingKey;
 import accord.utils.*;
 import net.nicoulaj.compilecommand.annotations.Inline;
 
-import static accord.primitives.Routable.Kind.Key;
+import static accord.primitives.Routable.Domain.Key;
 
 @SuppressWarnings("rawtypes")
 // TODO (desired, efficiency): check that foldl call-sites are inlined and optimised by HotSpot
@@ -46,7 +46,7 @@ public abstract class AbstractKeys<K extends RoutableKey, KS extends Routables<K
     }
 
     @Override
-    public final Unseekable.Kind kindOfContents()
+    public final Routable.Domain kindOfContents()
     {
         return Key;
     }

--- a/accord-core/src/main/java/accord/primitives/AbstractRanges.java
+++ b/accord-core/src/main/java/accord/primitives/AbstractRanges.java
@@ -96,9 +96,9 @@ public abstract class AbstractRanges<RS extends Routables<Range, ?>> implements 
     }
 
     @Override
-    public final Unseekable.Kind kindOfContents()
+    public final Routable.Domain kindOfContents()
     {
-        return Unseekable.Kind.Range;
+        return Routable.Domain.Range;
     }
 
     @Override

--- a/accord-core/src/main/java/accord/primitives/Ballot.java
+++ b/accord-core/src/main/java/accord/primitives/Ballot.java
@@ -22,6 +22,21 @@ import accord.local.Node.Id;
 
 public class Ballot extends Timestamp
 {
+    public static Ballot fromBits(long msb, long lsb, Id node)
+    {
+        return new Ballot(msb, lsb, node);
+    }
+
+    public static Ballot fromValues(long epoch, long hlc, Id node)
+    {
+        return fromValues(epoch, hlc, 0, node);
+    }
+
+    public static Ballot fromValues(long epoch, long hlc, int flags, Id node)
+    {
+        return new Ballot(epoch, hlc, flags, node);
+    }
+
     public static final Ballot ZERO = new Ballot(Timestamp.NONE);
 
     public Ballot(Timestamp from)
@@ -29,8 +44,18 @@ public class Ballot extends Timestamp
         super(from);
     }
 
-    public Ballot(long epoch, long real, int logical, Id node)
+    Ballot(long epoch, long hlc, int flags, Id node)
     {
-        super(epoch, real, logical, node);
+        super(epoch, hlc, flags, node);
+    }
+
+    Ballot(long msb, long lsb, Id node)
+    {
+        super(msb, lsb, node);
+    }
+
+    public Ballot merge(Timestamp that)
+    {
+        return merge(this, that, Ballot::fromBits);
     }
 }

--- a/accord-core/src/main/java/accord/primitives/Range.java
+++ b/accord-core/src/main/java/accord/primitives/Range.java
@@ -178,7 +178,7 @@ public abstract class Range implements Comparable<RoutableKey>, Unseekable, Seek
         return end;
     }
 
-    public final Kind kind() { return Kind.Range; }
+    public final Domain domain() { return Domain.Range; }
 
     public abstract boolean startInclusive();
     public abstract boolean endInclusive();

--- a/accord-core/src/main/java/accord/primitives/Routable.java
+++ b/accord-core/src/main/java/accord/primitives/Routable.java
@@ -7,8 +7,28 @@ import accord.api.RoutingKey;
  */
 public interface Routable
 {
-    enum Kind { Key, Range }
-    Kind kind();
+    enum Domain
+    {
+        Key, Range;
+        private static final Domain[] VALUES = Domain.values();
+
+        public boolean isKey()
+        {
+            return this == Key;
+        }
+
+        public boolean isRange()
+        {
+            return this == Range;
+        }
+
+        public static Routable.Domain ofOrdinal(int ordinal)
+        {
+            return VALUES[ordinal];
+        }
+    }
+
+    Domain domain();
     Unseekable toUnseekable();
     RoutingKey someIntersectingRoutingKey();
 }

--- a/accord-core/src/main/java/accord/primitives/RoutableKey.java
+++ b/accord-core/src/main/java/accord/primitives/RoutableKey.java
@@ -46,7 +46,7 @@ public interface RoutableKey extends Routable, Comparable<RoutableKey>
      */
     int compareTo(@Nonnull RoutableKey that);
 
-    default Kind kind() { return Kind.Key; }
+    default Domain domain() { return Domain.Key; }
 
     RoutingKey toUnseekable();
 

--- a/accord-core/src/main/java/accord/primitives/Routables.java
+++ b/accord-core/src/main/java/accord/primitives/Routables.java
@@ -57,7 +57,7 @@ public interface Routables<K extends Routable, U extends Routables<K, ?>> extend
      */
     int findNext(int thisIndex, K find, SortedArrays.Search search);
 
-    Routable.Kind kindOfContents();
+    Routable.Domain kindOfContents();
 
     @Inline
     static <Input extends Routable, T> T foldl(Routables<Input, ?> inputs, AbstractRanges<?> matching, IndexedFold<? super Input, T> fold, T initialValue)

--- a/accord-core/src/main/java/accord/primitives/Timestamp.java
+++ b/accord-core/src/main/java/accord/primitives/Timestamp.java
@@ -19,49 +19,124 @@
 package accord.primitives;
 
 import accord.local.Node.Id;
+import accord.utils.Invariants;
+
+import javax.annotation.Nonnull;
 
 public class Timestamp implements Comparable<Timestamp>
 {
+    public static Timestamp fromBits(long msb, long lsb, Id node)
+    {
+        return new Timestamp(msb, lsb, node);
+    }
+
+    public static Timestamp fromValues(long epoch, long hlc, Id node)
+    {
+        return new Timestamp(epoch, hlc, 0, node);
+    }
+
+    public static Timestamp fromValues(long epoch, long hlc, int flags, Id node)
+    {
+        return new Timestamp(epoch, hlc, flags, node);
+    }
+
+    public static Timestamp maxForEpoch(long epoch)
+    {
+        return new Timestamp(epochMsb(epoch) | 0xffff, Long.MAX_VALUE, Id.MAX);
+    }
+
+    public static Timestamp minForEpoch(long epoch)
+    {
+        return new Timestamp(epochMsb(epoch), 0, Id.NONE);
+    }
+
+    private static final long MAX_EPOCH = (1L << 48) - 1;
+    private static final long HLC_INCR = 1L << 16;
+    private static final long MAX_FLAGS = HLC_INCR - 1;
     public static final Timestamp NONE = new Timestamp(0, 0, 0, Id.NONE);
 
-    public final long epoch;
-    public final long real;
-    public final int logical;
+    public final long msb;
+    public final long lsb;
     public final Id node;
 
-    public Timestamp(long epoch, long real, int logical, Id node)
+    Timestamp(long epoch, long hlc, int flags, Id node)
     {
-        this.epoch = epoch;
-        this.real = real;
-        this.logical = logical;
+        Invariants.checkArgument(epoch <= MAX_EPOCH);
+        Invariants.checkArgument(flags <= MAX_FLAGS);
+        this.msb = epochMsb(epoch) | hlcMsb(hlc);
+        this.lsb = hlcLsb(hlc) | flags;
+        this.node = node;
+    }
+
+    Timestamp(long msb, long lsb, Id node)
+    {
+        this.msb = msb;
+        this.lsb = lsb;
         this.node = node;
     }
 
     public Timestamp(Timestamp copy)
     {
-        this.epoch = copy.epoch;
-        this.real = copy.real;
-        this.logical = copy.logical;
+        this.msb = copy.msb;
+        this.lsb = copy.lsb;
         this.node = copy.node;
     }
 
-    public Timestamp withMinEpoch(long minEpoch)
+    Timestamp(Timestamp copy, int flags)
     {
-        return minEpoch <= epoch ? this : new Timestamp(minEpoch, real, logical, node);
+        Invariants.checkArgument(flags <= MAX_FLAGS);
+        this.msb = copy.msb;
+        this.lsb = notFlags(copy.lsb) | flags;
+        this.node = copy.node;
+    }
+
+    public long epoch()
+    {
+        return epoch(msb);
+    }
+
+    /**
+     * A hybrid logical clock with implementation-defined resolution
+     */
+    public long hlc()
+    {
+        return highHlc(msb) | lowHlc(lsb);
+    }
+
+    public int flags()
+    {
+        return flags(lsb);
+    }
+
+    public Timestamp withEpochAtLeast(long minEpoch)
+    {
+        return minEpoch <= epoch() ? this : new Timestamp(minEpoch, hlc(), flags(), node);
     }
 
     public Timestamp logicalNext(Id node)
     {
-        return new Timestamp(epoch, real, logical + 1, node);
+        long lsb = this.lsb + HLC_INCR;
+        long msb = this.msb;
+        if (lowHlc(lsb) == 0)
+            ++msb; // overflow of lsb
+        return new Timestamp(msb, lsb, node);
     }
 
     @Override
-    public int compareTo(Timestamp that)
+    public int compareTo(@Nonnull Timestamp that)
     {
         if (this == that) return 0;
-        int c = Long.compare(this.epoch, that.epoch);
-        if (c == 0) c = Long.compare(this.real, that.real);
-        if (c == 0) c = Integer.compare(this.logical, that.logical);
+        int c = Long.compareUnsigned(this.msb, that.msb);
+        if (c == 0) c = Long.compare(lowHlc(this.lsb), lowHlc(that.lsb));
+        if (c == 0) c = this.node.compareTo(that.node);
+        return c;
+    }
+
+    public int compareToStrict(@Nonnull Timestamp that)
+    {
+        if (this == that) return 0;
+        int c = Long.compareUnsigned(this.msb, that.msb);
+        if (c == 0) c = Long.compareUnsigned(this.lsb, that.lsb);
         if (c == 0) c = this.node.compareTo(that.node);
         return c;
     }
@@ -69,12 +144,20 @@ public class Timestamp implements Comparable<Timestamp>
     @Override
     public int hashCode()
     {
-        return (int) (((((epoch * 31) + real) * 31) + node.hashCode()) * 31 + logical);
+        return (int) (((msb * 31) + lowHlc(lsb)) * 31) + node.hashCode();
     }
 
     public boolean equals(Timestamp that)
     {
-        return this.epoch == that.epoch && this.real == that.real && this.logical == that.logical && this.node.equals(that.node);
+        return this.msb == that.msb && lowHlc(this.lsb) == lowHlc(that.lsb) && this.node.equals(that.node);
+    }
+
+    /**
+     * Include flag bits in identity
+     */
+    public boolean equalsStrict(Timestamp that)
+    {
+        return this.msb == that.msb && this.lsb == that.lsb && this.node.equals(that.node);
     }
 
     @Override
@@ -98,10 +181,67 @@ public class Timestamp implements Comparable<Timestamp>
         return a.compareTo(b) <= 0 ? a : b;
     }
 
+    private static long epoch(long msb)
+    {
+        return msb >>> 16;
+    }
+
+    private static long epochMsb(long epoch)
+    {
+        return epoch << 16;
+    }
+
+    private static long hlcMsb(long hlc)
+    {
+        return hlc >>> 48;
+    }
+
+    private static long hlcLsb(long hlc)
+    {
+        return hlc << 16;
+    }
+
+    private static long highHlc(long msb)
+    {
+        return msb << 48;
+    }
+
+    private static long lowHlc(long lsb)
+    {
+        return lsb >>> 16;
+    }
+
+    private static int flags(long lsb)
+    {
+        return (int) (lsb & MAX_FLAGS);
+    }
+
+    private static long notFlags(long lsb)
+    {
+        return lsb & ~MAX_FLAGS;
+    }
+
+    public Timestamp merge(Timestamp that)
+    {
+        return merge(this, that, Timestamp::fromBits);
+    }
+
+    interface Constructor<T>
+    {
+        T construct(long msb, long lsb, Id node);
+    }
+
+    static <T extends Timestamp> T merge(Timestamp a, Timestamp b, Constructor<T> constructor)
+    {
+        Invariants.checkArgument(a.msb == b.msb);
+        Invariants.checkArgument(lowHlc(a.lsb) == lowHlc(b.lsb));
+        Invariants.checkArgument(a.node.equals(b.node));
+        return constructor.construct(a.msb, a.lsb | b.lsb, a.node);
+    }
+
     @Override
     public String toString()
     {
-        return "[" + epoch + ',' + real + ',' + logical + ',' + node + ']';
+        return "[" + epoch() + ',' + hlc() + ',' + flags() + ',' + node + ']';
     }
-
 }

--- a/accord-core/src/main/java/accord/primitives/TxnId.java
+++ b/accord-core/src/main/java/accord/primitives/TxnId.java
@@ -19,16 +19,106 @@
 package accord.primitives;
 
 import accord.local.Node.Id;
+import accord.primitives.Routable.Domain;
+import accord.primitives.Txn.Kind;
+
+import static accord.primitives.Txn.Kind.Read;
+import static accord.primitives.Txn.Kind.Write;
 
 public class TxnId extends Timestamp
 {
-    public TxnId(Timestamp timestamp)
+    public static TxnId fromBits(long msb, long lsb, Id node)
     {
-        super(timestamp);
+        return new TxnId(msb, lsb, node);
     }
 
-    public TxnId(long epoch, long real, int logical, Id node)
+    public static TxnId fromValues(long epoch, long hlc, Id node)
     {
-        super(epoch, real, logical, node);
+        return new TxnId(epoch, hlc, 0, node);
+    }
+
+    public static TxnId fromValues(long epoch, long hlc, int flags, Id node)
+    {
+        return new TxnId(epoch, hlc, flags, node);
+    }
+
+    public TxnId(Timestamp timestamp, Kind rw, Domain domain)
+    {
+        super(timestamp, flags(rw, domain));
+    }
+
+    public TxnId(long epoch, long hlc, Kind rw, Domain domain, Id node)
+    {
+        this(epoch, hlc, flags(rw, domain), node);
+    }
+
+    private TxnId(long epoch, long hlc, int flags, Id node)
+    {
+        super(epoch, hlc, flags, node);
+    }
+
+    private TxnId(long msb, long lsb, Id node)
+    {
+        super(msb, lsb, node);
+    }
+
+    public boolean isWrite()
+    {
+        return rwOrdinal(flags()) == Write.ordinal();
+    }
+
+    public boolean isRead()
+    {
+        return rwOrdinal(flags()) == Read.ordinal();
+    }
+
+    public Kind rw()
+    {
+        return rw(flags());
+    }
+
+    public Domain domain()
+    {
+        return domain(flags());
+    }
+
+    public TxnId merge(Timestamp that)
+    {
+        return merge(this, that, TxnId::fromBits);
+    }
+
+    private static int flags(Kind rw, Domain domain)
+    {
+        return flags(rw) | flags(domain);
+    }
+
+    private static int flags(Kind rw)
+    {
+        return rw.ordinal() << 1;
+    }
+
+    private static int flags(Domain domain)
+    {
+        return domain.ordinal();
+    }
+
+    private static Kind rw(int flags)
+    {
+        return Kind.ofOrdinal(rwOrdinal(flags));
+    }
+
+    private static Domain domain(int flags)
+    {
+        return Domain.ofOrdinal(domainOrdinal(flags));
+    }
+
+    private static int rwOrdinal(int flags)
+    {
+        return (flags >> 1) & 1;
+    }
+
+    private static int domainOrdinal(int flags)
+    {
+        return flags & 1;
     }
 }

--- a/accord-core/src/main/java/accord/primitives/Writes.java
+++ b/accord-core/src/main/java/accord/primitives/Writes.java
@@ -67,7 +67,7 @@ public class Writes
         if (write == null)
             return SUCCESS;
 
-        Ranges ranges = safeStore.ranges().since(executeAt.epoch);
+        Ranges ranges = safeStore.ranges().since(executeAt.epoch());
         if (ranges == null)
             return SUCCESS;
 

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -294,7 +294,7 @@ public class TopologyManager implements ConfigurationService.Listener
 
     public Topologies withUnsyncedEpochs(Unseekables<?, ?> select, Timestamp at)
     {
-        return withUnsyncedEpochs(select, at.epoch);
+        return withUnsyncedEpochs(select, at.epoch());
     }
 
     public Topologies withUnsyncedEpochs(Unseekables<?, ?> select, long epoch)
@@ -304,7 +304,7 @@ public class TopologyManager implements ConfigurationService.Listener
 
     public Topologies withUnsyncedEpochs(Unseekables<?, ?> select, Timestamp min, Timestamp max)
     {
-        return withUnsyncedEpochs(select, min.epoch, max.epoch);
+        return withUnsyncedEpochs(select, min.epoch(), max.epoch());
     }
 
     public Topologies withUnsyncedEpochs(Unseekables<?, ?> select, long minEpoch, long maxEpoch)

--- a/accord-core/src/test/java/accord/burn/TopologyUpdates.java
+++ b/accord-core/src/test/java/accord/burn/TopologyUpdates.java
@@ -118,12 +118,12 @@ public class TopologyUpdates
                     break;
                 case PreApplied:
                 case Applied:
-                    node.withEpoch(Math.max(executeAt.epoch, toEpoch), () -> {
+                    node.withEpoch(Math.max(executeAt.epoch(), toEpoch), () -> {
                         FetchData.fetch(PreApplied.minKnown, node, txnId, route, executeAt, toEpoch, callback);
                     });
                     break;
                 case Invalidated:
-                    node.forEachLocal(contextFor(txnId), route, txnId.epoch, toEpoch, safeStore -> {
+                    node.forEachLocal(contextFor(txnId), route, txnId.epoch(), toEpoch, safeStore -> {
                         safeStore.command(txnId).commitInvalidate(safeStore);
                     });
             }

--- a/accord-core/src/test/java/accord/coordinate/CoordinateTest.java
+++ b/accord-core/src/test/java/accord/coordinate/CoordinateTest.java
@@ -33,6 +33,8 @@ import static accord.Utils.id;
 import static accord.Utils.ids;
 import static accord.Utils.writeTxn;
 import static accord.impl.IntKey.keys;
+import static accord.primitives.Routable.Domain.Key;
+import static accord.primitives.Txn.Kind.Write;
 
 public class CoordinateTest
 {
@@ -44,7 +46,7 @@ public class CoordinateTest
             Node node = cluster.get(1);
             Assertions.assertNotNull(node);
 
-            TxnId txnId = node.nextTxnId();
+            TxnId txnId = node.nextTxnId(Write, Key);
             Keys keys = keys(10);
             Txn txn = writeTxn(keys);
             FullKeyRoute route = keys.toRoute(keys.get(0).toUnseekable());
@@ -71,8 +73,8 @@ public class CoordinateTest
 
     private TxnId coordinate(Node node, long clock, Keys keys) throws Throwable
     {
-        TxnId txnId = node.nextTxnId();
-        txnId = new TxnId(txnId.epoch, txnId.real + clock, 0, txnId.node);
+        TxnId txnId = node.nextTxnId(Write, Key);
+        txnId = new TxnId(txnId.epoch(), txnId.hlc() + clock, Write, Key, txnId.node);
         Txn txn = writeTxn(keys);
         Result result = Coordinate.coordinate(node, txnId, txn, node.computeRoute(txnId, txn.keys())).get();
         Assertions.assertEquals(MockStore.RESULT, result);
@@ -135,7 +137,7 @@ public class CoordinateTest
             Node node = cluster.get(1);
             Assertions.assertNotNull(node);
 
-            TxnId txnId = node.nextTxnId();
+            TxnId txnId = node.nextTxnId(Write, Key);
             Keys oneKey = keys(10);
             Keys twoKeys = keys(10, 20);
             Txn txn = new Txn.InMemory(oneKey, MockStore.read(oneKey), MockStore.QUERY, MockStore.update(twoKeys));

--- a/accord-core/src/test/java/accord/coordinate/TopologyChangeTest.java
+++ b/accord-core/src/test/java/accord/coordinate/TopologyChangeTest.java
@@ -18,14 +18,11 @@
 
 package accord.coordinate;
 
-import accord.impl.mock.EpochSync;
 import accord.impl.mock.MockCluster;
 import accord.impl.mock.MockConfigurationService;
-import accord.impl.mock.RecordingMessageSink;
 import accord.local.Command;
 import accord.local.Node;
 import accord.local.Status;
-import accord.messages.Accept;
 import accord.primitives.Range;
 import accord.topology.Topology;
 import accord.primitives.Keys;
@@ -35,25 +32,15 @@ import accord.utils.EpochFunction;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import static accord.Utils.*;
 import static accord.impl.IntKey.keys;
 import static accord.impl.IntKey.range;
 import static accord.local.PreLoadContext.empty;
+import static accord.primitives.Routable.Domain.Key;
+import static accord.primitives.Txn.Kind.Write;
 
 public class TopologyChangeTest
 {
-    private static TxnId coordinate(Node node, Keys keys) throws Throwable
-    {
-        TxnId txnId = node.nextTxnId();
-        Txn txn = writeTxn(keys);
-        node.coordinate(txnId, txn).get();
-        return txnId;
-    }
-
     @Test
     void disjointElectorate() throws Throwable
     {
@@ -72,7 +59,7 @@ public class TopologyChangeTest
                                               .build())
         {
             Node node1 = cluster.get(1);
-            TxnId txnId1 = node1.nextTxnId();
+            TxnId txnId1 = node1.nextTxnId(Write, Key);
             Txn txn1 = writeTxn(keys);
             node1.coordinate(txnId1, txn1).get();
             node1.commandStores().forEach(empty(), keys, 1, 1, commands -> {
@@ -83,7 +70,7 @@ public class TopologyChangeTest
             cluster.configServices(4, 5, 6).forEach(config -> config.reportTopology(topology2));
 
             Node node4 = cluster.get(4);
-            TxnId txnId2 = node4.nextTxnId();
+            TxnId txnId2 = node4.nextTxnId(Write, Key);
             Txn txn2 = writeTxn(keys);
             node4.coordinate(txnId2, txn2).get();
 

--- a/accord-core/src/test/java/accord/impl/TestAgent.java
+++ b/accord-core/src/test/java/accord/impl/TestAgent.java
@@ -56,6 +56,6 @@ public class TestAgent implements Agent
     @Override
     public boolean isExpired(TxnId initiated, long now)
     {
-        return TimeUnit.SECONDS.convert(now - initiated.real, TimeUnit.MICROSECONDS) >= 10;
+        return TimeUnit.SECONDS.convert(now - initiated.hlc(), TimeUnit.MICROSECONDS) >= 10;
     }
 }

--- a/accord-core/src/test/java/accord/impl/list/ListAgent.java
+++ b/accord-core/src/test/java/accord/impl/list/ListAgent.java
@@ -70,6 +70,6 @@ public class ListAgent implements Agent
     @Override
     public boolean isExpired(TxnId initiated, long now)
     {
-        return now - initiated.real >= timeout;
+        return now - initiated.hlc() >= timeout;
     }
 }

--- a/accord-core/src/test/java/accord/impl/list/ListRequest.java
+++ b/accord-core/src/test/java/accord/impl/list/ListRequest.java
@@ -34,7 +34,6 @@ import accord.messages.CheckStatus.IncludeInfo;
 import accord.messages.MessageType;
 import accord.messages.ReplyContext;
 import accord.primitives.RoutingKeys;
-import accord.primitives.RoutingKeys;
 import accord.primitives.Txn;
 import accord.messages.Request;
 import accord.primitives.TxnId;
@@ -51,7 +50,7 @@ public class ListRequest implements Request
         int count = 0;
         protected CheckOnResult(Node node, TxnId txnId, RoutingKey homeKey, BiConsumer<Outcome, Throwable> callback)
         {
-            super(node, txnId, RoutingKeys.of(homeKey), txnId.epoch, IncludeInfo.All);
+            super(node, txnId, RoutingKeys.of(homeKey), txnId.epoch(), IncludeInfo.All);
             this.callback = callback;
         }
 

--- a/accord-core/src/test/java/accord/impl/mock/MockCluster.java
+++ b/accord-core/src/test/java/accord/impl/mock/MockCluster.java
@@ -26,6 +26,8 @@ import accord.local.Node;
 import accord.local.Node.Id;
 import accord.local.ShardDistributor;
 import accord.primitives.Ranges;
+import accord.primitives.Routable;
+import accord.primitives.Txn;
 import accord.utils.EpochFunction;
 import accord.utils.ThreadPoolScheduler;
 import accord.primitives.TxnId;
@@ -45,6 +47,8 @@ import java.util.function.BiFunction;
 import java.util.function.LongSupplier;
 
 import static accord.Utils.*;
+import static accord.primitives.Routable.Domain.Key;
+import static accord.primitives.Txn.Kind.Write;
 
 public class MockCluster implements Network, AutoCloseable, Iterable<Node>
 {
@@ -382,7 +386,7 @@ public class MockCluster implements Network, AutoCloseable, Iterable<Node>
 
         public TxnId idForNode(long epoch, Id id)
         {
-            return new TxnId(epoch, now.get(), 0, id);
+            return new TxnId(epoch, now.get(), Write, Key, id);
         }
 
         public TxnId idForNode(long epoch, int id)

--- a/accord-core/src/test/java/accord/local/NodeTest.java
+++ b/accord-core/src/test/java/accord/local/NodeTest.java
@@ -26,9 +26,9 @@ import org.junit.jupiter.api.Test;
 
 public class NodeTest
 {
-    private static Timestamp ts(long epoch, long real, int logical, int node)
+    private static Timestamp ts(long epoch, long hlc, int node)
     {
-        return new Timestamp(epoch, real, logical, new Node.Id(node));
+        return Timestamp.fromValues(epoch, hlc, new Node.Id(node));
     }
 
     @Test
@@ -44,12 +44,13 @@ public class NodeTest
             Timestamp timestamp2 = node.uniqueNow();
 
             clock.increment();
+            clock.increment();
+            clock.increment();
             Timestamp timestamp3 = node.uniqueNow();
 
-            Assertions.assertEquals(ts(1, 101, 0, 1), timestamp1);
-            Assertions.assertEquals(ts(1, 101, 1, 1), timestamp2);
-
-            Assertions.assertEquals(ts(1, 102, 0, 1), timestamp3);
+            Assertions.assertEquals(ts(1, 101, 1), timestamp1);
+            Assertions.assertEquals(ts(1, 102, 1), timestamp2);
+            Assertions.assertEquals(ts(1, 104, 1), timestamp3);
         }
     }
 
@@ -64,11 +65,11 @@ public class NodeTest
 
             clock.increment();
             Timestamp timestamp1 = node.uniqueNow();
-            Assertions.assertEquals(ts(1, 101, 0, 1), timestamp1);
+            Assertions.assertEquals(ts(1, 101, 1), timestamp1);
 
             configService.reportTopology(node.topology().current().withEpoch(2));
             Timestamp timestamp2 = node.uniqueNow();
-            Assertions.assertEquals(ts(2, 101, 1, 1), timestamp2);
+            Assertions.assertEquals(ts(2, 102, 1), timestamp2);
         }
     }
 
@@ -82,19 +83,15 @@ public class NodeTest
 
             clock.increment();
             Timestamp timestamp1 = node.uniqueNow();
-            Assertions.assertEquals(ts(1, 101, 0, 1), timestamp1);
+            Assertions.assertEquals(ts(1, 101, 1), timestamp1);
 
-            // atLeast equal to most recent ts, logical should increment
-            Assertions.assertEquals(ts(1, 101, 1, 1),
+            // atLeast equal to most recent ts, should simply increment
+            Assertions.assertEquals(ts(1, 102, 1),
                                     node.uniqueNow(timestamp1));
 
-            // atLeast less than most recent ts
-            Assertions.assertEquals(ts(1, 101, 2, 1),
-                                    node.uniqueNow(ts(1, 99, 0, 1)));
-
             // atLeast greater than most recent ts
-            Assertions.assertEquals(ts(1, 110, 1, 1),
-                                    node.uniqueNow(ts(1, 110, 0, 2)));
+            Assertions.assertEquals(ts(1, 111, 1),
+                                    node.uniqueNow(ts(1, 110, 2)));
         }
     }
 }

--- a/accord-maelstrom/src/main/java/accord/maelstrom/Json.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/Json.java
@@ -113,13 +113,13 @@ public class Json
                 in.nextNull();
                 return null;
             }
-            return readTimestamp(in, Timestamp::new);
+            return readTimestamp(in, Timestamp::fromBits);
         }
     };
 
     private interface TimestampFactory<T>
     {
-        T create(long epoch, long real, int logical, Id node);
+        T create(long msb, long lsb, Id node);
     }
 
     private static <T> T readTimestamp(JsonReader in, TimestampFactory<T> factory) throws IOException
@@ -130,12 +130,11 @@ public class Json
             return null;
         }
         in.beginArray();
-        long epoch = in.nextLong();
-        long real = in.nextLong();
-        int logical = in.nextInt();
+        long msb = in.nextLong();
+        long lsb = in.nextLong();
         Id node = ID_ADAPTER.read(in);
         in.endArray();
-        return factory.create(epoch, real, logical, node);
+        return factory.create(msb, lsb, node);
     }
 
     private static void writeTimestamp(JsonWriter out, Timestamp timestamp) throws IOException
@@ -146,9 +145,8 @@ public class Json
             return;
         }
         out.beginArray();
-        out.value(timestamp.epoch);
-        out.value(timestamp.real);
-        out.value(timestamp.logical);
+        out.value(timestamp.msb);
+        out.value(timestamp.lsb);
         ID_ADAPTER.write(out, timestamp.node);
         out.endArray();
     }
@@ -164,7 +162,7 @@ public class Json
         @Override
         public TxnId read(JsonReader in) throws IOException
         {
-            return readTimestamp(in, TxnId::new);
+            return readTimestamp(in, TxnId::fromBits);
         }
     };
 
@@ -179,7 +177,7 @@ public class Json
         @Override
         public Ballot read(JsonReader in) throws IOException
         {
-            return readTimestamp(in, Ballot::new);
+            return readTimestamp(in, Ballot::fromBits);
         }
     };
 

--- a/accord-maelstrom/src/main/java/accord/maelstrom/MaelstromAgent.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/MaelstromAgent.java
@@ -60,6 +60,6 @@ public class MaelstromAgent implements Agent
     @Override
     public boolean isExpired(TxnId initiated, long now)
     {
-        return TimeUnit.SECONDS.convert(now - initiated.real, TimeUnit.MICROSECONDS) >= 10;
+        return TimeUnit.SECONDS.convert(now - initiated.hlc(), TimeUnit.MICROSECONDS) >= 10;
     }
 }


### PR DESCRIPTION
Specifically, TxnId should have no more than 20 bytes of payload, and should encode simple flags about a Txn, such as whether it is a read or write transaction, and whether it operates on keys or ranges.