### PR TITLE
ExclusiveSyncPoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 accord-core/build/
 accord-maelstrom/build/
+.rat-excludes.txt

--- a/accord-core/build.gradle
+++ b/accord-core/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 }
 
 task burn(type: JavaExec) {
-    classpath sourceSets.main.runtimeClasspath, sourceSets.test.output
+    classpath sourceSets.main.runtimeClasspath, sourceSets.test.runtimeClasspath
     mainClass = 'accord.burn.BurnTest'
     jvmArgs '-Dlogback.configurationFile=burn-logback.xml'
     args = ['-c', '1']
@@ -103,7 +103,7 @@ task burnforkloop {
 task burnloop {
     doLast {
         javaexec {
-            classpath sourceSets.main.runtimeClasspath, sourceSets.test.output
+            classpath sourceSets.main.runtimeClasspath, sourceSets.test.runtimeClasspath
             mainClass = 'accord.burn.BurnTest'
             jvmArgs '-Dlogback.configurationFile=burn-logback.xml'
             args = ['-c', project.hasProperty('burnTimes') ? project.getProperty('burnTimes') : '1000000']

--- a/accord-core/src/main/java/accord/api/Agent.java
+++ b/accord-core/src/main/java/accord/api/Agent.java
@@ -20,7 +20,9 @@ package accord.api;
 
 import accord.local.Command;
 import accord.local.Node;
+import accord.primitives.Seekables;
 import accord.primitives.Timestamp;
+import accord.primitives.Txn;
 import accord.primitives.TxnId;
 
 /**
@@ -53,4 +55,6 @@ public interface Agent extends UncaughtExceptionListener
     void onHandledException(Throwable t);
 
     boolean isExpired(TxnId initiated, long now);
+
+    Txn emptyTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges);
 }

--- a/accord-core/src/main/java/accord/coordinate/Coordinate.java
+++ b/accord-core/src/main/java/accord/coordinate/Coordinate.java
@@ -117,7 +117,9 @@ public class Coordinate extends AsyncResults.SettableResult<Result> implements C
 
         if (!reply.isOk())
         {
+            // TODO (expected): reads should not be recovered, so should not be preempted
             // we've been preempted by a recovery coordinator; defer to it, and wait to hear any result
+            preAcceptIsDone = true;
             tryFailure(new Preempted(txnId, route.homeKey()));
             return;
         }

--- a/accord-core/src/main/java/accord/coordinate/CoordinatePreAccept.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinatePreAccept.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.coordinate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import accord.coordinate.tracking.FastPathTracker;
+import accord.coordinate.tracking.RequestStatus;
+import accord.local.Node;
+import accord.local.Node.Id;
+import accord.messages.Callback;
+import accord.messages.PreAccept;
+import accord.messages.PreAccept.PreAcceptOk;
+import accord.messages.PreAccept.PreAcceptReply;
+import accord.primitives.FullRoute;
+import accord.primitives.Txn;
+import accord.primitives.TxnId;
+import accord.topology.Topologies;
+import accord.utils.async.AsyncResults;
+
+import static accord.utils.Invariants.checkState;
+
+/**
+ * Perform initial rounds of PreAccept and Accept until we have reached agreement about when we should execute.
+ * If we are preempted by a recovery coordinator, we abort and let them complete (and notify us about the execution result)
+ *
+ * TODO (desired, testing): dedicated burn test to validate outcomes
+ */
+abstract class CoordinatePreAccept<T> extends AsyncResults.SettableResult<T> implements Callback<PreAcceptReply>, BiConsumer<T, Throwable>
+{
+    final Node node;
+    final TxnId txnId;
+    final Txn txn;
+    final FullRoute<?> route;
+
+    final FastPathTracker tracker;
+    private boolean preAcceptIsDone;
+    private final List<PreAcceptOk> successes;
+
+    CoordinatePreAccept(Node node, TxnId txnId, Txn txn, FullRoute<?> route)
+    {
+        this.node = node;
+        this.txnId = txnId;
+        this.txn = txn;
+        this.route = route;
+        Topologies topologies = node.topology().withUnsyncedEpochs(route, txnId, txnId);
+        this.tracker = new FastPathTracker(topologies);
+        this.successes = new ArrayList<>(tracker.topologies().estimateUniqueNodes());
+    }
+
+    void start()
+    {
+        // TODO (desired, efficiency): consider sending only to electorate of most recent topology (as only these PreAccept votes matter)
+        // note that we must send to all replicas of old topology, as electorate may not be reachable
+        node.send(tracker.nodes(), to -> new PreAccept(to, tracker.topologies(), txnId, txn, route),
+                  node.commandStores().select(route.homeKey()), this);
+    }
+
+    @Override
+    public synchronized void onFailure(Id from, Throwable failure)
+    {
+        if (preAcceptIsDone)
+            return;
+
+        switch (tracker.recordFailure(from))
+        {
+            default: throw new AssertionError();
+            case NoChange:
+                break;
+            case Failed:
+                checkState(!preAcceptIsDone);
+                preAcceptIsDone = true;
+                tryFailure(new Timeout(txnId, route.homeKey()));
+                break;
+            case Success:
+                checkState(!preAcceptIsDone);
+                preAcceptIsDone = true;
+                onPreAccepted(successes);
+        }
+    }
+
+    @Override
+    public void onCallbackFailure(Id from, Throwable failure)
+    {
+        tryFailure(failure);
+    }
+
+    public synchronized void onSuccess(Id from, PreAcceptReply reply)
+    {
+        if (preAcceptIsDone)
+            return;
+
+        if (!reply.isOk())
+        {
+            // we've been preempted by a recovery coordinator; defer to it, and wait to hear any result
+            tryFailure(new Preempted(txnId, route.homeKey()));
+            return;
+        }
+
+        PreAcceptOk ok = (PreAcceptOk) reply;
+        successes.add(ok);
+
+        boolean fastPath = ok.witnessedAt.compareTo(txnId) == 0;
+        // TODO (desired, safety): update formalisation (and proof), as we do not seek additional pre-accepts from later epochs.
+        //                         instead we rely on accept to do our work: a quorum of accept in the later epoch
+        //                         and its effect on preaccepted timestamps and the deps it returns create our sync point.
+        if (tracker.recordSuccess(from, fastPath) == RequestStatus.Success)
+        {
+            checkState(!preAcceptIsDone);
+            preAcceptIsDone = true;
+            onPreAccepted(successes);
+        }
+    }
+
+    abstract void onPreAccepted(List<PreAcceptOk> successes);
+
+    @Override
+    public void accept(T success, Throwable failure)
+    {
+        if (failure instanceof CoordinationFailed)
+            ((CoordinationFailed) failure).set(txnId, route.homeKey());
+
+        if (success != null) trySuccess(success);
+        else tryFailure(failure);
+    }
+}

--- a/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.coordinate;
+
+import java.util.List;
+
+import accord.local.Node;
+import accord.messages.Apply;
+import accord.messages.PreAccept.PreAcceptOk;
+import accord.primitives.Ballot;
+import accord.primitives.Deps;
+import accord.primitives.FullRoute;
+import accord.primitives.Seekables;
+import accord.primitives.SyncPoint;
+import accord.primitives.Timestamp;
+import accord.primitives.Txn;
+import accord.primitives.Txn.Kind;
+import accord.primitives.TxnId;
+import accord.utils.async.AsyncResult;
+
+import static accord.coordinate.Propose.Invalidate.proposeAndCommitInvalidate;
+import static accord.primitives.Timestamp.mergeMax;
+import static accord.primitives.Txn.Kind.ExclusiveSyncPoint;
+import static accord.utils.Functions.foldl;
+
+/**
+ * Perform initial rounds of PreAccept and Accept until we have reached agreement about when we should execute.
+ * If we are preempted by a recovery coordinator, we abort and let them complete (and notify us about the execution result)
+ *
+ * TODO (desired, testing): dedicated burn test to validate outcomes
+ */
+public class CoordinateSyncPoint extends CoordinatePreAccept<SyncPoint>
+{
+    private CoordinateSyncPoint(Node node, TxnId txnId, Txn txn, FullRoute<?> route)
+    {
+        super(node, txnId, txn, route);
+    }
+
+    public static AsyncResult<SyncPoint> exclusive(Node node, Seekables<?, ?> keysOrRanges)
+    {
+        return coordinate(ExclusiveSyncPoint, node, keysOrRanges);
+    }
+
+    public static AsyncResult<SyncPoint> inclusive(Node node, Seekables<?, ?> keysOrRanges)
+    {
+        return coordinate(Kind.SyncPoint, node, keysOrRanges);
+    }
+
+    private static AsyncResult<SyncPoint> coordinate(Kind kind, Node node, Seekables<?, ?> keysOrRanges)
+    {
+        TxnId txnId = node.nextTxnId(kind, keysOrRanges.domain());
+        FullRoute<?> route = node.computeRoute(txnId, keysOrRanges);
+        CoordinateSyncPoint coordinate = new CoordinateSyncPoint(node, txnId, node.agent().emptyTxn(kind, keysOrRanges), route);
+        coordinate.start();
+        return coordinate;
+    }
+
+    void onPreAccepted(List<PreAcceptOk> successes)
+    {
+        Deps deps = Deps.merge(successes, ok -> ok.deps);
+        Timestamp executeAt = foldl(successes, (ok, prev) -> mergeMax(ok.witnessedAt, prev), Timestamp.NONE);
+        if (executeAt.isRejected())
+        {
+            proposeAndCommitInvalidate(node, Ballot.ZERO, txnId, route.homeKey(), route, executeAt, this);
+        }
+        else
+        {
+            // SyncPoint transactions always propose their own txnId as their executeAt, as they are not really executed.
+            // They only create happens-after relationships wrt their dependencies, which represent all transactions
+            // that *may* execute before their txnId, so once these dependencies apply we can say that any action that
+            // awaits these dependencies applies after them. In the case of ExclusiveSyncPoint, we additionally guarantee
+            // that no lower TxnId can later apply.
+            new Propose<SyncPoint>(node, tracker.topologies(), Ballot.ZERO, txnId, txn, route, deps, txnId, this)
+            {
+                @Override
+                void onAccepted()
+                {
+                    node.send(tracker.nodes(), id -> new Apply(id, tracker.topologies(), tracker.topologies(), txnId.epoch(), txnId, route, txn, txnId, deps, txn.execute(txnId, null), txn.result(txnId, null)));
+                    accept(new SyncPoint(txnId, deps), null);
+                }
+            }.start();
+        }
+    }
+}

--- a/accord-core/src/main/java/accord/coordinate/CoordinationFailed.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinationFailed.java
@@ -26,11 +26,11 @@ import accord.primitives.TxnId;
 /**
  * Thrown when a transaction exceeds its specified timeout for obtaining a result for a client
  */
-public class CoordinateFailed extends Throwable
+public class CoordinationFailed extends Throwable
 {
     private @Nullable TxnId txnId;
     private @Nullable RoutingKey homeKey;
-    public CoordinateFailed(TxnId txnId, @Nullable RoutingKey homeKey)
+    public CoordinationFailed(TxnId txnId, @Nullable RoutingKey homeKey)
     {
         this.txnId = txnId;
         this.homeKey = homeKey;

--- a/accord-core/src/main/java/accord/coordinate/Execute.java
+++ b/accord-core/src/main/java/accord/coordinate/Execute.java
@@ -45,10 +45,10 @@ class Execute extends ReadCoordinator<ReadReply>
     final Timestamp executeAt;
     final Deps deps;
     final Topologies applyTo;
-    final BiConsumer<Result, Throwable> callback;
+    final BiConsumer<? super Result, Throwable> callback;
     private Data data;
 
-    private Execute(Node node, TxnId txnId, Txn txn, FullRoute<?> route, Seekables<?, ?> readScope, Timestamp executeAt, Deps deps, BiConsumer<Result, Throwable> callback)
+    private Execute(Node node, TxnId txnId, Txn txn, FullRoute<?> route, Seekables<?, ?> readScope, Timestamp executeAt, Deps deps, BiConsumer<? super Result, Throwable> callback)
     {
         super(node, node.topology().forEpoch(readScope.toUnseekables(), executeAt.epoch()), txnId);
         this.txn = txn;
@@ -60,7 +60,7 @@ class Execute extends ReadCoordinator<ReadReply>
         this.callback = callback;
     }
 
-    public static void execute(Node node, TxnId txnId, Txn txn, FullRoute<?> route, Timestamp executeAt, Deps deps, BiConsumer<Result, Throwable> callback)
+    public static void execute(Node node, TxnId txnId, Txn txn, FullRoute<?> route, Timestamp executeAt, Deps deps, BiConsumer<? super Result, Throwable> callback)
     {
         if (txn.read().keys().isEmpty())
         {

--- a/accord-core/src/main/java/accord/coordinate/Exhausted.java
+++ b/accord-core/src/main/java/accord/coordinate/Exhausted.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 /**
  * Thrown when a transaction exceeds its specified timeout for obtaining a result for a client
  */
-public class Exhausted extends CoordinateFailed
+public class Exhausted extends CoordinationFailed
 {
     public Exhausted(TxnId txnId, @Nullable RoutingKey homeKey)
     {

--- a/accord-core/src/main/java/accord/coordinate/Invalidated.java
+++ b/accord-core/src/main/java/accord/coordinate/Invalidated.java
@@ -18,9 +18,18 @@
 
 package accord.coordinate;
 
+import accord.api.RoutingKey;
+import accord.primitives.TxnId;
+
+import javax.annotation.Nullable;
+
 /**
  * Thrown when a transaction has been invalidated
  */
-public class Invalidated extends Throwable
+public class Invalidated extends CoordinationFailed
 {
+    public Invalidated(TxnId txnId, @Nullable RoutingKey homeKey)
+    {
+        super(txnId, homeKey);
+    }
 }

--- a/accord-core/src/main/java/accord/coordinate/Preempted.java
+++ b/accord-core/src/main/java/accord/coordinate/Preempted.java
@@ -27,7 +27,7 @@ import accord.primitives.TxnId;
  * Thrown when a coordinator is preempted by another recovery
  * coordinator intending to complete the transaction
  */
-public class Preempted extends CoordinateFailed
+public class Preempted extends CoordinationFailed
 {
     public Preempted(TxnId txnId, @Nullable RoutingKey homeKey)
     {

--- a/accord-core/src/main/java/accord/coordinate/Propose.java
+++ b/accord-core/src/main/java/accord/coordinate/Propose.java
@@ -24,26 +24,32 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
-import accord.api.Result;
 import accord.api.RoutingKey;
 import accord.coordinate.tracking.AbstractTracker.ShardOutcomes;
 import accord.coordinate.tracking.QuorumTracker;
 import accord.coordinate.tracking.QuorumTracker.QuorumShardTracker;
 import accord.coordinate.tracking.RequestStatus;
-import accord.messages.Callback;
-import accord.primitives.*;
-import accord.topology.Shard;
-import accord.topology.Topologies;
 import accord.local.Node;
 import accord.local.Node.Id;
 import accord.messages.Accept;
 import accord.messages.Accept.AcceptReply;
+import accord.messages.Callback;
+import accord.primitives.Ballot;
+import accord.primitives.Deps;
+import accord.primitives.FullRoute;
+import accord.primitives.Route;
+import accord.primitives.Timestamp;
+import accord.primitives.Txn;
+import accord.primitives.TxnId;
+import accord.topology.Shard;
+import accord.topology.Topologies;
 
 import static accord.coordinate.tracking.AbstractTracker.ShardOutcomes.Fail;
 import static accord.coordinate.tracking.RequestStatus.Failed;
+import static accord.messages.Commit.Invalidate.commitInvalidate;
 import static accord.utils.Invariants.debug;
 
-class Propose implements Callback<AcceptReply>
+abstract class Propose<R> implements Callback<AcceptReply>
 {
     final Node node;
     final Ballot ballot;
@@ -52,14 +58,14 @@ class Propose implements Callback<AcceptReply>
     final FullRoute<?> route;
     final Deps deps;
 
-    private final List<AcceptReply> acceptOks;
+    final List<AcceptReply> acceptOks;
     private final Map<Id, AcceptReply> debug = debug() ? new HashMap<>() : null;
-    private final Timestamp executeAt;
-    private final QuorumTracker acceptTracker;
-    private final BiConsumer<Result, Throwable> callback;
+    final Timestamp executeAt;
+    final QuorumTracker acceptTracker;
+    final BiConsumer<? super R, Throwable> callback;
     private boolean isDone;
 
-    Propose(Node node, Topologies topologies, Ballot ballot, TxnId txnId, Txn txn, FullRoute<?> route, Deps deps, Timestamp executeAt, BiConsumer<Result, Throwable> callback)
+    Propose(Node node, Topologies topologies, Ballot ballot, TxnId txnId, Txn txn, FullRoute<?> route, Deps deps, Timestamp executeAt, BiConsumer<? super R, Throwable> callback)
     {
         this.node = node;
         this.ballot = ballot;
@@ -73,18 +79,9 @@ class Propose implements Callback<AcceptReply>
         this.acceptTracker = new QuorumTracker(topologies);
     }
 
-    public static void propose(Node node, Ballot ballot, TxnId txnId, Txn txn, FullRoute<?> route,
-                               Timestamp executeAt, Deps deps, BiConsumer<Result, Throwable> callback)
+    void start()
     {
-        Topologies topologies = node.topology().withUnsyncedEpochs(route, txnId, executeAt);
-        propose(node, topologies, ballot, txnId, txn, route, executeAt, deps, callback);
-    }
-
-    public static void propose(Node node, Topologies topologies, Ballot ballot, TxnId txnId, Txn txn, FullRoute<?> route,
-                               Timestamp executeAt, Deps deps, BiConsumer<Result, Throwable> callback)
-    {
-        Propose propose = new Propose(node, topologies, ballot, txnId, txn, route, deps, executeAt, callback);
-        node.send(propose.acceptTracker.nodes(), to -> new Accept(to, topologies, ballot, txnId, route, executeAt, txn.keys(), deps), propose);
+        node.send(acceptTracker.nodes(), to -> new Accept(to, acceptTracker.topologies(), ballot, txnId, route, executeAt, txn.keys(), deps), this);
     }
 
     @Override
@@ -106,7 +103,10 @@ class Propose implements Callback<AcceptReply>
             case Success:
                 acceptOks.add(reply);
                 if (acceptTracker.recordSuccess(from) == RequestStatus.Success)
+                {
+                    isDone = true;
                     onAccepted();
+                }
         }
     }
 
@@ -127,12 +127,7 @@ class Propose implements Callback<AcceptReply>
         callback.accept(null, failure);
     }
 
-    private void onAccepted()
-    {
-        isDone = true;
-        Deps deps = Deps.merge(acceptOks, ok -> ok.deps);
-        Execute.execute(node, txnId, txn, route, executeAt, deps, callback);
-    }
+    abstract void onAccepted();
 
     // A special version for proposing the invalidation of a transaction; only needs to succeed on one shard
     static class Invalidate implements Callback<AcceptReply>
@@ -162,6 +157,23 @@ class Propose implements Callback<AcceptReply>
             Invalidate invalidate = new Invalidate(node, shard, ballot, txnId, invalidateWithKey, callback);
             node.send(shard.nodes, to -> new Accept.Invalidate(ballot, txnId, invalidateWithKey), invalidate);
             return invalidate;
+        }
+
+        public static Invalidate proposeAndCommitInvalidate(Node node, Ballot ballot, TxnId txnId, RoutingKey invalidateWithKey, Route<?> commitInvalidationTo, Timestamp invalidateUntil, BiConsumer<?, Throwable> callback)
+        {
+            return proposeInvalidate(node, ballot, txnId, invalidateWithKey, (success, fail) -> {
+                if (fail != null)
+                {
+                    callback.accept(null, fail);
+                }
+                else
+                {
+                    node.withEpoch(invalidateUntil.epoch(), () -> {
+                        commitInvalidate(node, txnId, commitInvalidationTo, invalidateUntil);
+                        callback.accept(null, new Invalidated(txnId, invalidateWithKey));
+                    });
+                }
+            });
         }
 
         @Override

--- a/accord-core/src/main/java/accord/coordinate/ProposeAndExecute.java
+++ b/accord-core/src/main/java/accord/coordinate/ProposeAndExecute.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.coordinate;
+
+import java.util.function.BiConsumer;
+
+import accord.api.Result;
+import accord.local.Node;
+import accord.primitives.Ballot;
+import accord.primitives.Deps;
+import accord.primitives.FullRoute;
+import accord.primitives.Timestamp;
+import accord.primitives.Txn;
+import accord.primitives.TxnId;
+import accord.topology.Topologies;
+
+class ProposeAndExecute extends Propose<Result>
+{
+    ProposeAndExecute(Node node, Topologies topologies, Ballot ballot, TxnId txnId, Txn txn, FullRoute<?> route, Deps deps, Timestamp executeAt, BiConsumer<Result, Throwable> callback)
+    {
+        super(node, topologies, ballot, txnId, txn, route, deps, executeAt, callback);
+    }
+
+    public static void proposeAndExecute(Node node, Ballot ballot, TxnId txnId, Txn txn, FullRoute<?> route,
+                                         Timestamp executeAt, Deps deps, BiConsumer<Result, Throwable> callback)
+    {
+        Topologies topologies = node.topology().withUnsyncedEpochs(route, txnId, executeAt);
+        proposeAndExecute(node, topologies, ballot, txnId, txn, route, executeAt, deps, callback);
+    }
+
+    public static void proposeAndExecute(Node node, Topologies topologies, Ballot ballot, TxnId txnId, Txn txn, FullRoute<?> route,
+                                         Timestamp executeAt, Deps deps, BiConsumer<Result, Throwable> callback)
+    {
+        ProposeAndExecute propose = new ProposeAndExecute(node, topologies, ballot, txnId, txn, route, deps, executeAt, callback);
+        propose.start();
+    }
+
+    void onAccepted()
+    {
+        Deps deps = Deps.merge(acceptOks, ok -> ok.deps);
+        Execute.execute(node, txnId, txn, route, executeAt, deps, callback);
+    }
+}

--- a/accord-core/src/main/java/accord/impl/CommandsForKey.java
+++ b/accord-core/src/main/java/accord/impl/CommandsForKey.java
@@ -41,9 +41,9 @@ public class CommandsForKey
 {
     public static class SerializerSupport
     {
-        public static CommandsForKey.Listener listener(Key key)
+        public static Listener listener(Key key)
         {
-            return new CommandsForKey.Listener(key);
+            return new Listener(key);
         }
 
         public static  <D> CommandsForKey create(Key key, Timestamp max,
@@ -229,7 +229,7 @@ public class CommandsForKey
         }
     }
 
-    public static class Listener implements CommandListener
+    public static class Listener implements Command.DurableAndIdempotentListener
     {
         protected final Key listenerKey;
 
@@ -354,7 +354,7 @@ public class CommandsForKey
         throw new UnsupportedOperationException();
     }
 
-    public final CommandListener asListener()
+    public final Command.DurableAndIdempotentListener asListener()
     {
         return new Listener(key());
     }

--- a/accord-core/src/main/java/accord/impl/InMemoryCommandStore.java
+++ b/accord-core/src/main/java/accord/impl/InMemoryCommandStore.java
@@ -541,7 +541,7 @@ public abstract class InMemoryCommandStore extends CommandStore
         public void addListener(Command.TransientListener listener)
         {
             if (transientListeners == null) transientListeners = new Listeners<>();
-            else transientListeners.add(listener);
+            transientListeners.add(listener);
         }
 
         public void removeListener(Command.TransientListener listener)

--- a/accord-core/src/main/java/accord/impl/InMemoryCommandStore.java
+++ b/accord-core/src/main/java/accord/impl/InMemoryCommandStore.java
@@ -18,30 +18,69 @@
 
 package accord.impl;
 
-import accord.api.*;
-import accord.local.*;
-import accord.local.CommandStores.RangesForEpochHolder;
-import accord.local.CommandStores.RangesForEpoch;
-import accord.primitives.Timestamp;
-import accord.primitives.TxnId;
-import accord.primitives.*;
-import accord.utils.Invariants;
-import accord.utils.async.AsyncChain;
-import accord.utils.async.AsyncChains;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static accord.local.SafeCommandStore.TestDep.*;
-import static accord.local.SafeCommandStore.TestKind.Ws;
-import static accord.local.Status.*;
+import accord.api.Agent;
+import accord.api.DataStore;
+import accord.api.Key;
+import accord.api.ProgressLog;
+import accord.local.Command;
+import accord.local.CommandListener;
+import accord.local.CommandStore;
+import accord.local.CommandStores.RangesForEpoch;
+import accord.local.CommandStores.RangesForEpochHolder;
+import accord.local.CommonAttributes;
+import accord.local.Listeners;
+import accord.local.NodeTimeService;
+import accord.local.PreLoadContext;
+import accord.local.SafeCommand;
+import accord.local.SafeCommandStore;
+import accord.local.SaveStatus;
+import accord.local.Status;
+import accord.primitives.AbstractKeys;
+import accord.primitives.PartialDeps;
+import accord.primitives.Range;
+import accord.primitives.Ranges;
+import accord.primitives.Routable;
+import accord.primitives.RoutableKey;
+import accord.primitives.Routables;
+import accord.primitives.Seekable;
+import accord.primitives.Seekables;
+import accord.primitives.Timestamp;
+import accord.primitives.TxnId;
+import accord.utils.Invariants;
+import accord.utils.ReducingRangeMap;
+import accord.utils.async.AsyncChain;
+import accord.utils.async.AsyncChains;
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static accord.local.SafeCommandStore.TestDep.ANY_DEPS;
+import static accord.local.SafeCommandStore.TestDep.WITH;
+import static accord.local.Status.Committed;
+import static accord.local.Status.PreAccepted;
+import static accord.local.Status.PreCommitted;
 import static accord.primitives.Routables.Slice.Minimal;
 
 public abstract class InMemoryCommandStore extends CommandStore
@@ -56,6 +95,8 @@ public abstract class InMemoryCommandStore extends CommandStore
     private final TreeMap<TxnId, RangeCommand> rangeCommands = new TreeMap<>();
 
     private InMemorySafeStore current;
+
+    private ReducingRangeMap<Timestamp> rejectBefore;
 
     public InMemoryCommandStore(int id, NodeTimeService time, Agent agent, DataStore store, ProgressLog.Factory progressLogFactory, RangesForEpochHolder rangesForEpochHolder)
     {
@@ -346,6 +387,16 @@ public abstract class InMemoryCommandStore extends CommandStore
         }
     }
 
+    public void setRejectBefore(ReducingRangeMap<Timestamp> newRejectBefore)
+    {
+        this.rejectBefore = newRejectBefore;
+    }
+
+    public ReducingRangeMap<Timestamp> getRejectBefore()
+    {
+        return rejectBefore;
+    }
+
     private <T> T executeInContext(InMemoryCommandStore commandStore, PreLoadContext preLoadContext, Function<? super SafeCommandStore, T> function, boolean isDirectCall)
     {
 
@@ -607,13 +658,6 @@ public abstract class InMemoryCommandStore extends CommandStore
         }
 
         @Override
-        public long latestEpoch()
-        {
-            return commandStore.time.epoch();
-
-        }
-
-        @Override
         public Timestamp maxConflict(Seekables<?, ?> keysOrRanges, Ranges slice)
         {
             Timestamp timestamp = commandStore.mapReduceForKey(this, keysOrRanges, slice, (forKey, prev) -> Timestamp.max(forKey.max(), prev), Timestamp.NONE, null);
@@ -696,7 +740,7 @@ public abstract class InMemoryCommandStore extends CommandStore
                 if (maxStatus != null && command.status().compareTo(maxStatus) > 0)
                     return;
 
-                if (testKind == Ws && command.txnId().rw().isRead())
+                if (!testKind.test(command.txnId().rw()))
                     return;
 
                 if (testDep != ANY_DEPS)

--- a/accord-core/src/main/java/accord/impl/InMemorySafeCommand.java
+++ b/accord-core/src/main/java/accord/impl/InMemorySafeCommand.java
@@ -18,6 +18,8 @@
 
 package accord.impl;
 
+import java.util.Collection;
+
 import accord.impl.InMemoryCommandStore.GlobalCommand;
 import accord.local.Command;
 import accord.local.SafeCommand;
@@ -46,6 +48,24 @@ public class InMemorySafeCommand extends SafeCommand implements SafeState<Comman
     {
         checkNotInvalidated();
         global.value(update);
+    }
+
+    @Override
+    public void addListener(Command.TransientListener listener)
+    {
+        global.addListener(listener);
+    }
+
+    @Override
+    public void removeListener(Command.TransientListener listener)
+    {
+        global.removeListener(listener);
+    }
+
+    @Override
+    public Collection<Command.TransientListener> transientListeners()
+    {
+        return global.transientListeners();
     }
 
     @Override

--- a/accord-core/src/main/java/accord/impl/SizeOfIntersectionSorter.java
+++ b/accord-core/src/main/java/accord/impl/SizeOfIntersectionSorter.java
@@ -24,6 +24,7 @@ import accord.topology.ShardSelection;
 import accord.topology.Topologies;
 import accord.topology.Topology;
 
+// TODO (required): a variant that sorts by distance
 public class SizeOfIntersectionSorter implements TopologySorter
 {
     public static final TopologySorter.Supplier SUPPLIER = new Supplier() {

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -188,9 +188,9 @@ public abstract class CommandStores<S extends CommandStore>
             return i;
         }
 
-        public boolean intersects(long epoch, AbstractKeys<?, ?> keys)
+        public boolean intersects(long epoch, Routables<?, ?> routables)
         {
-            return at(epoch).intersects(keys);
+            return at(epoch).intersects(routables);
         }
 
         public Ranges currentRanges()

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -92,7 +92,7 @@ public abstract class CommandStores<S extends CommandStore>
 
         /**
          * This is updated asynchronously, so should only be fetched between executing tasks;
-         * otherwise the contents may differ between invocations for the same task
+         * otherwise the contents may differ between invocations for the same task.
          * @return the current RangesForEpoch
          */
         public RangesForEpoch get() { return current; }

--- a/accord-core/src/main/java/accord/local/Commands.java
+++ b/accord-core/src/main/java/accord/local/Commands.java
@@ -317,7 +317,7 @@ public class Commands
                     case PreCommitted:
                         // we don't know when these dependencies will execute, and cannot execute until we do
 
-                        command = safeCommand.addListener(new Command.Listener(txnId));
+                        command = safeCommand.addListener(new Command.ProxyListener(txnId));
                         update.addWaitingOnCommit(command.txnId());
                         break;
                     case Committed:
@@ -328,7 +328,7 @@ public class Commands
                     case ReadyToExecute:
                     case PreApplied:
                     case Applied:
-                        command = safeCommand.addListener(new Command.Listener(txnId));
+                        command = safeCommand.addListener(new Command.ProxyListener(txnId));
                         insertPredecessor(txnId, executeAt, update, command);
                     case Invalidated:
                         break;

--- a/accord-core/src/main/java/accord/local/Commands.java
+++ b/accord-core/src/main/java/accord/local/Commands.java
@@ -324,7 +324,7 @@ public class Commands
             return WaitingOn.EMPTY;
 
         WaitingOn.Update update = new WaitingOn.Update();
-        partialDeps.forEach(ranges, depId -> {
+        partialDeps.forEachUniqueTxnId(ranges, depId -> {
             SafeCommand safeCommand = safeStore.ifLoaded(depId);
             if (safeCommand == null)
             {

--- a/accord-core/src/main/java/accord/local/CommonAttributes.java
+++ b/accord-core/src/main/java/accord/local/CommonAttributes.java
@@ -35,7 +35,7 @@ public interface CommonAttributes
     Route<?> route();
     PartialTxn partialTxn();
     PartialDeps partialDeps();
-    Listeners.Immutable listeners();
+    Listeners.Immutable durableListeners();
 
     default Mutable mutable()
     {
@@ -67,7 +67,7 @@ public interface CommonAttributes
             this.route = attributes.route();
             this.partialTxn = attributes.partialTxn();
             this.partialDeps = attributes.partialDeps();
-            this.listeners = attributes.listeners();
+            this.listeners = attributes.durableListeners();
         }
 
         @Override
@@ -162,7 +162,7 @@ public interface CommonAttributes
         }
 
         @Override
-        public Listeners.Immutable listeners()
+        public Listeners.Immutable durableListeners()
         {
             if (listeners == null || listeners.isEmpty())
                 return Listeners.Immutable.EMPTY;
@@ -171,7 +171,7 @@ public interface CommonAttributes
             return new Listeners.Immutable(listeners);
         }
 
-        public Mutable addListener(CommandListener listener)
+        public Mutable addListener(Command.DurableAndIdempotentListener listener)
         {
             if (listeners == null)
                 listeners = new Listeners();
@@ -181,7 +181,7 @@ public interface CommonAttributes
             return this;
         }
 
-        public Mutable removeListener(CommandListener listener)
+        public Mutable removeListener(Command.Listener listener)
         {
             if (listener == null || listeners.isEmpty())
                 return this;

--- a/accord-core/src/main/java/accord/local/Listeners.java
+++ b/accord-core/src/main/java/accord/local/Listeners.java
@@ -23,18 +23,18 @@ import accord.utils.DeterministicIdentitySet;
 import java.util.Collection;
 import java.util.function.Predicate;
 
-public class Listeners extends DeterministicIdentitySet<CommandListener>
+public class Listeners<L extends Command.Listener> extends DeterministicIdentitySet<L>
 {
     public Listeners()
     {
     }
 
-    public Listeners(Listeners copy)
+    public Listeners(Listeners<L> copy)
     {
         super(copy);
     }
 
-    public static class Immutable extends Listeners
+    public static class Immutable extends Listeners<Command.DurableAndIdempotentListener>
     {
         public static final Immutable EMPTY = new Immutable();
 
@@ -43,18 +43,18 @@ public class Listeners extends DeterministicIdentitySet<CommandListener>
             super();
         }
 
-        public Immutable(Listeners listeners)
+        public Immutable(Listeners<Command.DurableAndIdempotentListener> listeners)
         {
             super(listeners);
         }
 
-        Listeners mutable()
+        Listeners<Command.DurableAndIdempotentListener> mutable()
         {
-            return new Listeners(this);
+            return new Listeners<>(this);
         }
 
         @Override
-        public boolean add(CommandListener item)
+        public boolean add(Command.DurableAndIdempotentListener item)
         {
             throw new UnsupportedOperationException("Cannot modify immutable set");
         }
@@ -72,7 +72,7 @@ public class Listeners extends DeterministicIdentitySet<CommandListener>
         }
 
         @Override
-        public boolean addAll(Collection<? extends CommandListener> c)
+        public boolean addAll(Collection<? extends Command.DurableAndIdempotentListener> c)
         {
             throw new UnsupportedOperationException("Cannot modify immutable set");
         }
@@ -84,7 +84,7 @@ public class Listeners extends DeterministicIdentitySet<CommandListener>
         }
 
         @Override
-        public boolean removeIf(Predicate<? super CommandListener> filter)
+        public boolean removeIf(Predicate<? super Command.DurableAndIdempotentListener> filter)
         {
             throw new UnsupportedOperationException("Cannot modify immutable set");
         }

--- a/accord-core/src/main/java/accord/local/SafeCommand.java
+++ b/accord-core/src/main/java/accord/local/SafeCommand.java
@@ -18,6 +18,8 @@
 
 package accord.local;
 
+import java.util.Collection;
+
 import accord.api.Result;
 import accord.primitives.Ballot;
 import accord.primitives.Timestamp;
@@ -37,6 +39,9 @@ public abstract class SafeCommand
     public abstract Command current();
     public abstract void invalidate();
     public abstract boolean invalidated();
+    public abstract void addListener(Command.TransientListener listener);
+    public abstract void removeListener(Command.TransientListener listener);
+    public abstract Collection<Command.TransientListener> transientListeners();
 
     public boolean isEmpty()
     {
@@ -56,12 +61,12 @@ public abstract class SafeCommand
         return update;
     }
 
-    public Command addListener(CommandListener listener)
+    public Command addListener(Command.DurableAndIdempotentListener listener)
     {
         return update(Command.addListener(current(), listener));
     }
 
-    public Command removeListener(CommandListener listener)
+    public Command removeListener(Command.DurableAndIdempotentListener listener)
     {
         return update(Command.removeListener(current(), listener));
     }

--- a/accord-core/src/main/java/accord/messages/Defer.java
+++ b/accord-core/src/main/java/accord/messages/Defer.java
@@ -30,7 +30,7 @@ import static accord.messages.Defer.Ready.Expired;
 import static accord.messages.Defer.Ready.No;
 import static accord.messages.Defer.Ready.Yes;
 
-class Defer implements CommandListener
+class Defer implements Command.TransientListener
 {
     public enum Ready { No, Yes, Expired }
 
@@ -99,12 +99,6 @@ class Defer implements CommandListener
     {
         Invariants.checkState(caller.equals(request.txnId));
         return request;
-    }
-
-    @Override
-    public boolean isTransient()
-    {
-        return true;
     }
 }
 

--- a/accord-core/src/main/java/accord/messages/ReadData.java
+++ b/accord-core/src/main/java/accord/messages/ReadData.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import accord.local.Command.TransientListener;
 import accord.primitives.*;
 
 import accord.local.*;
@@ -43,7 +44,7 @@ import static accord.messages.TxnRequest.*;
 import static accord.utils.MapReduceConsume.forEach;
 
 // TODO (required, efficiency): dedup - can currently have infinite pending reads that will be executed independently
-public class ReadData extends AbstractEpochRequest<ReadData.ReadNack> implements CommandListener
+public class ReadData extends AbstractEpochRequest<ReadData.ReadNack> implements TransientListener
 {
     private static final Logger logger = LoggerFactory.getLogger(ReadData.class);
 
@@ -54,7 +55,7 @@ public class ReadData extends AbstractEpochRequest<ReadData.ReadNack> implements
             return new ReadData(txnId, scope, executeAtEpoch, waitForEpoch);
         }
     }
-    private class ObsoleteTracker implements CommandListener
+    private class ObsoleteTracker implements TransientListener
     {
         @Override
         public void onChange(SafeCommandStore safeStore, SafeCommand safeCommand)
@@ -73,12 +74,6 @@ public class ReadData extends AbstractEpochRequest<ReadData.ReadNack> implements
         public PreLoadContext listenerPreLoadContext(TxnId caller)
         {
             return ReadData.this.listenerPreLoadContext(caller);
-        }
-
-        @Override
-        public boolean isTransient()
-        {
-            return true;
         }
     }
 
@@ -129,12 +124,6 @@ public class ReadData extends AbstractEpochRequest<ReadData.ReadNack> implements
         ids.add(txnId);
         ids.add(caller);
         return PreLoadContext.contextFor(ids, keys());
-    }
-
-    @Override
-    public boolean isTransient()
-    {
-        return true;
     }
 
     @Override

--- a/accord-core/src/main/java/accord/messages/WaitOnCommit.java
+++ b/accord-core/src/main/java/accord/messages/WaitOnCommit.java
@@ -32,7 +32,7 @@ import static accord.local.Status.Committed;
 import static accord.utils.Utils.listOf;
 import accord.topology.Topology;
 
-public class WaitOnCommit implements Request, MapReduceConsume<SafeCommandStore, Void>, PreLoadContext, CommandListener
+public class WaitOnCommit implements Request, MapReduceConsume<SafeCommandStore, Void>, PreLoadContext, Command.TransientListener
 {
     private static final Logger logger = LoggerFactory.getLogger(WaitOnCommit.class);
 
@@ -144,12 +144,6 @@ public class WaitOnCommit implements Request, MapReduceConsume<SafeCommandStore,
     {
         if (waitingOnUpdater.decrementAndGet(this) == -1)
             node.reply(replyTo, replyContext, WaitOnCommitOk.INSTANCE);
-    }
-
-    @Override
-    public boolean isTransient()
-    {
-        return true;
     }
 
     @Override

--- a/accord-core/src/main/java/accord/primitives/KeyDeps.java
+++ b/accord-core/src/main/java/accord/primitives/KeyDeps.java
@@ -93,7 +93,7 @@ public class KeyDeps implements Iterable<Map.Entry<Key, TxnId>>
         @Override
         protected KeyDeps build(Key[] keys, TxnId[] txnIds, int[] keysToTxnIds)
         {
-            return new KeyDeps(Keys.ofSorted(keys), txnIds, keysToTxnIds);
+            return new KeyDeps(Keys.ofSortedUnique(keys), txnIds, keysToTxnIds);
         }
     }
 
@@ -145,7 +145,7 @@ public class KeyDeps implements Iterable<Map.Entry<Key, TxnId>>
 
     KeyDeps(Key[] keys, TxnId[] txnIds, int[] keysToTxnIds)
     {
-        this(Keys.ofSorted(keys), txnIds, keysToTxnIds);
+        this(Keys.ofSortedUnique(keys), txnIds, keysToTxnIds);
     }
 
     KeyDeps(Keys keys, TxnId[] txnIds, int[] keysToTxnIds)

--- a/accord-core/src/main/java/accord/primitives/Keys.java
+++ b/accord-core/src/main/java/accord/primitives/Keys.java
@@ -109,7 +109,7 @@ public class Keys extends AbstractKeys<Key, Keys> implements Seekables<Key, Keys
     public static Keys ofUnique(Key ... keys)
     {
         // check unique
-        return ofSorted(sort(keys));
+        return ofSortedUnique(sort(keys));
     }
 
     public static Keys of(Collection<? extends Key> keys)
@@ -167,7 +167,7 @@ public class Keys extends AbstractKeys<Key, Keys> implements Seekables<Key, Keys
 
             Key[] result = cache.complete(array, count);
             cache.discard(array, count);
-            return ofSorted(result);
+            return ofSortedUnique(result);
         }
         catch (Throwable t)
         {
@@ -176,17 +176,12 @@ public class Keys extends AbstractKeys<Key, Keys> implements Seekables<Key, Keys
         }
     }
 
-    public static Keys ofUnique(Collection<? extends Key> keys)
-    {
-        return ofUnique(keys.toArray(new Key[0]));
-    }
-
     public static Keys of(Set<? extends Key> keys)
     {
         return ofUnique(keys.toArray(new Key[0]));
     }
 
-    public static Keys ofSorted(Key ... keys)
+    public static Keys ofSortedUnique(Key ... keys)
     {
         if (!isSortedUnique(keys))
             throw new IllegalArgumentException(Arrays.toString(keys) + " is not sorted");
@@ -195,30 +190,12 @@ public class Keys extends AbstractKeys<Key, Keys> implements Seekables<Key, Keys
 
     private static Keys dedupSorted(Key ... keys)
     {
-        int removed = 0;
-        for (int i = 1 ; i < keys.length ; ++i)
-        {
-            int c = keys[i - 1].compareTo(keys[i]);
-            if (c >= 0)
-            {
-                if (c > 0)
-                    throw new IllegalArgumentException(Arrays.toString(keys) + " is not sorted");
-
-                removed++;
-            }
-            else if (removed > 0)
-            {
-                keys[i - removed] = keys[i];
-            }
-        }
-        if (removed > 0)
-            keys = Arrays.copyOf(keys, keys.length - removed);
-        return new Keys(keys);
+        return new Keys(SortedArrays.toUnique(keys));
     }
 
-    public static Keys ofSorted(Collection<? extends Key> keys)
+    public static Keys ofSortedUnique(Collection<? extends Key> keys)
     {
-        return ofSorted(keys.toArray(new Key[0]));
+        return ofSortedUnique(keys.toArray(new Key[0]));
     }
 
     static Keys ofSortedUnchecked(Key ... keys)

--- a/accord-core/src/main/java/accord/primitives/Range.java
+++ b/accord-core/src/main/java/accord/primitives/Range.java
@@ -26,6 +26,8 @@ import accord.utils.SortedArrays.Search;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import static accord.utils.SortedArrays.Search.CEIL;
 import static accord.utils.SortedArrays.Search.FAST;
 
@@ -320,7 +322,7 @@ public abstract class Range implements Comparable<RoutableKey>, Unseekable, Seek
     }
 
     @Override
-    public RoutingKey someIntersectingRoutingKey(Ranges ranges)
+    public RoutingKey someIntersectingRoutingKey(@Nullable Ranges ranges)
     {
         if (ranges == null)
             return startInclusive() ? start.toUnseekable() : end.toUnseekable();

--- a/accord-core/src/main/java/accord/primitives/Routables.java
+++ b/accord-core/src/main/java/accord/primitives/Routables.java
@@ -279,12 +279,15 @@ public interface Routables<K extends Routable, U extends Routables<K, ?>> extend
                 m = (int)(im >>> 32);
 
                 Range mv = ms.get(m);
-                int nexti = Helper.findLimit(is, i, ms, m);
-                while (i < nexti)
+                int nexti = Helper.findLimit(is, i, ms, m) - 1;
+                while (true)
                 {
                     accumulator = fold.apply(is.get(i).slice(mv), accumulator, i);
-                    ++i;
+                    if (i < nexti) ++i;
+                    else break;
                 }
+                if (!(is.get(i) instanceof Range) || ((Range)is.get(i)).end().compareTo(mv.end()) <= 0) ++i;
+                else ++m;
             }
 
             return accumulator;

--- a/accord-core/src/main/java/accord/primitives/RoutingKeys.java
+++ b/accord-core/src/main/java/accord/primitives/RoutingKeys.java
@@ -19,9 +19,13 @@
 package accord.primitives;
 
 import accord.api.RoutingKey;
+import accord.utils.Invariants;
 import accord.utils.SortedArrays;
 
 import static accord.utils.ArrayBuffers.cachedRoutingKeys;
+import static accord.utils.Invariants.checkArgument;
+import static accord.utils.SortedArrays.isSortedUnique;
+import static accord.utils.SortedArrays.toUnique;
 
 public class RoutingKeys extends AbstractUnseekableKeys<AbstractUnseekableKeys<?>> implements Unseekables<RoutingKey, AbstractUnseekableKeys<?>>
 {
@@ -42,7 +46,13 @@ public class RoutingKeys extends AbstractUnseekableKeys<AbstractUnseekableKeys<?
 
     public static RoutingKeys of(RoutingKey ... keys)
     {
-        return new RoutingKeys(sort(keys));
+        return new RoutingKeys(toUnique(sort(keys)));
+    }
+
+    public static RoutingKeys ofSortedUnique(RoutingKey ... keys)
+    {
+        checkArgument(isSortedUnique(keys));
+        return new RoutingKeys(keys);
     }
 
     @Override

--- a/accord-core/src/main/java/accord/primitives/SyncPoint.java
+++ b/accord-core/src/main/java/accord/primitives/SyncPoint.java
@@ -18,14 +18,24 @@
 
 package accord.primitives;
 
+/**
+ * Defines an inequality point in the processing of the distributed transaction log, which is to say that
+ * this is able to say that the point has passed, or that it has not yet passed, but it is unable to
+ * guarantee that it is processed at the precise moment given by {@code at}. This is because we do not
+ * expect the whole cluster to process these, and we do not want transaction processing to be held up,
+ * so while these are processed much like a transaction, they are invisible to real transactions which
+ * may proceed before this is witnessed by the node processing it.
+ */
 public class SyncPoint
 {
-    public final Timestamp at;
+    public final TxnId syncId;
     public final Deps waitFor;
+    public final Route<?> route;
 
-    public SyncPoint(Timestamp at, Deps waitFor)
+    public SyncPoint(TxnId syncId, Deps waitFor, Route<?> route)
     {
-        this.at = at;
+        this.syncId = syncId;
         this.waitFor = waitFor;
+        this.route = route;
     }
 }

--- a/accord-core/src/main/java/accord/primitives/SyncPoint.java
+++ b/accord-core/src/main/java/accord/primitives/SyncPoint.java
@@ -16,20 +16,16 @@
  * limitations under the License.
  */
 
-package accord.coordinate;
+package accord.primitives;
 
-import javax.annotation.Nullable;
-
-import accord.api.RoutingKey;
-import accord.primitives.TxnId;
-
-/**
- * Thrown when a transaction exceeds its specified timeout for obtaining a result for a client
- */
-public class Timeout extends CoordinationFailed
+public class SyncPoint
 {
-    public Timeout(TxnId txnId, @Nullable RoutingKey homeKey)
+    public final Timestamp at;
+    public final Deps waitFor;
+
+    public SyncPoint(Timestamp at, Deps waitFor)
     {
-        super(txnId, homeKey);
+        this.at = at;
+        this.waitFor = waitFor;
     }
 }

--- a/accord-core/src/main/java/accord/primitives/Timestamp.java
+++ b/accord-core/src/main/java/accord/primitives/Timestamp.java
@@ -21,10 +21,21 @@ package accord.primitives;
 import accord.local.Node.Id;
 import accord.utils.Invariants;
 
+import static accord.utils.Invariants.checkArgument;
+
 import javax.annotation.Nonnull;
 
 public class Timestamp implements Comparable<Timestamp>
 {
+    private static final int REJECTED_FLAG = 0x8000;
+
+    /**
+     * The set of flags we want to retain as we merge timestamps (e.g. when taking mergeMax).
+     * Today this is only the REJECTED_FLAG, but we may include additional flags in future (such as Committed, Applied..)
+     * which we may also want to retain when merging in other contexts (such as in Deps).
+     */
+    private static final int MERGE_FLAGS = 0x8000;
+
     public static Timestamp fromBits(long msb, long lsb, Id node)
     {
         return new Timestamp(msb, lsb, node);
@@ -86,7 +97,7 @@ public class Timestamp implements Comparable<Timestamp>
 
     Timestamp(Timestamp copy, int flags)
     {
-        Invariants.checkArgument(flags <= MAX_FLAGS);
+        checkArgument(flags <= MAX_FLAGS);
         this.msb = copy.msb;
         this.lsb = notFlags(copy.lsb) | flags;
         this.node = copy.node;
@@ -110,9 +121,36 @@ public class Timestamp implements Comparable<Timestamp>
         return flags(lsb);
     }
 
+    public boolean isRejected()
+    {
+        return (lsb & REJECTED_FLAG) != 0;
+    }
+
+    public Timestamp asRejected()
+    {
+        return withExtraFlags(REJECTED_FLAG);
+    }
+
     public Timestamp withEpochAtLeast(long minEpoch)
     {
         return minEpoch <= epoch() ? this : new Timestamp(minEpoch, hlc(), flags(), node);
+    }
+
+    public Timestamp withExtraFlags(int flags)
+    {
+        checkArgument(flags <= MAX_FLAGS);
+        long newLsb = lsb | flags;
+        if (lsb == newLsb)
+            return this;
+        return new Timestamp(msb, newLsb, node);
+    }
+
+    public Timestamp mergeFlags(Timestamp mergeFlags)
+    {
+        long newLsb = lsb | (mergeFlags.lsb & MERGE_FLAGS);
+        if (lsb == newLsb)
+            return this;
+        return new Timestamp(msb, newLsb, node);
     }
 
     public Timestamp logicalNext(Id node)
@@ -171,6 +209,26 @@ public class Timestamp implements Comparable<Timestamp>
     public static <T extends Timestamp> T max(T a, T b)
     {
         return a.compareTo(b) >= 0 ? a : b;
+    }
+
+    /**
+     * Take the maximum of the two, but merge any mergeable flags
+     */
+    public static Timestamp mergeMax(Timestamp a, Timestamp b)
+    {
+        return a.compareTo(b) >= 0 ? a.mergeFlags(b) : b.mergeFlags(a);
+    }
+
+    public static <T extends Timestamp> T rejectedOrMax(T a, T b)
+    {
+        return a.compareTo(b) >= 0 ? a : b;
+    }
+
+    public static Timestamp rejectStale(Timestamp maybeReject, Timestamp ifOnOrBefore)
+    {
+        if (maybeReject.compareTo(ifOnOrBefore) > 0)
+            return maybeReject;
+        return maybeReject.asRejected();
     }
 
     public static <T extends Timestamp> T nonNullOrMax(T a, T b)
@@ -235,9 +293,9 @@ public class Timestamp implements Comparable<Timestamp>
 
     static <T extends Timestamp> T merge(Timestamp a, Timestamp b, Constructor<T> constructor)
     {
-        Invariants.checkArgument(a.msb == b.msb);
-        Invariants.checkArgument(lowHlc(a.lsb) == lowHlc(b.lsb));
-        Invariants.checkArgument(a.node.equals(b.node));
+        checkArgument(a.msb == b.msb);
+        checkArgument(lowHlc(a.lsb) == lowHlc(b.lsb));
+        checkArgument(a.node.equals(b.node));
         return constructor.construct(a.msb, a.lsb | b.lsb, a.node);
     }
 

--- a/accord-core/src/main/java/accord/primitives/Txn.java
+++ b/accord-core/src/main/java/accord/primitives/Txn.java
@@ -35,7 +35,41 @@ public interface Txn
 {
     enum Kind
     {
-        Read, Write;
+        Read,
+        Write,
+
+        /**
+         * A pseudo-transaction whose deps represent the complete set of transactions that may execute before it,
+         * without interfering with their execution.
+         *
+         * A SyncPoint is unique in that it does not agree an executeAt, but instead agrees a precise collection of
+         * dependencies that represent a superset of the transactions that have reached consensus to execute before
+         * their txnId. This set of dependencies will be made durable in the Accept round, and re-proposed by recovery
+         * if the transaction is not fully committed (but was durably accepted).
+         *
+         * This is only safe because the transaction does not really "execute" and does not order itself with respect to
+         * others, it only orders others with respect to itself, so its executeAt can be declared to be its txnId.
+         * In effect it represents an inequality relation, rather than a precise point in the transaction log - its
+         * dependencies permit saying that we are "after" its point in the log, not that we are *at* that point.
+         * This permits us to use the dependencies from the PreAccept round.
+         *
+         * Note, it would be possible to do a three-round operation that achieved this with a precise "at" position
+         * in the log, with a second round between PreAccept and Accept to collect deps < executeAt, if executeAt &gt; txnId,
+         * but we do not need this property here.
+         *
+         * This all ensures the effect of this transaction on invalidation of earlier transactions is durable.
+         * This is most useful for ExclusiveSyncPoint.
+         */
+        SyncPoint,
+
+        /**
+         * A {@link #SyncPoint} that invalidates transactions with lower TxnId that it does not witness, i.e. it ensures
+         * that earlier TxnId that had not reached consensus before it did must be retried with a higher TxnId,
+         * so that replicas that are bootstrapping may ignore lower TxnId and still be sure they have a complete
+         * representation of the reified transaction log.
+         */
+        ExclusiveSyncPoint;
+
         // in future: BlindWrite, Interactive?
 
         private static final Kind[] VALUES = Kind.values();
@@ -48,6 +82,18 @@ public interface Txn
         public boolean isRead()
         {
             return this == Read;
+        }
+
+        /**
+         * Does the transaction propose dependencies as part of its Accept round, i.e. make durable a set of dependencies
+         *
+         * Note that this it is only possible to do this for transactions whose execution time is not dependent on
+         * others, i.e. where we may safely propose executeAt = txnId regardless of when it is witnessed by
+         * replicas
+         */
+        public boolean proposesDeps()
+        {
+            return this == ExclusiveSyncPoint || this == SyncPoint;
         }
 
         public static Kind ofOrdinal(int ordinal)
@@ -82,7 +128,7 @@ public interface Txn
             this.query = query;
         }
 
-        protected InMemory(@Nonnull Kind kind, @Nonnull Seekables<?, ?> keys, @Nonnull Read read, @Nullable Query query, @Nullable Update update)
+        public InMemory(@Nonnull Kind kind, @Nonnull Seekables<?, ?> keys, @Nonnull Read read, @Nullable Query query, @Nullable Update update)
         {
             this.kind = kind;
             this.keys = keys;

--- a/accord-core/src/main/java/accord/primitives/TxnId.java
+++ b/accord-core/src/main/java/accord/primitives/TxnId.java
@@ -120,7 +120,7 @@ public class TxnId extends Timestamp
 
     private static int rwOrdinal(int flags)
     {
-        return (flags >> 1) & 1;
+        return (flags >> 1) & 3;
     }
 
     private static int domainOrdinal(int flags)

--- a/accord-core/src/main/java/accord/utils/ArrayBuffers.java
+++ b/accord-core/src/main/java/accord/utils/ArrayBuffers.java
@@ -300,7 +300,7 @@ public class ArrayBuffers
         @Override
         public T[] completeWithExisting(T[] buffer, int usedSize)
         {
-            return checkArgument(buffer, buffer.length == usedSize);
+            return complete(buffer, usedSize);
         }
 
         @Override
@@ -449,7 +449,11 @@ public class ArrayBuffers
         @Override
         public T[] completeWithExisting(T[] buffer, int usedSize)
         {
-            return buffer;
+            // note, due to how we have implemented the buffering decisions, this is identical to #complete
+            if (usedSize == buffer.length)
+                return buffer;
+
+            return Arrays.copyOf(buffer, usedSize);
         }
 
         @Override

--- a/accord-core/src/main/java/accord/utils/Functions.java
+++ b/accord-core/src/main/java/accord/utils/Functions.java
@@ -57,4 +57,12 @@ public class Functions
         return result;
     }
 
+    public static <I, O> O foldl(List<I> list, BiFunction<I, O, O> foldl, O zero)
+    {
+        O result = zero;
+        for (int i = 0, mi = list.size(); i < mi; ++i)
+            result = foldl.apply(list.get(i), result);
+        return result;
+    }
+
 }

--- a/accord-core/src/main/java/accord/utils/IndexedBiConsumer.java
+++ b/accord-core/src/main/java/accord/utils/IndexedBiConsumer.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.utils;
+
+public interface IndexedBiConsumer<P1, P2>
+{
+    /**
+     * Apply some function to two object parameters and an associated index (usually within a collection).
+     */
+    void accept(P1 p1, P2 p2, int index);
+}

--- a/accord-core/src/main/java/accord/utils/IndexedBiFold.java
+++ b/accord-core/src/main/java/accord/utils/IndexedBiFold.java
@@ -16,20 +16,8 @@
  * limitations under the License.
  */
 
-package accord.coordinate;
+package accord.utils;
 
-import javax.annotation.Nullable;
-
-import accord.api.RoutingKey;
-import accord.primitives.TxnId;
-
-/**
- * Thrown when a transaction exceeds its specified timeout for obtaining a result for a client
- */
-public class Timeout extends CoordinationFailed
+public interface IndexedBiFold<P1, P2, Accumulate> extends IndexedTriFunction<P1, P2, Accumulate, Accumulate>
 {
-    public Timeout(TxnId txnId, @Nullable RoutingKey homeKey)
-    {
-        super(txnId, homeKey);
-    }
 }

--- a/accord-core/src/main/java/accord/utils/IndexedQuadFunction.java
+++ b/accord-core/src/main/java/accord/utils/IndexedQuadFunction.java
@@ -16,20 +16,9 @@
  * limitations under the License.
  */
 
-package accord.coordinate;
+package accord.utils;
 
-import javax.annotation.Nullable;
-
-import accord.api.RoutingKey;
-import accord.primitives.TxnId;
-
-/**
- * Thrown when a transaction exceeds its specified timeout for obtaining a result for a client
- */
-public class Timeout extends CoordinationFailed
+public interface IndexedQuadFunction<P1, P2, P3, P4, V>
 {
-    public Timeout(TxnId txnId, @Nullable RoutingKey homeKey)
-    {
-        super(txnId, homeKey);
-    }
+    V apply(P1 p1, P2 p2, P3 p3, P4 p4, int index);
 }

--- a/accord-core/src/main/java/accord/utils/IndexedTriFold.java
+++ b/accord-core/src/main/java/accord/utils/IndexedTriFold.java
@@ -16,20 +16,8 @@
  * limitations under the License.
  */
 
-package accord.coordinate;
+package accord.utils;
 
-import javax.annotation.Nullable;
-
-import accord.api.RoutingKey;
-import accord.primitives.TxnId;
-
-/**
- * Thrown when a transaction exceeds its specified timeout for obtaining a result for a client
- */
-public class Timeout extends CoordinationFailed
+public interface IndexedTriFold<P1, P2, P3, Accumulate> extends IndexedQuadFunction<P1, P2, P3, Accumulate, Accumulate>
 {
-    public Timeout(TxnId txnId, @Nullable RoutingKey homeKey)
-    {
-        super(txnId, homeKey);
-    }
 }

--- a/accord-core/src/main/java/accord/utils/ReducingIntervalMap.java
+++ b/accord-core/src/main/java/accord/utils/ReducingIntervalMap.java
@@ -67,7 +67,7 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
         this.values = values;
     }
 
-    public V reduceValues(BiFunction<V, V, V> reduce)
+    public V foldl(BiFunction<V, V, V> reduce)
     {
         V result = values[0];
         for (int i = 1; i < values.length; ++i)
@@ -309,7 +309,7 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
             if (sameAsTailKey || sameAsTailValue)
             {
                 if (sameAsTailValue) ends.set(tailIdx, end);
-                else values.set(tailIdx, reduce.apply(value, values.get(tailIdx)));
+                else values.set(tailIdx, reduce.apply(values.get(tailIdx), value));
             }
             else
             {

--- a/accord-core/src/main/java/accord/utils/ReducingIntervalMap.java
+++ b/accord-core/src/main/java/accord/utils/ReducingIntervalMap.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.utils;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Mostly copied/adapted from Cassandra's PaxosRepairHistory class
+ *
+ * Represents a map of ranges where precisely one value is bound to each point in the continuum of ranges,
+ * and a simple function is sufficient to merge values inserted to overlapping ranges.
+ *
+ * A simple sorted array of bounds is sufficient to represent the state and perform efficient lookups.
+ *
+ * TODO (desired): use a mutable b-tree instead
+ */
+public class ReducingIntervalMap<K extends Comparable<? super K>, V>
+{
+    private static final Comparable[] NO_OBJECTS = new Comparable[0];
+
+    // for simplicity at construction, we permit this to be overridden by the first insertion
+    final boolean inclusiveEnds;
+    final K[] ends;
+    final V[] values;
+
+    public ReducingIntervalMap(V value)
+    {
+        this(false, value);
+    }
+
+    public ReducingIntervalMap(boolean inclusiveEnds, V value)
+    {
+        this.inclusiveEnds = inclusiveEnds;
+        this.ends = (K[]) NO_OBJECTS;
+        this.values = (V[]) new Object[] { value };
+    }
+
+    @VisibleForTesting
+    ReducingIntervalMap(boolean inclusiveEnds, K[] ends, V[] values)
+    {
+        this.inclusiveEnds = inclusiveEnds;
+        this.ends = ends;
+        this.values = values;
+    }
+
+    public V reduceValues(BiFunction<V, V, V> reduce)
+    {
+        V result = values[0];
+        for (int i = 1; i < values.length; ++i)
+            result = reduce.apply(result, values[i]);
+        return result;
+    }
+
+    public String toString()
+    {
+        return toString(v -> true);
+    }
+
+    public String toString(Predicate<V> include)
+    {
+        return IntStream.range(0, ends.length)
+                        .filter(i -> include.test(values[i]))
+                        .mapToObj(i -> ends[i] + "=" + values[i])
+                        .collect(Collectors.joining(", ", "{", "}"));
+    }
+
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReducingIntervalMap that = (ReducingIntervalMap) o;
+        return Arrays.equals(ends, that.ends) && Arrays.equals(values, that.values);
+    }
+
+    public int hashCode()
+    {
+        return Arrays.hashCode(values);
+    }
+
+    public V get(K key)
+    {
+        int idx = Arrays.binarySearch(ends, key);
+        if (idx < 0) idx = -1 - idx;
+        else if (!inclusiveEnds) ++idx;
+        return values[idx];
+    }
+
+    public V value(int idx)
+    {
+        if (idx < 0 || idx > size())
+            throw new IndexOutOfBoundsException();
+
+        return values[idx];
+    }
+
+    public int indexOf(K key)
+    {
+        int idx = Arrays.binarySearch(ends, key);
+        if (idx < 0) idx = -1 - idx;
+        else if (!inclusiveEnds) --idx;
+        return idx;
+    }
+
+    private boolean contains(int idx, K key)
+    {
+        if (idx < 0 || idx > size())
+            throw new IndexOutOfBoundsException();
+
+        int cmp = inclusiveEnds ? 0 : 1;
+        return  (   idx == 0      || ends[idx - 1].compareTo(key) <  cmp)
+                && (idx == size() || ends[idx    ].compareTo(key) >= cmp);
+    }
+
+    public int size()
+    {
+        return ends.length;
+    }
+
+    RangeIterator rangeIterator()
+    {
+        return new RangeIterator();
+    }
+
+    public Searcher searcher()
+    {
+        return new Searcher();
+    }
+
+    // append the item to the given list, modifying the underlying list
+    // if the item makes previoud entries redundant
+
+    static <K extends Comparable<? super K>, V, M extends ReducingIntervalMap<K, V>> M merge(M historyLeft, M historyRight, BiFunction<V, V, V> reduce, BuilderFactory<K, V, M> factory)
+    {
+        if (historyLeft == null)
+            return historyRight;
+
+        if (historyRight == null)
+            return historyLeft;
+
+        boolean inclusiveEnds = inclusiveEnds(historyLeft.inclusiveEnds, historyLeft.size() > 0, historyRight.inclusiveEnds, historyRight.size() > 0);
+        Builder<K, V, M> builder = factory.create(inclusiveEnds, historyLeft.size() + historyRight.size());
+
+        ReducingIntervalMap<K, V>.RangeIterator left = historyLeft.rangeIterator();
+        ReducingIntervalMap<K, V>.RangeIterator right = historyRight.rangeIterator();
+        while (left.hasEnd() && right.hasEnd())
+        {
+            int cmp = left.end().compareTo(right.end());
+
+            V value = reduce.apply(left.value(), right.value());
+            if (cmp == 0)
+            {
+                builder.append(left.end(), value, reduce);
+                left.next();
+                right.next();
+            }
+            else
+            {
+                ReducingIntervalMap<K, V>.RangeIterator firstIter = cmp < 0 ? left : right;
+                builder.append(firstIter.end(), value, reduce);
+                firstIter.next();
+            }
+        }
+
+        while (left.hasEnd())
+        {
+            builder.append(left.end(), reduce.apply(left.value(), right.value()), reduce);
+            left.next();
+        }
+
+        while (right.hasEnd())
+        {
+            builder.append(right.end(), reduce.apply(left.value(), right.value()), reduce);
+            right.next();
+        }
+
+        builder.appendLast(reduce.apply(left.value(), right.value()));
+        return builder.build();
+    }
+
+    RangeIterator intersecting(K start, K end)
+    {
+        int from = Arrays.binarySearch(ends, start);
+        if (from < 0) from = -1 - from;
+        else if (inclusiveEnds) ++from;
+
+        int to = Arrays.binarySearch(ends, end);
+        if (to < 0) to = -1 - to;
+        else if (!inclusiveEnds) ++to;
+
+        return new RangeIterator(from, 1 + to);
+    }
+
+    public class Searcher
+    {
+        int idx = -1;
+
+        public V find(K key)
+        {
+            // TODO (low priority, efficiency): assume ascending iteration and use expSearch
+            if (idx < 0 || !contains(idx, key))
+                idx = indexOf(key);
+            return value(idx);
+        }
+    }
+
+    class RangeIterator
+    {
+        final int end;
+        int i;
+
+        RangeIterator()
+        {
+            this.end = values.length;
+        }
+
+        RangeIterator(int from, int to)
+        {
+            this.i = from;
+            this.end = to;
+        }
+
+        boolean hasNext()
+        {
+            return i < end;
+        }
+
+        void next()
+        {
+            ++i;
+        }
+
+        boolean hasStart()
+        {
+            return i > 0;
+        }
+
+        boolean hasEnd()
+        {
+            return i < ends.length;
+        }
+
+        K start()
+        {
+            return ends[i - 1];
+        }
+
+        K end()
+        {
+            return ends[i];
+        }
+
+        V value()
+        {
+            return values[i];
+        }
+    }
+
+    interface BuilderFactory<K extends Comparable<? super K>, V, M extends ReducingIntervalMap<K, V>>
+    {
+        Builder<K, V, M> create(boolean inclusiveEnds, int capacity);
+    }
+
+    static abstract class Builder<K extends Comparable<? super K>, V, M extends ReducingIntervalMap<K, V>>
+    {
+        final boolean inclusiveEnds;
+        final List<K> ends;
+        final List<V> values;
+
+        Builder(boolean inclusiveEnds, int capacity)
+        {
+            this.inclusiveEnds = inclusiveEnds;
+            this.ends = new ArrayList<>(capacity);
+            this.values = new ArrayList<>(capacity + 1);
+        }
+
+        void append(K end, V value, BiFunction<V, V, V> reduce)
+        {
+            int tailIdx = ends.size() - 1;
+
+            assert ends.size() == values.size();
+            assert tailIdx < 0 || end.compareTo(ends.get(tailIdx)) >= 0;
+
+            boolean sameAsTailKey = tailIdx >= 0 && end.equals(ends.get(tailIdx));
+            boolean sameAsTailValue = tailIdx >= 0 && value.equals(values.get(tailIdx));
+            if (sameAsTailKey || sameAsTailValue)
+            {
+                if (sameAsTailValue) ends.set(tailIdx, end);
+                else values.set(tailIdx, reduce.apply(value, values.get(tailIdx)));
+            }
+            else
+            {
+                ends.add(end);
+                values.add(value);
+            }
+        }
+
+        void appendLast(V value)
+        {
+            assert values.size() == ends.size();
+            int tailIdx = ends.size() - 1;
+            if (!values.isEmpty() && value.equals(values.get(tailIdx)))
+                ends.remove(tailIdx);
+            else
+                values.add(value);
+        }
+
+        abstract M buildInternal();
+
+        final M build()
+        {
+            Invariants.checkState(ends.size() + 1 == values.size());
+            return buildInternal();
+        }
+    }
+
+    static boolean inclusiveEnds(boolean leftIsInclusive, boolean leftIsDecisive, boolean rightIsInclusive, boolean rightIsDecisive)
+    {
+        if (leftIsInclusive == rightIsInclusive)
+            return leftIsInclusive;
+        else if (leftIsDecisive && rightIsDecisive)
+            throw new IllegalStateException("Mismatching bound inclusivity/exclusivity");
+        else if (leftIsDecisive)
+            return leftIsInclusive;
+        else
+            return rightIsInclusive;
+    }
+}

--- a/accord-core/src/main/java/accord/utils/ReducingRangeMap.java
+++ b/accord-core/src/main/java/accord/utils/ReducingRangeMap.java
@@ -42,16 +42,22 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         this.endKeys = RoutingKeys.ofSortedUnique(ends);
     }
 
+    public V foldl(Routables<?, ?> routables, BiFunction<V, V, V> fold, V initialValue)
+    {
+        return foldl(routables, fold, initialValue, ignore -> false);
+    }
+
     public <V2> V2 foldl(Routables<?, ?> routables, BiFunction<V, V2, V2> fold, V2 initialValue, Predicate<V2> terminate)
     {
         switch (routables.domain())
         {
             default: throw new AssertionError();
             case Key: return foldl((AbstractKeys<?, ?>) routables, fold, initialValue, terminate);
-            case Range: return Routables.foldl(endKeys, (AbstractRanges<?>) routables, (f, vs, routingKey, v, index) -> f.apply(vs[index], v), fold, values, initialValue, terminate);
+            case Range: return foldl((AbstractRanges<?>) routables, fold, initialValue, terminate);
         }
     }
 
+    // TODO (required): test
     public <V2> V2 foldl(AbstractKeys<?, ?> keys, BiFunction<V, V2, V2> reduce, V2 accumulator, Predicate<V2> terminate)
     {
         int i = 0, j = 0;
@@ -59,15 +65,47 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         {
             i = endKeys.findNext(i, keys.get(j), FAST);
             if (i < 0) i = -1 - i;
-            else if (inclusiveEnds) ++i;
+            else if (!inclusiveEnds) ++i;
 
             accumulator = reduce.apply(values[i], accumulator);
-            if (i == endKeys.size() || terminate.test(accumulator))
+            if (terminate.test(accumulator))
                 return accumulator;
+
+            if (i == endKeys.size())
+                return j + 1 == keys.size() ? accumulator : reduce.apply(values[i], accumulator);
 
             j = keys.findNext(j + 1, endKeys.get(i), FAST);
             if (j < 0) j = -1 - j;
-            else if (inclusiveEnds) ++j;
+        }
+        return accumulator;
+    }
+
+    // TODO (required): test
+    public <V2> V2 foldl(AbstractRanges<?> ranges, BiFunction<V, V2, V2> reduce, V2 accumulator, Predicate<V2> terminate)
+    {
+        int i = 0, j = 0;
+        while (j < ranges.size())
+        {
+            Range range = ranges.get(j);
+            i = endKeys.findNext(i, range.start(), FAST);
+            if (i < 0) i = -1 - i;
+            else if (inclusiveEnds) ++i;
+
+            int nexti = endKeys.findNext(i, range.end(), FAST);
+            if (nexti < 0) nexti = -nexti;
+            else if (inclusiveEnds) ++nexti;
+
+            while (i < nexti)
+            {
+                accumulator = reduce.apply(values[i++], accumulator);
+                if (terminate.test(accumulator))
+                    return accumulator;
+            }
+            if (i > endKeys.size())
+                return accumulator;
+
+            j = ranges.findNext(j + 1, endKeys.get(i - 1), FAST);
+            if (j < 0) j = -1 - j;
         }
         return accumulator;
     }
@@ -106,31 +144,40 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         return builder.build();
     }
 
-    public static <V> ReducingRangeMap<V> merge(ReducingRangeMap<V> historyLeft, ReducingRangeMap<V> historyRight, BiFunction<V, V, V> reduce)
+    public static <V> ReducingRangeMap<V> create(Ranges ranges, V value, V zero)
     {
-        return ReducingIntervalMap.merge(historyLeft, historyRight, reduce, ReducingRangeMap.Builder::new);
+        if (ranges.isEmpty())
+            return new ReducingRangeMap<>(zero);
+
+        ReducingRangeMap.Builder<V> builder = new ReducingRangeMap.Builder<>(ranges.get(0).endInclusive(), ranges.size() * 2);
+        for (Range range : ranges)
+        {
+            builder.append(range.start(), zero, (a, b) -> a); // if we are equal to prev end, take the prev value not zero
+            builder.append(range.end(), value, (a, b) -> { throw new IllegalStateException(); });
+        }
+        builder.appendLast(zero);
+        return builder.build();
     }
 
     public static <V> ReducingRangeMap<V> add(ReducingRangeMap<V> existing, Ranges ranges, V value, BiFunction<V, V, V> reduce)
     {
-        V zero = existing.values[0];
-        boolean inclusiveEnds = inclusiveEnds(existing.inclusiveEnds, existing.size() > 0, ranges.size() > 0 && ranges.get(0).endInclusive(), ranges.size() > 0);
-        ReducingRangeMap.Builder<V> builder = new ReducingRangeMap.Builder<>(inclusiveEnds, ranges.size() * 2);
-        for (Range range : ranges)
-        {
-            // don't add a point for an opening min token, since it
-            // effectively leaves the bottom of the range unbounded
-            builder.append(range.start(), zero, reduce);
-            builder.append(range.end(), value, reduce);
-        }
-        builder.appendLast(zero);
+        return add(existing, ranges, value, reduce, existing.values[0]);
+    }
 
-        return merge(existing, builder.build(), reduce, ReducingRangeMap.Builder::new);
+    public static <V> ReducingRangeMap<V> add(ReducingRangeMap<V> existing, Ranges ranges, V value, BiFunction<V, V, V> reduce, V zero)
+    {
+        ReducingRangeMap<V> add = create(ranges, value, zero);
+        return merge(existing, add, reduce);
     }
 
     public static ReducingRangeMap<Timestamp> add(ReducingRangeMap<Timestamp> existing, Ranges ranges, Timestamp value)
     {
         return add(existing, ranges, value, Timestamp::max);
+    }
+
+    public static <V> ReducingRangeMap<V> merge(ReducingRangeMap<V> historyLeft, ReducingRangeMap<V> historyRight, BiFunction<V, V, V> reduce)
+    {
+        return ReducingIntervalMap.merge(historyLeft, historyRight, reduce, ReducingRangeMap.Builder::new);
     }
 
     static class Builder<V> extends ReducingIntervalMap.Builder<RoutingKey, V, ReducingRangeMap<V>>

--- a/accord-core/src/main/java/accord/utils/ReducingRangeMap.java
+++ b/accord-core/src/main/java/accord/utils/ReducingRangeMap.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package accord.utils;
+
+import accord.api.RoutingKey;
+import accord.primitives.*;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+import static accord.utils.SortedArrays.Search.FAST;
+
+public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
+{
+    final RoutingKeys endKeys;
+
+    public ReducingRangeMap(V value)
+    {
+        super(value);
+        this.endKeys = RoutingKeys.EMPTY;
+    }
+
+    ReducingRangeMap(boolean inclusiveEnds, RoutingKey[] ends, V[] values)
+    {
+        super(inclusiveEnds, ends, values);
+        this.endKeys = RoutingKeys.ofSortedUnique(ends);
+    }
+
+    public <V2> V2 foldl(Routables<?, ?> routables, BiFunction<V, V2, V2> fold, V2 initialValue, Predicate<V2> terminate)
+    {
+        switch (routables.domain())
+        {
+            default: throw new AssertionError();
+            case Key: return foldl((AbstractKeys<?, ?>) routables, fold, initialValue, terminate);
+            case Range: return Routables.foldl(endKeys, (AbstractRanges<?>) routables, (f, vs, routingKey, v, index) -> f.apply(vs[index], v), fold, values, initialValue, terminate);
+        }
+    }
+
+    public <V2> V2 foldl(AbstractKeys<?, ?> keys, BiFunction<V, V2, V2> reduce, V2 accumulator, Predicate<V2> terminate)
+    {
+        int i = 0, j = 0;
+        while (j < keys.size())
+        {
+            i = endKeys.findNext(i, keys.get(j), FAST);
+            if (i < 0) i = -1 - i;
+            else if (inclusiveEnds) ++i;
+
+            accumulator = reduce.apply(values[i], accumulator);
+            if (i == endKeys.size() || terminate.test(accumulator))
+                return accumulator;
+
+            j = keys.findNext(j + 1, endKeys.get(i), FAST);
+            if (j < 0) j = -1 - j;
+            else if (inclusiveEnds) ++j;
+        }
+        return accumulator;
+    }
+
+    /**
+     * returns a copy of this ReducingRangeMap limited to the ranges supplied, with all other ranges reporting the "zero" value
+     */
+    @VisibleForTesting
+    static <V> ReducingRangeMap<V> trim(ReducingRangeMap<V> existing, Ranges ranges, BiFunction<V, V, V> reduce)
+    {
+        boolean inclusiveEnds = inclusiveEnds(existing.inclusiveEnds, existing.size() > 0, ranges.size() > 0 && ranges.get(0).endInclusive(), ranges.size() > 0);
+        ReducingRangeMap.Builder<V> builder = new ReducingRangeMap.Builder<>(inclusiveEnds, existing.size());
+
+        V zero = existing.values[0];
+        for (Range select : ranges)
+        {
+            ReducingIntervalMap<RoutingKey, V>.RangeIterator intersects = existing.intersecting(select.start(), select.end());
+            while (intersects.hasNext())
+            {
+                if (zero.equals(intersects.value()))
+                {
+                    intersects.next();
+                    continue;
+                }
+
+                RoutingKey start = intersects.hasStart() && intersects.start().compareTo(select.start()) >= 0 ? intersects.start() : select.start();
+                RoutingKey end = intersects.hasEnd() && intersects.end().compareTo(select.end()) <= 0 ? intersects.end() : select.end();
+
+                builder.append(start, zero, reduce);
+                builder.append(end, intersects.value(), reduce);
+                intersects.next();
+            }
+        }
+
+        builder.appendLast(zero);
+        return builder.build();
+    }
+
+    public static <V> ReducingRangeMap<V> merge(ReducingRangeMap<V> historyLeft, ReducingRangeMap<V> historyRight, BiFunction<V, V, V> reduce)
+    {
+        return ReducingIntervalMap.merge(historyLeft, historyRight, reduce, ReducingRangeMap.Builder::new);
+    }
+
+    public static <V> ReducingRangeMap<V> add(ReducingRangeMap<V> existing, Ranges ranges, V value, BiFunction<V, V, V> reduce)
+    {
+        V zero = existing.values[0];
+        boolean inclusiveEnds = inclusiveEnds(existing.inclusiveEnds, existing.size() > 0, ranges.size() > 0 && ranges.get(0).endInclusive(), ranges.size() > 0);
+        ReducingRangeMap.Builder<V> builder = new ReducingRangeMap.Builder<>(inclusiveEnds, ranges.size() * 2);
+        for (Range range : ranges)
+        {
+            // don't add a point for an opening min token, since it
+            // effectively leaves the bottom of the range unbounded
+            builder.append(range.start(), zero, reduce);
+            builder.append(range.end(), value, reduce);
+        }
+        builder.appendLast(zero);
+
+        return merge(existing, builder.build(), reduce, ReducingRangeMap.Builder::new);
+    }
+
+    public static ReducingRangeMap<Timestamp> add(ReducingRangeMap<Timestamp> existing, Ranges ranges, Timestamp value)
+    {
+        return add(existing, ranges, value, Timestamp::max);
+    }
+
+    static class Builder<V> extends ReducingIntervalMap.Builder<RoutingKey, V, ReducingRangeMap<V>>
+    {
+        Builder(boolean inclusiveEnds, int capacity)
+        {
+            super(inclusiveEnds, capacity);
+        }
+
+        ReducingRangeMap<V> buildInternal()
+        {
+            return new ReducingRangeMap<>(inclusiveEnds, ends.toArray(new RoutingKey[0]), (V[])values.toArray(new Object[0]));
+        }
+    }
+}

--- a/accord-core/src/main/java/accord/utils/SortedArrays.java
+++ b/accord-core/src/main/java/accord/utils/SortedArrays.java
@@ -941,5 +941,27 @@ public class SortedArrays
         return true;
     }
 
+    public static <T extends Comparable<? super T>> T[] toUnique(T[] sorted)
+    {
+        int removed = 0;
+        for (int i = 1 ; i < sorted.length ; ++i)
+        {
+            int c = sorted[i - 1].compareTo(sorted[i]);
+            if (c >= 0)
+            {
+                if (c > 0)
+                    throw new IllegalArgumentException(Arrays.toString(sorted) + " is not sorted");
 
+                removed++;
+            }
+            else if (removed > 0)
+            {
+                sorted[i - removed] = sorted[i];
+            }
+        }
+        if (removed == 0)
+            return sorted;
+
+        return Arrays.copyOf(sorted, sorted.length - removed);
+    }
 }

--- a/accord-core/src/main/java/accord/utils/SortedArrays.java
+++ b/accord-core/src/main/java/accord/utils/SortedArrays.java
@@ -18,9 +18,11 @@
 
 package accord.utils;
 
+import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.function.IntFunction;
+import java.util.stream.StreamSupport;
 
 import accord.utils.ArrayBuffers.ObjectBuffers;
 import accord.utils.ArrayBuffers.IntBufferAllocator;
@@ -29,6 +31,7 @@ import net.nicoulaj.compilecommand.annotations.Inline;
 import javax.annotation.Nullable;
 
 import static accord.utils.ArrayBuffers.uncached;
+import static accord.utils.Invariants.checkArgument;
 import static accord.utils.SortedArrays.Search.FAST;
 
 // TODO (low priority, efficiency): improvements:
@@ -38,6 +41,57 @@ import static accord.utils.SortedArrays.Search.FAST;
 //        - Exploit exponentialSearch in union/intersection/etc
 public class SortedArrays
 {
+    public static class SortedArrayList<T extends Comparable<? super T>> extends AbstractList<T>
+    {
+        final T[] array;
+        public SortedArrayList(T[] array)
+        {
+            this.array = checkArgument(array, SortedArrays::isSortedUnique);
+        }
+
+        @Override
+        public T get(int index)
+        {
+            return array[index];
+        }
+
+        @Override
+        public int size()
+        {
+            return array.length;
+        }
+
+        public int findNext(int i, Comparable<? super T> find)
+        {
+            return exponentialSearch(array, i, array.length, find);
+        }
+
+        public boolean containsAll(SortedArrayList<T> test)
+        {
+            return test.array.length == SortedArrays.foldlIntersection(Comparable::compareTo, array, 0, array.length, test.array, 0, test.array.length, (t, p, v, li, ri) -> v + 1, 0, 0, test.array.length);
+        }
+    }
+
+    public static class ExtendedSortedArrayList<T extends Comparable<? super T>> extends SortedArrayList<T>
+    {
+        public static <T extends Comparable<? super T>> ExtendedSortedArrayList<T> sortedCopyOf(Iterable<T> iterator, IntFunction<T[]> allocator)
+        {
+            return new ExtendedSortedArrayList<T>(checkArgument(StreamSupport.stream(iterator.spliterator(), false).sorted().toArray(allocator), SortedArrays::isSortedUnique), allocator);
+        }
+
+        final IntFunction<T[]> allocator;
+        public ExtendedSortedArrayList(T[] array, IntFunction<T[]> allocator)
+        {
+            super(array);
+            this.allocator = allocator;
+        }
+
+        public ExtendedSortedArrayList<T> difference(SortedArrayList<T> remove)
+        {
+            return new ExtendedSortedArrayList<T>(linearDifference(array, remove.array, allocator), allocator);
+        }
+    }
+
     /**
      * {@link #linearUnion(Comparable[], int, Comparable[], int, ObjectBuffers)}
      */
@@ -233,20 +287,35 @@ public class SortedArrays
      */
     public static <T> T[] linearIntersection(T[] left, int leftLength, T[] right, int rightLength, AsymmetricComparator<? super T, ? super T> comparator, ObjectBuffers<T> buffers)
     {
+        return (T[])internalLinearIntersection(leftLength <= rightLength, left, leftLength, right, rightLength, comparator, buffers, buffers);
+    }
+
+    /**
+     * A linear intersection where we only want results from the left inputs, and the right inputs may either be a different type or otherwise only used for filtering
+     */
+    public static <T1, T2> T1[] asymmetricLinearIntersection(T1[] left, int leftLength, T2[] right, int rightLength, AsymmetricComparator<? super T1, ? super T2> comparator, ObjectBuffers<T1> buffers)
+    {
+        return (T1[])internalLinearIntersection(true, left, leftLength, right, rightLength, comparator, buffers, null);
+    }
+
+    /**
+     * A linear intersection where we only want results from the left inputs, and the right inputs may either be a different type or otherwise only used for filtering
+     */
+    private static <T1, T2> Object[] internalLinearIntersection(boolean preferLeft, T1[] left, int leftLength, T2[] right, int rightLength, AsymmetricComparator<? super T1, ? super T2> comparator, ObjectBuffers<T1> leftBuffers, @Nullable ObjectBuffers<T2> rightBuffers)
+    {
         int leftIdx = 0;
         int rightIdx = 0;
 
-        T[] result = null;
+        Object[] result = null;
         int resultSize = 0;
 
-        // first pick a subset candidate, and merge both until we encounter an element not present in the other array
-        if (leftLength <= rightLength)
+        if (preferLeft)
         {
             boolean hasMatch = false;
             while (leftIdx < leftLength && rightIdx < rightLength)
             {
-                T leftKey = left[leftIdx];
-                T rightKey = right[rightIdx];
+                T1 leftKey = left[leftIdx];
+                T2 rightKey = right[rightIdx];
                 int cmp = leftKey == rightKey ? 0 : comparator.compare(leftKey, rightKey);
 
                 if (cmp >= 0)
@@ -259,22 +328,23 @@ public class SortedArrays
                 else
                 {
                     resultSize = leftIdx++;
-                    result = buffers.get(resultSize + Math.min(leftLength - leftIdx, rightLength - rightIdx));
+                    result = leftBuffers.get(resultSize + Math.min(leftLength - leftIdx, rightLength - rightIdx));
                     System.arraycopy(left, 0, result, 0, resultSize);
                     break;
                 }
             }
 
             if (result == null)
-                return hasMatch ? buffers.completeWithExisting(left, leftLength) : buffers.complete(buffers.get(0), 0);
+                return hasMatch ? leftBuffers.completeWithExisting(left, leftIdx) : leftBuffers.complete(leftBuffers.get(0), 0);
         }
         else
         {
+            checkArgument(rightBuffers != null);
             boolean hasMatch = false;
             while (leftIdx < leftLength && rightIdx < rightLength)
             {
-                T leftKey = left[leftIdx];
-                T rightKey = right[rightIdx];
+                T1 leftKey = left[leftIdx];
+                T2 rightKey = right[rightIdx];
                 int cmp = leftKey == rightKey ? 0 : comparator.compare(leftKey, rightKey);
 
                 if (cmp <= 0)
@@ -287,23 +357,22 @@ public class SortedArrays
                 else
                 {
                     resultSize = rightIdx++;
-                    result = buffers.get(resultSize + Math.min(leftLength - leftIdx, rightLength - rightIdx));
+                    result = rightBuffers.get(resultSize + Math.min(leftLength - leftIdx, rightLength - rightIdx));
                     System.arraycopy(right, 0, result, 0, resultSize);
                     break;
                 }
             }
 
             if (result == null)
-                return hasMatch ? buffers.completeWithExisting(right, rightLength) : buffers.complete(buffers.get(0), 0);
+                return hasMatch ? rightBuffers.completeWithExisting(right, rightIdx) : rightBuffers.complete(rightBuffers.get(0), 0);
         }
 
         try
         {
-
             while (leftIdx < leftLength && rightIdx < rightLength)
             {
-                T leftKey = left[leftIdx];
-                T rightKey = right[rightIdx];
+                T1 leftKey = left[leftIdx];
+                T2 rightKey = right[rightIdx];
                 int cmp = leftKey == rightKey ? 0 : comparator.compare(leftKey, rightKey);
 
                 if (cmp == 0)
@@ -316,11 +385,125 @@ public class SortedArrays
                 else rightIdx++;
             }
 
-            return buffers.complete(result, resultSize);
+            return leftBuffers.complete((T1[])result, resultSize);
         }
         finally
         {
-            buffers.discard(result, resultSize);
+            leftBuffers.discard((T1[])result, resultSize);
+        }
+    }
+
+    /**
+     * A linear intersection where we only want results from the left inputs, and the right inputs may either be a different type or otherwise only used for filtering
+     */
+    public static <T1, T2> T1[] asymmetricLinearIntersectionWithOverlaps(T1[] left, int leftLength, T2[] right, int rightLength, AsymmetricComparator<? super T1, ? super T2> comparator, ObjectBuffers<T1> buffers)
+    {
+        return (T1[])internalLinearIntersectionWithOverlaps(true, left, leftLength, right, rightLength, comparator, buffers, null);
+    }
+
+    /**
+     * A linear intersection where we only want results from the left inputs, and the right inputs may either be a different type or otherwise only used for filtering
+     */
+    private static <T1, T2> Object[] internalLinearIntersectionWithOverlaps(boolean preferLeft, T1[] left, int leftLength, T2[] right, int rightLength, AsymmetricComparator<? super T1, ? super T2> comparator, ObjectBuffers<T1> leftBuffers, @Nullable ObjectBuffers<T2> rightBuffers)
+    {
+        int leftIdx = 0;
+        int rightIdx = 0;
+
+        Object[] result = null;
+        int resultSize = 0;
+
+        if (preferLeft)
+        {
+            boolean hasMatch = false;
+            while (leftIdx < leftLength && rightIdx < rightLength)
+            {
+                T1 leftKey = left[leftIdx];
+                T2 rightKey = right[rightIdx];
+                int cmp = leftKey == rightKey ? 0 : comparator.compare(leftKey, rightKey);
+
+                if (cmp == 0)
+                {
+                    leftIdx++;
+                    hasMatch = true;
+                }
+                else if (cmp > 0)
+                {
+                    rightIdx++;
+                }
+                else
+                {
+                    resultSize = leftIdx++;
+                    result = leftBuffers.get(resultSize + leftLength - leftIdx);
+                    System.arraycopy(left, 0, result, 0, resultSize);
+                    break;
+                }
+            }
+
+            if (result == null)
+                return hasMatch ? leftBuffers.completeWithExisting(left, leftIdx) : leftBuffers.complete(leftBuffers.get(0), 0);
+        }
+        else
+        {
+            checkArgument(rightBuffers != null);
+            boolean hasMatch = false;
+            while (leftIdx < leftLength && rightIdx < rightLength)
+            {
+                T1 leftKey = left[leftIdx];
+                T2 rightKey = right[rightIdx];
+                int cmp = leftKey == rightKey ? 0 : comparator.compare(leftKey, rightKey);
+
+                if (cmp == 0)
+                {
+                    rightIdx++;
+                    hasMatch = true;
+                }
+                else if (cmp < 0)
+                {
+                    leftIdx++;
+                }
+                else
+                {
+                    resultSize = rightIdx++;
+                    result = rightBuffers.get(resultSize + rightLength - rightIdx);
+                    System.arraycopy(right, 0, result, 0, resultSize);
+                    break;
+                }
+            }
+
+            if (result == null)
+                return hasMatch ? rightBuffers.completeWithExisting(right, rightIdx) : rightBuffers.complete(rightBuffers.get(0), 0);
+        }
+
+        try
+        {
+            while (leftIdx < leftLength && rightIdx < rightLength)
+            {
+                T1 leftKey = left[leftIdx];
+                T2 rightKey = right[rightIdx];
+                int cmp = leftKey == rightKey ? 0 : comparator.compare(leftKey, rightKey);
+
+                if (cmp == 0)
+                {
+                    if (preferLeft)
+                    {
+                        leftIdx++;
+                        result[resultSize++] = leftKey;
+                    }
+                    else
+                    {
+                        rightIdx++;
+                        result[resultSize++] = rightKey;
+                    }
+                }
+                else if (cmp < 0) leftIdx++;
+                else rightIdx++;
+            }
+
+            return leftBuffers.complete((T1[])result, resultSize);
+        }
+        finally
+        {
+            leftBuffers.discard((T1[])result, resultSize);
         }
     }
 
@@ -921,12 +1104,12 @@ public class SortedArrays
     }
 
 
-    public static <T extends Comparable<T>> boolean isSortedUnique(T[] array)
+    public static <T extends Comparable<? super T>> boolean isSortedUnique(T[] array)
     {
         return isSortedUnique(array, Comparable::compareTo);
     }
 
-    public static  <T> boolean isSortedUnique(T[] array, Comparator<T> comparator)
+    public static <T> boolean isSortedUnique(T[] array, Comparator<T> comparator)
     {
         return isSorted(array, comparator, 0);
     }

--- a/accord-core/src/main/java/accord/utils/TriFunction.java
+++ b/accord-core/src/main/java/accord/utils/TriFunction.java
@@ -16,20 +16,9 @@
  * limitations under the License.
  */
 
-package accord.coordinate;
+package accord.utils;
 
-import javax.annotation.Nullable;
-
-import accord.api.RoutingKey;
-import accord.primitives.TxnId;
-
-/**
- * Thrown when a transaction exceeds its specified timeout for obtaining a result for a client
- */
-public class Timeout extends CoordinationFailed
+public interface TriFunction<P1, P2, P3, O>
 {
-    public Timeout(TxnId txnId, @Nullable RoutingKey homeKey)
-    {
-        super(txnId, homeKey);
-    }
+    O apply(P1 p1, P2 p2, P3 p3);
 }

--- a/accord-core/src/test/java/accord/burn/BurnTest.java
+++ b/accord-core/src/test/java/accord/burn/BurnTest.java
@@ -18,6 +18,7 @@
 
 package accord.burn;
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/accord-core/src/test/java/accord/coordinate/CoordinateTest.java
+++ b/accord-core/src/test/java/accord/coordinate/CoordinateTest.java
@@ -91,7 +91,7 @@ public class CoordinateTest
             TxnId oldId1 = node.nextTxnId(Write, Key);
             TxnId oldId2 = node.nextTxnId(Write, Key);
 
-            getUninterruptibly(CoordinateSyncPoint.exclusive(node, ranges(range(1, 2))));
+            getUninterruptibly(CoordinateSyncPoint.exclusive(node, ranges(range(0, 1))));
             try
             {
                 Keys keys = keys(1);

--- a/accord-core/src/test/java/accord/coordinate/CoordinateTest.java
+++ b/accord-core/src/test/java/accord/coordinate/CoordinateTest.java
@@ -22,12 +22,22 @@ import accord.local.Node;
 import accord.impl.mock.MockCluster;
 import accord.api.Result;
 import accord.impl.mock.MockStore;
-import accord.primitives.*;
+import java.util.concurrent.ExecutionException;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static accord.Utils.*;
+import accord.primitives.FullKeyRoute;
+import accord.primitives.FullRangeRoute;
+import accord.primitives.Keys;
+import accord.primitives.Ranges;
+import accord.primitives.Txn;
+import accord.primitives.TxnId;
+
+import static accord.Utils.id;
+import static accord.Utils.ids;
+import static accord.Utils.ranges;
+import static accord.Utils.writeTxn;
 import static accord.impl.IntKey.keys;
 import static accord.impl.IntKey.range;
 import static accord.primitives.Routable.Domain.Key;
@@ -52,6 +62,7 @@ public class CoordinateTest
             Assertions.assertEquals(MockStore.RESULT, result);
         }
     }
+
     @Test
     void simpleRangeTest() throws Throwable
     {
@@ -66,6 +77,38 @@ public class CoordinateTest
             FullRangeRoute route = keys.toRoute(keys.get(0).someIntersectingRoutingKey(null));
             Result result = getUninterruptibly(Coordinate.coordinate(node, txnId, txn, route));
             Assertions.assertEquals(MockStore.RESULT, result);
+        }
+    }
+
+    @Test
+    void exclusiveSyncTest() throws Throwable
+    {
+        try (MockCluster cluster = MockCluster.builder().build())
+        {
+            Node node = cluster.get(1);
+            Assertions.assertNotNull(node);
+
+            TxnId oldId1 = node.nextTxnId(Write, Key);
+            TxnId oldId2 = node.nextTxnId(Write, Key);
+
+            getUninterruptibly(CoordinateSyncPoint.exclusive(node, ranges(range(1, 2))));
+            try
+            {
+                Keys keys = keys(1);
+                Txn txn = writeTxn(keys);
+                FullKeyRoute route = keys.toRoute(keys.get(0).someIntersectingRoutingKey(null));
+                getUninterruptibly(Coordinate.coordinate(node, oldId1, txn, route));
+                Assertions.fail();
+            }
+            catch (ExecutionException e)
+            {
+                Assertions.assertEquals(Invalidated.class, e.getCause().getClass());
+            }
+
+            Keys keys = keys(2);
+            Txn txn = writeTxn(keys);
+            FullKeyRoute route = keys.toRoute(keys.get(0).someIntersectingRoutingKey(null));
+            getUninterruptibly(Coordinate.coordinate(node, oldId2, txn, route));
         }
     }
 

--- a/accord-core/src/test/java/accord/impl/TestAgent.java
+++ b/accord-core/src/test/java/accord/impl/TestAgent.java
@@ -18,10 +18,13 @@
 
 package accord.impl;
 
+import accord.impl.mock.MockStore;
 import accord.local.Command;
 import accord.local.Node;
 import accord.api.Agent;
 import accord.api.Result;
+import accord.local.Command;
+import accord.primitives.*;
 import accord.primitives.Timestamp;
 import accord.primitives.TxnId;
 
@@ -57,5 +60,11 @@ public class TestAgent implements Agent
     public boolean isExpired(TxnId initiated, long now)
     {
         return TimeUnit.SECONDS.convert(now - initiated.hlc(), TimeUnit.MICROSECONDS) >= 10;
+    }
+
+    @Override
+    public Txn emptyTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
+    {
+        return new Txn.InMemory(kind, keysOrRanges, MockStore.read(Keys.EMPTY), MockStore.QUERY, null);
     }
 }

--- a/accord-core/src/test/java/accord/impl/list/ListAgent.java
+++ b/accord-core/src/test/java/accord/impl/list/ListAgent.java
@@ -20,14 +20,11 @@ package accord.impl.list;
 
 import java.util.function.Consumer;
 
-import com.google.common.base.Functions;
-
 import accord.impl.mock.Network;
 import accord.local.Command;
 import accord.local.Node;
 import accord.api.Agent;
 import accord.api.Result;
-import accord.local.Command;
 import accord.primitives.*;
 
 import static accord.local.Node.Id.NONE;
@@ -84,6 +81,6 @@ public class ListAgent implements Agent
     @Override
     public Txn emptyTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
     {
-        return new Txn.InMemory(kind, keysOrRanges, new ListRead(identity(), Keys.EMPTY, Keys.EMPTY), new ListQuery(NONE, -1), null);
+        return new Txn.InMemory(kind, keysOrRanges, new ListRead(identity(), Keys.EMPTY, Keys.EMPTY), new ListQuery(NONE, Integer.MIN_VALUE), null);
     }
 }

--- a/accord-core/src/test/java/accord/impl/list/ListAgent.java
+++ b/accord-core/src/test/java/accord/impl/list/ListAgent.java
@@ -20,11 +20,19 @@ package accord.impl.list;
 
 import java.util.function.Consumer;
 
+import com.google.common.base.Functions;
+
 import accord.impl.mock.Network;
 import accord.local.Command;
 import accord.local.Node;
 import accord.api.Agent;
 import accord.api.Result;
+import accord.local.Command;
+import accord.primitives.*;
+
+import static accord.local.Node.Id.NONE;
+import static com.google.common.base.Functions.identity;
+
 import accord.primitives.Timestamp;
 import accord.primitives.TxnId;
 
@@ -71,5 +79,11 @@ public class ListAgent implements Agent
     public boolean isExpired(TxnId initiated, long now)
     {
         return now - initiated.hlc() >= timeout;
+    }
+
+    @Override
+    public Txn emptyTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
+    {
+        return new Txn.InMemory(kind, keysOrRanges, new ListRead(identity(), Keys.EMPTY, Keys.EMPTY), new ListQuery(NONE, -1), null);
     }
 }

--- a/accord-core/src/test/java/accord/impl/list/ListQuery.java
+++ b/accord-core/src/test/java/accord/impl/list/ListQuery.java
@@ -45,7 +45,7 @@ public class ListQuery implements Query
     public Result compute(TxnId txnId, Data data, Read untypedRead, Update update)
     {
         ListRead read = (ListRead) untypedRead;
-        Keys responseKeys = Keys.ofSorted(((ListData)data).keySet());
+        Keys responseKeys = Keys.ofSortedUnique(((ListData)data).keySet());
         int[][] values = new int[responseKeys.size()][];
         for (Map.Entry<Key, int[]> e : ((ListData)data).entrySet())
         {

--- a/accord-core/src/test/java/accord/impl/list/ListRequest.java
+++ b/accord-core/src/test/java/accord/impl/list/ListRequest.java
@@ -23,7 +23,7 @@ import java.util.function.BiConsumer;
 import accord.api.Result;
 import accord.api.RoutingKey;
 import accord.coordinate.CheckShards;
-import accord.coordinate.CoordinateFailed;
+import accord.coordinate.CoordinationFailed;
 import accord.impl.basic.Cluster;
 import accord.impl.basic.Packet;
 import accord.local.Node;
@@ -106,11 +106,11 @@ public class ListRequest implements Request
             {
                 node.reply(client, replyContext, (ListResult) success);
             }
-            else if (fail instanceof CoordinateFailed)
+            else if (fail instanceof CoordinationFailed)
             {
                 ((Cluster)node.scheduler()).onDone(() -> {
-                    RoutingKey homeKey = ((CoordinateFailed) fail).homeKey();
-                    TxnId txnId = ((CoordinateFailed) fail).txnId();
+                    RoutingKey homeKey = ((CoordinationFailed) fail).homeKey();
+                    TxnId txnId = ((CoordinationFailed) fail).txnId();
                     node.commandStores()
                         .select(homeKey)
                         .execute(() -> CheckOnResult.checkOnResult(node, txnId, homeKey, (s, f) -> {

--- a/accord-core/src/test/java/accord/messages/PreAcceptTest.java
+++ b/accord-core/src/test/java/accord/messages/PreAcceptTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
@@ -71,7 +72,7 @@ public class PreAcceptTest
     }
 
     @Test
-    void initialCommandTest()
+    void initialCommandTest() throws ExecutionException
     {
         RecordingMessageSink messageSink = new RecordingMessageSink(ID1, Network.BLACK_HOLE);
         Clock clock = new Clock(100);
@@ -110,7 +111,7 @@ public class PreAcceptTest
     }
 
     @Test
-    void nackTest()
+    void nackTest() throws ExecutionException
     {
         RecordingMessageSink messageSink = new RecordingMessageSink(ID1, Network.BLACK_HOLE);
         Clock clock = new Clock(100);
@@ -173,7 +174,7 @@ public class PreAcceptTest
     }
 
     @Test
-    void multiKeyTimestampUpdate()
+    void multiKeyTimestampUpdate() throws ExecutionException
     {
         RecordingMessageSink messageSink = new RecordingMessageSink(ID1, Network.BLACK_HOLE);
         Clock clock = new Clock(100);
@@ -209,7 +210,7 @@ public class PreAcceptTest
      * with the proposed timestamp
      */
     @Test
-    void singleKeyNewerTimestamp()
+    void singleKeyNewerTimestamp() throws ExecutionException
     {
         RecordingMessageSink messageSink = new RecordingMessageSink(ID1, Network.BLACK_HOLE);
         Clock clock = new Clock(100);
@@ -236,7 +237,7 @@ public class PreAcceptTest
     }
 
     @Test
-    void supersedingEpochPrecludesFastPath()
+    void supersedingEpochPrecludesFastPath() throws ExecutionException
     {
         RecordingMessageSink messageSink = new RecordingMessageSink(ID1, Network.BLACK_HOLE);
         Clock clock = new Clock(100);

--- a/accord-core/src/test/java/accord/messages/ReadDataTest.java
+++ b/accord-core/src/test/java/accord/messages/ReadDataTest.java
@@ -75,6 +75,7 @@ import org.mockito.stubbing.Answer;
 import static accord.Utils.createNode;
 import static accord.Utils.id;
 import static accord.utils.Utils.listOf;
+import static accord.utils.async.AsyncChains.getUninterruptibly;
 import static org.mockito.ArgumentMatchers.any;
 
 class ReadDataTest
@@ -224,7 +225,7 @@ class ReadDataTest
     {
         try
         {
-            AsyncChains.getUninterruptibly(execute);
+            getUninterruptibly(execute);
         }
         catch (ExecutionException e)
         {

--- a/accord-core/src/test/java/accord/utils/Pair.java
+++ b/accord-core/src/test/java/accord/utils/Pair.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package accord.utils;
+
+import com.google.common.base.Objects;
+
+public class Pair<T1, T2>
+{
+    public final T1 left;
+    public final T2 right;
+
+    protected Pair(T1 left, T2 right)
+    {
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public final int hashCode()
+    {
+        int hashCode = 31 + (left == null ? 0 : left.hashCode());
+        return 31*hashCode + (right == null ? 0 : right.hashCode());
+    }
+
+    @Override
+    public final boolean equals(Object o)
+    {
+        if(!(o instanceof Pair))
+            return false;
+        Pair that = (Pair)o;
+        // handles nulls properly
+        return Objects.equal(left, that.left) && Objects.equal(right, that.right);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "(" + left + "," + right + ")";
+    }
+
+    //For functional interfaces
+    public T1 left()
+    {
+        return left;
+    }
+
+    //For functional interfaces
+    public T2 right()
+    {
+        return right;
+    }
+
+    public static <X, Y> Pair<X, Y> create(X x, Y y)
+    {
+        return new Pair<X, Y>(x, y);
+    }
+}

--- a/accord-core/src/test/java/accord/utils/ReducingRangeMapTest.java
+++ b/accord-core/src/test/java/accord/utils/ReducingRangeMapTest.java
@@ -1,0 +1,575 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.utils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Random;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import accord.api.RoutingKey;
+import accord.impl.IntKey;
+import accord.local.Node;
+import accord.primitives.Range;
+import accord.primitives.Ranges;
+import accord.primitives.RoutingKeys;
+import accord.primitives.Timestamp;
+
+import static accord.utils.ReducingRangeMap.trim;
+import static java.lang.Integer.MAX_VALUE;
+import static java.lang.Integer.MIN_VALUE;
+
+// TODO (desired): test start inclusive ranges
+public class ReducingRangeMapTest
+{
+    static final Logger logger = LoggerFactory.getLogger(ReducingRangeMapTest.class);
+    static final ReducingRangeMap<Timestamp> EMPTY = new ReducingRangeMap<>(Timestamp.NONE);
+    static final RoutingKey MINIMUM_EXCL = new IntKey.Routing(MIN_VALUE);
+    static final RoutingKey MAXIMUM_EXCL = new IntKey.Routing(MAX_VALUE);
+    private static RoutingKey rk(int t)
+    {
+        return new IntKey.Routing(t);
+    }
+    private static RoutingKey rk(Random random)
+    {
+        int rk = random.nextInt();
+        if (random.nextBoolean()) rk = -rk;
+        if (rk == MAX_VALUE) --rk;
+        return new IntKey.Routing(rk);
+    }
+
+    private static Timestamp none()
+    {
+        return Timestamp.NONE;
+    }
+
+    private static Timestamp ts(int b)
+    {
+        return Timestamp.fromValues(1, b, 0, new Node.Id(1));
+    }
+
+    private static Range r(RoutingKey l, RoutingKey r)
+    {
+        return new Range.EndInclusive(l, r);
+    }
+
+    private static RoutingKey incr(RoutingKey rk)
+    {
+        return new IntKey.Routing(((IntKey.Routing)rk).key + 1);
+    }
+
+    private static RoutingKey decr(RoutingKey rk)
+    {
+        return new IntKey.Routing(((IntKey.Routing)rk).key - 1);
+    }
+
+    private static Range r(int l, int r)
+    {
+        return r(rk(l), rk(r));
+    }
+
+    private static Pair<RoutingKey, Timestamp> pt(int t, int b)
+    {
+        return Pair.create(rk(t), ts(b));
+    }
+
+    private static Pair<RoutingKey, Timestamp> pt(int t, Timestamp b)
+    {
+        return Pair.create(rk(t), b);
+    }
+
+    private static Pair<RoutingKey, Timestamp> pt(RoutingKey t, int b)
+    {
+        return Pair.create(t, ts(b));
+    }
+
+    private static ReducingRangeMap<Timestamp> h(Pair<RoutingKey, Timestamp>... points)
+    {
+        int length = points.length + (points[points.length - 1].left == null ? 0 : 1);
+        RoutingKey[] routingKeys = new RoutingKey[length - 1];
+        Timestamp[] timestamps = new Timestamp[length];
+        for (int i = 0 ; i < length - 1 ; ++i)
+        {
+            routingKeys[i] = points[i].left;
+            timestamps[i] = points[i].right;
+        }
+        timestamps[length - 1] = length == points.length ? points[length - 1].right : none();
+        return new ReducingRangeMap<>(true, routingKeys, timestamps);
+    }
+
+    static
+    {
+        assert rk(100).equals(rk(100));
+        assert ts(111).equals(ts(111));
+    }
+
+    private static class Builder
+    {
+        ReducingRangeMap<Timestamp> history = EMPTY;
+
+        Builder add(Timestamp timestamp, Range... ranges)
+        {
+            history = ReducingRangeMap.add(history, Ranges.of(ranges), timestamp);
+            return this;
+        }
+
+        Builder clear()
+        {
+            history = EMPTY;
+            return this;
+        }
+    }
+
+    static Builder builder()
+    {
+        return new Builder();
+    }
+
+    @Test
+    public void testAdd()
+    {
+        Builder builder = builder();
+        Assertions.assertEquals(h(pt(10, none()), pt(20, 5), pt(30, none()), pt(40, 5)),
+                            builder.add(ts(5), r(10, 20), r(30, 40)).history);
+
+        Assertions.assertEquals(none(), builder.history.get(rk(0)));
+        Assertions.assertEquals(none(), builder.history.get(rk(10)));
+        Assertions.assertEquals(ts(5), builder.history.get(rk(11)));
+        Assertions.assertEquals(ts(5), builder.history.get(rk(20)));
+        Assertions.assertEquals(none(), builder.history.get(rk(21)));
+
+        builder.clear();
+        Assertions.assertEquals(h(pt(10, none()), pt(20, 5), pt(30, none()), pt(40, 6)),
+                            builder.add(ts(5), r(10, 20)).add(ts(6), r(30, 40)).history);
+        builder.clear();
+        Assertions.assertEquals(h(pt(10, none()), pt(20, 5), pt(30, 6), pt(40, 5)),
+                            builder.add(ts(5), r(10, 40)).add(ts(6), r(20, 30)).history);
+
+        builder.clear();
+        Assertions.assertEquals(h(pt(10, none()), pt(20, 6), pt(30, 5)),
+                            builder.add(ts(6), r(10, 20)).add(ts(5), r(15, 30)).history);
+
+        builder.clear();
+        Assertions.assertEquals(h(pt(10, none()), pt(20, 5), pt(30, 6)),
+                            builder.add(ts(5), r(10, 25)).add(ts(6), r(20, 30)).history);
+    }
+
+    @Test
+    public void testTrim()
+    {
+        Assertions.assertEquals(h(pt(10, none()), pt(20, 5), pt(30, none()), pt(40, 5), pt(50, none()), pt(60, 5)),
+                            trim(h(pt(0, none()), pt(70, 5)), Ranges.of(r(10, 20), r(30, 40), r(50, 60)), Timestamp::max));
+
+        Assertions.assertEquals(h(pt(10, none()), pt(20, 5)),
+                            trim(h(pt(0, none()), pt(20, 5)), Ranges.of(r(10, 30)), Timestamp::max));
+
+        Assertions.assertEquals(h(pt(10, none()), pt(20, 5)),
+                            trim(h(pt(10, none()), pt(30, 5)), Ranges.of(r(0, 20)), Timestamp::max));
+    }
+//
+//    @Test
+//    public void testFullRange()
+//    {
+//        // test full range is collapsed
+//        Builder builder = builder();
+//        Assertions.assertEquals(h(pt(null, 5)),
+//                            builder.add(b(5), r(MIN_RoutingKey, MIN_RoutingKey)).history);
+//
+//        Assertions.assertEquals(b(5), builder.history.get(MIN_RoutingKey));
+//        Assertions.assertEquals(b(5), builder.history.get(t(0)));
+//    }
+
+    private static RoutingKey[] tks(int ... tks)
+    {
+        return IntStream.of(tks).mapToObj(ReducingRangeMapTest::rk).toArray(RoutingKey[]::new);
+    }
+
+    @Test
+    public void testRandomTrims() throws ExecutionException, InterruptedException
+    {
+        ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+        List<ListenableFuture<Void>> results = new ArrayList<>();
+        int count = 1000;
+        for (int numberOfAdditions : new int[] { 1, 10, 100 })
+        {
+            for (float maxCoveragePerRange : new float[] { 0.01f, 0.1f, 0.5f })
+            {
+                for (float chanceOfMinRoutingKey : new float[] { 0.01f, 0.1f })
+                {
+                    results.addAll(testRandomTrims(executor, count, numberOfAdditions, 3, maxCoveragePerRange, chanceOfMinRoutingKey));
+                }
+            }
+        }
+        Futures.allAsList(results).get();
+        executor.shutdown();
+    }
+
+    private List<ListenableFuture<Void>> testRandomTrims(ExecutorService executor, int tests, int numberOfAdditions, int maxNumberOfRangesPerAddition, float maxCoveragePerRange, float chanceOfMinRoutingKey)
+    {
+        return ThreadLocalRandom.current()
+                .longs(tests)
+                .mapToObj(seed -> {
+
+                    SettableFuture<Void> promise = SettableFuture.create();
+                    executor.execute(() -> {
+                        try
+                        {
+                            testRandomTrims(seed, numberOfAdditions, maxNumberOfRangesPerAddition, maxCoveragePerRange, chanceOfMinRoutingKey);
+                            promise.set(null);
+                        }
+                        catch (Throwable t)
+                        {
+                            promise.setException(t);
+                        }
+                    });
+                    return promise;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private void testRandomTrims(long seed, int numberOfAdditions, int maxNumberOfRangesPerAddition, float maxCoveragePerRange, float chanceOfMinRoutingKey)
+    {
+        Random random = new Random(seed);
+        logger.info("Seed {} ({}, {}, {}, {})", seed, numberOfAdditions, maxNumberOfRangesPerAddition, maxCoveragePerRange, chanceOfMinRoutingKey);
+        ReducingRangeMap<Timestamp> history = RandomMap.build(random, numberOfAdditions, maxNumberOfRangesPerAddition, maxCoveragePerRange, chanceOfMinRoutingKey);
+        // generate a random list of ranges that cover the whole ring
+        int[] routingKeys = random.ints(16).map(i -> i == MIN_VALUE ? i + 1 : i).distinct().toArray();
+        if (random.nextBoolean())
+            routingKeys[0] = MIN_VALUE + 1;
+        Arrays.sort(routingKeys);
+        List<List<Range>> ranges = IntStream.range(0, routingKeys.length <= 3 ? 1 : 1 + random.nextInt((routingKeys.length - 1) / 2))
+                .mapToObj(ignore -> new ArrayList<Range>())
+                .collect(Collectors.toList());
+
+        ranges.get(random.nextInt(ranges.size())).add(r(MINIMUM_EXCL, rk(routingKeys[0])));
+        for (int i = 1 ; i < routingKeys.length ; ++i)
+            ranges.get(random.nextInt(ranges.size())).add(r(routingKeys[i - 1], routingKeys[i]));
+        ranges.get(random.nextInt(ranges.size())).add(r(rk(routingKeys[routingKeys.length - 1]), MAXIMUM_EXCL));
+        // TODO: this was a wrap-around range
+//        ranges.get(random.nextInt(ranges.size())).add(r(routingKeys[routingKeys.length - 1], routingKeys[0]));
+
+        List<ReducingRangeMap<Timestamp>> splits = new ArrayList<>();
+        for (List<Range> rs : ranges)
+        {
+            ReducingRangeMap<Timestamp> trimmed = trim(history, Ranges.of(rs.toArray(new Range[0])), Timestamp::max);
+            splits.add(trimmed);
+            if (rs.isEmpty())
+                continue;
+
+            Range prev = rs.get(rs.size() - 1);
+            for (Range range : rs)
+            {
+                if (prev.end().equals(range.start()))
+                {
+                    Assertions.assertEquals(history.get(decr(range.start())), trimmed.get(decr(range.start())));
+                    Assertions.assertEquals(history.get(range.start()), trimmed.get(range.start()));
+                }
+                else
+                {
+                    Assertions.assertEquals(none(), trimmed.get(range.start()));
+                    Assertions.assertEquals(none(), trimmed.get(incr(prev.end())));
+                }
+                Assertions.assertEquals(history.get(incr(range.start())), trimmed.get(incr(range.start())));
+                if (!incr(range.start()).equals(range.end()))
+                    Assertions.assertEquals(history.get(decr(range.end())), trimmed.get(decr(range.end())));
+
+                Assertions.assertEquals(history.get(range.end()), trimmed.get(range.end()));
+                prev = range;
+            }
+        }
+
+        ReducingRangeMap<Timestamp> merged = EMPTY;
+        for (ReducingRangeMap<Timestamp> split : splits)
+            merged = ReducingRangeMap.merge(merged, split, Timestamp::max);
+
+        Assertions.assertEquals(history, merged);
+    }
+
+    @Test
+    public void testRandomAdds() throws ExecutionException, InterruptedException
+    {
+        ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+        List<ListenableFuture<Void>> results = new ArrayList<>();
+        int count = 1000;
+        for (int numberOfAdditions : new int[] { 1, 10, 100 })
+        {
+            for (float maxCoveragePerRange : new float[] { 0.01f, 0.1f, 0.5f })
+            {
+                for (float chanceOfMinRoutingKey : new float[] { 0.01f, 0.1f })
+                {
+                    results.addAll(testRandomAdds(executor, count, 3, numberOfAdditions, 3, maxCoveragePerRange, chanceOfMinRoutingKey));
+                }
+            }
+        }
+        Futures.allAsList(results).get();
+        executor.shutdown();
+    }
+
+    private List<ListenableFuture<Void>> testRandomAdds(ExecutorService executor, int tests, int numberOfMerges, int numberOfAdditions, int maxNumberOfRangesPerAddition, float maxCoveragePerRange, float chanceOfMinRoutingKey)
+    {
+        return ThreadLocalRandom.current()
+                .longs(tests)
+                .mapToObj(seed -> {
+                    SettableFuture<Void> promise = SettableFuture.create();
+                    executor.execute(() -> {
+                        try
+                        {
+                            testRandomAdds(seed, numberOfMerges, numberOfAdditions, maxNumberOfRangesPerAddition, maxCoveragePerRange, chanceOfMinRoutingKey);
+                            promise.set(null);
+                        }
+                        catch (Throwable t)
+                        {
+                            promise.setException(t);
+                        }
+                    });
+                    return promise;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private void testRandomAdds(long seed, int numberOfMerges, int numberOfAdditions, int maxNumberOfRangesPerAddition, float maxCoveragePerRange, float chanceOfMinRoutingKey)
+    {
+        Random random = new Random(seed);
+        String id = String.format("%d, %d, %d, %d, %f, %f", seed, numberOfMerges, numberOfAdditions, maxNumberOfRangesPerAddition, maxCoveragePerRange, chanceOfMinRoutingKey);
+        logger.info(id);
+        List<RandomWithCanonical> merge = new ArrayList<>();
+        while (numberOfMerges-- > 0)
+        {
+            RandomWithCanonical build = new RandomWithCanonical();
+            build.addRandom(random, numberOfAdditions, maxNumberOfRangesPerAddition, maxCoveragePerRange, chanceOfMinRoutingKey);
+            merge.add(build);
+        }
+
+        RandomWithCanonical check = new RandomWithCanonical();
+        for (RandomWithCanonical add : merge)
+            check = check.merge(add);
+//        check.serdeser();
+
+        check.validate(random, id);
+    }
+
+    static class RandomMap
+    {
+        ReducingRangeMap<Timestamp> test = new ReducingRangeMap<>(Timestamp.NONE);
+
+        void add(Ranges ranges, Timestamp timestamp)
+        {
+            test = ReducingRangeMap.add(test, ranges, timestamp);
+        }
+
+        void merge(RandomMap other)
+        {
+            test = ReducingRangeMap.merge(test, other.test, Timestamp::max);
+        }
+
+        void addOneRandom(Random random, int maxRangeCount, float maxCoverage, float minChance)
+        {
+            int count = maxRangeCount == 1 ? 1 : 1 + random.nextInt(maxRangeCount - 1);
+            Timestamp timestamp = ts(random.nextInt(MAX_VALUE));
+            List<Range> ranges = new ArrayList<>();
+            while (count-- > 0)
+            {
+                int length = (int) (2 * random.nextDouble() * maxCoverage * MAX_VALUE);
+                if (length == 0) length = 1;
+                Range range;
+                if (random.nextFloat() <= minChance)
+                {
+                    if (random.nextBoolean()) range = r(MIN_VALUE + 1, MIN_VALUE + 1 + length);
+                    else range = r(MAX_VALUE - length - 1, MAX_VALUE - 1);
+                }
+                else
+                {
+                    int start = random.nextInt(MAX_VALUE - length - 1);
+                    range = r(start, start + length);
+                }
+                ranges.add(range);
+            }
+            add(Ranges.of(ranges.toArray(new Range[0])), timestamp);
+        }
+
+        void addRandom(Random random, int count, int maxNumberOfRangesPerAddition, float maxCoveragePerAddition, float minRoutingKeyChance)
+        {
+            while (count-- > 0)
+                addOneRandom(random, maxNumberOfRangesPerAddition, maxCoveragePerAddition, minRoutingKeyChance);
+        }
+
+        static ReducingRangeMap<Timestamp> build(Random random, int count, int maxNumberOfRangesPerAddition, float maxCoveragePerRange, float chanceOfMinRoutingKey)
+        {
+            RandomMap result = new RandomMap();
+            result.addRandom(random, count, maxNumberOfRangesPerAddition, maxCoveragePerRange, chanceOfMinRoutingKey);
+            return result.test;
+        }
+    }
+
+    static class RandomWithCanonical extends RandomMap
+    {
+        NavigableMap<RoutingKey, Timestamp> canonical = new TreeMap<>();
+        {
+            canonical.put(MINIMUM_EXCL, none());
+        }
+
+        Timestamp get(RoutingKey rk)
+        {
+            return canonical
+                    .floorEntry(decr(rk))
+                    .getValue();
+        }
+
+        RandomWithCanonical merge(RandomWithCanonical other)
+        {
+            RandomWithCanonical result = new RandomWithCanonical();
+            result.test = ReducingRangeMap.merge(test, other.test, Timestamp::max);
+            result.canonical = new TreeMap<>();
+            result.canonical.putAll(canonical);
+            for (Map.Entry<RoutingKey, Timestamp> entry : other.canonical.entrySet())
+            {
+                RoutingKey left = entry.getKey();
+                RoutingKey right = other.canonical.higherKey(left);
+                if (right == null) right = MAXIMUM_EXCL;
+                result.addCanonical(r(left, right), entry.getValue());
+            }
+            return result;
+        }
+
+//        void serdeser()
+//        {
+//            ReduceRangeMap<RoutingKey, Timestamp> tmp = ReduceRangeMap.fromTupleBufferList(test.toTupleBufferList());
+//            Assertions.assertEquals(test, tmp);
+//            test = tmp;
+//        }
+
+        void add(Ranges addRanges, Timestamp timestamp)
+        {
+            super.add(addRanges, timestamp);
+            for (Range range : addRanges)
+                addCanonical(range, timestamp);
+        }
+
+        void addCanonical(Range range, Timestamp timestamp)
+        {
+            canonical.put(range.start(), canonical.floorEntry(range.start()).getValue());
+            canonical.put(range.end(), canonical.floorEntry(range.end()).getValue());
+
+            canonical.subMap(range.start(), true, range.end(), false)
+                    .entrySet().forEach(e -> e.setValue(Timestamp.max(e.getValue(), timestamp)));
+        }
+
+        void validate(Random random, String id)
+        {
+            for (RoutingKey rk : canonical.keySet())
+            {
+                Assertions.assertEquals(get(decr(rk)), test.get(decr(rk)), id);
+                Assertions.assertEquals(get(rk), test.get(rk), id);
+                Assertions.assertEquals(get(incr(rk)), test.get(incr(rk)), id);
+            }
+
+            // check some random
+            {
+                int remaining = 1000;
+                while (remaining-- > 0)
+                {
+                    RoutingKey routingKey = rk(random);
+                    Assertions.assertEquals(get(routingKey), test.get(routingKey), id);
+                }
+            }
+
+            // validate foldl
+            {
+                int remaining = 100;
+                while (remaining-- > 0)
+                {
+                    int count = 1 + random.nextInt(20);
+                    RoutingKeys keys;
+                    Ranges ranges;
+                    {
+                        RoutingKey[] tmp = new RoutingKey[count];
+                        for (int i = 0 ; i < tmp.length ; ++i)
+                            tmp[i] = rk(random);
+                        keys = RoutingKeys.of(tmp);
+                        Range[] tmp2 = new Range[(keys.size() + 1) / 2];
+                        int i = 0, c = 0;
+                        if (keys.size() % 2 == 1 && random.nextBoolean())
+                            tmp2[c++] = r(MINIMUM_EXCL, keys.get(i++));
+                        while (i + 1 < keys.size())
+                        {
+                            tmp2[c++] = r(keys.get(i), keys.get(i+1));
+                            i += 2;
+                        }
+                        if (i < keys.size())
+                            tmp2[c++] = r(keys.get(i++), MAXIMUM_EXCL);
+                        ranges = Ranges.of(tmp2);
+                    }
+
+                    List<Timestamp> foldl = test.foldl(keys, (timestamp, timestamps) -> {
+                            if (timestamps.isEmpty() || !timestamps.get(timestamps.size() - 1).equals(timestamp))
+                                timestamps.add(timestamp);
+                            return timestamps;
+                        }, new ArrayList<>(), ignore -> false);
+
+                    List<Timestamp> canonFoldl = new ArrayList<>();
+                    for (RoutingKey key : keys)
+                    {
+                        Timestamp next = get(key);
+                        if (canonFoldl.isEmpty() || !canonFoldl.get(canonFoldl.size() - 1).equals(next))
+                            canonFoldl.add(next);
+                    }
+                    Assertions.assertEquals(canonFoldl, foldl, id);
+
+                    foldl = test.foldl(ranges, (timestamp, timestamps) -> {
+                        if (timestamps.isEmpty() || !timestamps.get(timestamps.size() - 1).equals(timestamp))
+                            timestamps.add(timestamp);
+                        return timestamps;
+                    }, new ArrayList<>(), ignore -> false);
+
+                    canonFoldl.clear();
+                    for (Range range : ranges)
+                    {
+                        RoutingKey start = canonical.floorKey(range.start());
+                        RoutingKey end = canonical.floorKey(range.end());
+                        for (Timestamp next : canonical.subMap(start, true, end, false).values())
+                        {
+                            if (canonFoldl.isEmpty() || !canonFoldl.get(canonFoldl.size() - 1).equals(next))
+                                canonFoldl.add(next);
+                        }
+                    }
+                    Assertions.assertEquals(canonFoldl, foldl, id);
+                }
+
+
+            }
+        }
+    }
+}

--- a/accord-maelstrom/src/main/java/accord/maelstrom/MaelstromAgent.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/MaelstromAgent.java
@@ -22,6 +22,8 @@ import accord.local.Command;
 import accord.local.Node;
 import accord.api.Agent;
 import accord.api.Result;
+import accord.local.Command;
+import accord.primitives.*;
 import accord.primitives.Timestamp;
 import accord.primitives.TxnId;
 
@@ -61,5 +63,11 @@ public class MaelstromAgent implements Agent
     public boolean isExpired(TxnId initiated, long now)
     {
         return TimeUnit.SECONDS.convert(now - initiated.hlc(), TimeUnit.MICROSECONDS) >= 10;
+    }
+
+    @Override
+    public Txn emptyTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
+    {
+        return new Txn.InMemory(kind, keysOrRanges, new MaelstromRead(Keys.EMPTY, Keys.EMPTY), new MaelstromQuery(Node.Id.NONE, -1), null);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,4 +31,5 @@ rat {
     // List of Gradle exclude directives, defaults to ['**/.gradle/**']
     excludes.add("**/build/**")
     excludes.add(".idea/**")
+    excludeFile.set(layout.projectDirectory.file(".rat-excludes.txt"))
 }


### PR DESCRIPTION
Introduce a special kind of `ExclusiveSyncPoint` transaction that invalidates all `TxnId` lower than it that are not witnessed by it. This permits bootstrapping nodes to ignore all `TxnId` older than this when starting their log.