### PR TITLE
Support asynchronous CommandStore message processing

### DIFF
--- a/accord-core/src/main/java/accord/impl/CommandsForKey.java
+++ b/accord-core/src/main/java/accord/impl/CommandsForKey.java
@@ -20,7 +20,7 @@ package accord.impl;
 
 import accord.api.Key;
 import accord.local.*;
-import accord.local.SafeCommandStore.CommandFunction;
+import accord.local.SafeCommandStore.SearchFunction;
 import accord.local.SafeCommandStore.TestDep;
 import accord.local.SafeCommandStore.TestKind;
 import accord.primitives.Keys;
@@ -55,7 +55,7 @@ public abstract class CommandsForKey implements CommandListener
         <T> T mapReduce(TestKind testKind, TestTimestamp testTimestamp, Timestamp timestamp,
                         TestDep testDep, @Nullable TxnId depId,
                         @Nullable Status minStatus, @Nullable Status maxStatus,
-                        CommandFunction<T, T> map, T initialValue, T terminalValue);
+                        SearchFunction<T, T> map, T initialValue, T terminalValue);
     }
 
     public abstract Key key();

--- a/accord-core/src/main/java/accord/impl/InMemoryCommandStores.java
+++ b/accord-core/src/main/java/accord/impl/InMemoryCommandStores.java
@@ -18,11 +18,16 @@
 
 package accord.impl;
 
-import accord.local.*;
 import accord.api.Agent;
 import accord.api.DataStore;
 import accord.api.ProgressLog;
+import accord.local.AsyncCommandStores;
 import accord.local.CommandStore;
+import accord.local.NodeTimeService;
+import accord.local.PreLoadContext;
+import accord.local.SafeCommandStore;
+import accord.local.ShardDistributor;
+import accord.local.SyncCommandStores;
 import accord.primitives.Routables;
 import accord.utils.MapReduce;
 

--- a/accord-core/src/main/java/accord/impl/InMemoryCommandsForKey.java
+++ b/accord-core/src/main/java/accord/impl/InMemoryCommandsForKey.java
@@ -20,7 +20,7 @@ package accord.impl;
 
 import accord.api.Key;
 import accord.local.Command;
-import accord.local.SafeCommandStore.CommandFunction;
+import accord.local.SafeCommandStore.SearchFunction;
 import accord.local.SafeCommandStore.TestDep;
 import accord.local.SafeCommandStore.TestKind;
 import accord.local.Status;
@@ -77,7 +77,7 @@ public class InMemoryCommandsForKey extends CommandsForKey
         public <T> T mapReduce(TestKind testKind, TestTimestamp testTimestamp, Timestamp timestamp,
                                TestDep testDep, @Nullable TxnId depId,
                                @Nullable Status minStatus, @Nullable Status maxStatus,
-                               CommandFunction<T, T> map, T initialValue, T terminalValue)
+                               SearchFunction<T, T> map, T initialValue, T terminalValue)
         {
 
             for (Command cmd : (testTimestamp == TestTimestamp.BEFORE ? commands.headMap(timestamp, false) : commands.tailMap(timestamp, false)).values())

--- a/accord-core/src/main/java/accord/local/Command.java
+++ b/accord-core/src/main/java/accord/local/Command.java
@@ -191,6 +191,9 @@ public abstract class Command implements CommandListener, BiConsumer<SafeCommand
     public Seekables<?, ?> keys()
     {
         // TODO (expected, consider): when do we need this, and will it always be sufficient?
+        // this is used for Apply; should probably have its own context for clarity, but since
+        // only used for local timestamp derivation in C* integration can probably remove it
+        // when we improve that
         return partialTxn().keys();
     }
 

--- a/accord-core/src/main/java/accord/local/Node.java
+++ b/accord-core/src/main/java/accord/local/Node.java
@@ -31,6 +31,7 @@ import accord.coordinate.*;
 import accord.messages.*;
 import accord.primitives.*;
 import accord.primitives.Routable.Domain;
+import accord.utils.AsyncMapReduceConsume;
 import accord.utils.MapReduceConsume;
 import com.google.common.annotations.VisibleForTesting;
 
@@ -275,7 +276,12 @@ public class Node implements ConfigurationService.Listener, NodeTimeService
         return commandStores.ifLocal(context, key, since.epoch(), Long.MAX_VALUE, ifLocal);
     }
 
-    public <T> void mapReduceConsumeLocal(TxnRequest<?> request, long minEpoch, long maxEpoch, MapReduceConsume<SafeCommandStore, T> mapReduceConsume)
+    public <T> void mapReduceConsumeLocal(TxnRequest request, long minEpoch, long maxEpoch, MapReduceConsume<SafeCommandStore, T> mapReduceConsume)
+    {
+        commandStores.mapReduceConsume(request, request.scope(), minEpoch, maxEpoch, mapReduceConsume);
+    }
+
+    public <T> void mapReduceConsumeLocal(TxnRequest request, long minEpoch, long maxEpoch, AsyncMapReduceConsume<SafeCommandStore, T> mapReduceConsume)
     {
         commandStores.mapReduceConsume(request, request.scope(), minEpoch, maxEpoch, mapReduceConsume);
     }

--- a/accord-core/src/main/java/accord/local/PreLoadContext.java
+++ b/accord-core/src/main/java/accord/local/PreLoadContext.java
@@ -50,7 +50,7 @@ public interface PreLoadContext
      *  Both can be done without. For range transactions calculateDeps needs to be asynchronous anyway to support
      *  potentially large scans, and for register we do not need to load into memory, we can perform a blind write.
      */
-    Seekables<?, ?> keys();
+    default Seekables<?, ?> keys() { return Keys.EMPTY; }
 
     static PreLoadContext contextFor(Iterable<TxnId> txnIds, Seekables<?, ?> keys)
     {
@@ -87,6 +87,11 @@ public interface PreLoadContext
     static PreLoadContext contextFor(Key key)
     {
         return contextFor(Collections.emptyList(), Keys.of(key));
+    }
+
+    static PreLoadContext contextFor(Seekables<?, ?> keys)
+    {
+        return contextFor(Collections.emptyList(), keys);
     }
 
     static PreLoadContext empty()

--- a/accord-core/src/main/java/accord/local/SyncCommandStores.java
+++ b/accord-core/src/main/java/accord/local/SyncCommandStores.java
@@ -4,9 +4,12 @@ import accord.api.Agent;
 import accord.api.DataStore;
 import accord.api.ProgressLog;
 import accord.primitives.Routables;
-import accord.utils.MapReduce;
-import accord.utils.MapReduceConsume;
+import accord.utils.*;
+import org.apache.cassandra.utils.concurrent.Future;
+import org.apache.cassandra.utils.concurrent.ImmediateFuture;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
@@ -31,7 +34,7 @@ public class SyncCommandStores extends CommandStores<SyncCommandStores.SyncComma
         super(time, agent, store, shardDistributor, progressLogFactory, shardFactory);
     }
 
-    protected static class SyncMapReduceAdapter<O> implements MapReduceAdapter<SyncCommandStore, O, O, O>
+    protected static class SyncMapReduceAdapter<O> implements MapReduceAdapter<SyncCommandStore, O, O, O, O>
     {
         private static final SyncMapReduceAdapter INSTANCE = new SyncMapReduceAdapter<>();
         public static <O> SyncMapReduceAdapter<O> instance() { return INSTANCE; }
@@ -44,27 +47,67 @@ public class SyncCommandStores extends CommandStores<SyncCommandStores.SyncComma
         }
 
         @Override
-        public O apply(MapReduce<? super SafeCommandStore, O> map, SyncCommandStore commandStore, PreLoadContext context)
+        public O apply(Function<? super SafeCommandStore, O> map, SyncCommandStore commandStore, PreLoadContext context)
         {
             return commandStore.executeSync(context, map);
         }
 
         @Override
-        public O reduce(MapReduce<? super SafeCommandStore, O> reduce, O prev, O next)
+        public O reduce(Reduce<O> reduce, O prev, O next)
         {
             return prev == SENTINEL ? next : reduce.reduce(prev, next);
         }
 
         @Override
-        public void consume(MapReduceConsume<?, O> reduceAndConsume, O result)
+        public void consume(ReduceConsume<O> reduceAndConsume, O result)
         {
             reduceAndConsume.accept(result, null);
         }
 
         @Override
-        public O reduce(MapReduce<?, O> reduce, O result)
+        public O reduce(Reduce<O> reduce, O result)
         {
             return result == SENTINEL ? null : result;
+        }
+    }
+
+    protected static class SyncFutureMapReduceAdapter<O> implements MapReduceAdapter<SyncCommandStore, Future<O>, List<Future<O>>, Future<O>, O>
+    {
+        private static final SyncFutureMapReduceAdapter INSTANCE = new SyncFutureMapReduceAdapter<>();
+        public static <O> SyncFutureMapReduceAdapter<O> instance() { return INSTANCE; }
+
+        @Override
+        public List<Future<O>> allocate()
+        {
+            return new ArrayList<>();
+        }
+
+        @Override
+        public Future<O> apply(Function<? super SafeCommandStore, Future<O>> map, SyncCommandStore commandStore, PreLoadContext context)
+        {
+            return commandStore.executeSync(context, map);
+        }
+
+        @Override
+        public List<Future<O>> reduce(Reduce<O> reduce, List<Future<O>> prev, Future<O> next)
+        {
+            prev.add(next);
+            return prev;
+        }
+
+        @Override
+        public void consume(ReduceConsume<O> consume, Future<O> reduced)
+        {
+            reduced.addCallback(consume);
+        }
+
+        @Override
+        public Future<O> reduce(Reduce<O> reduce, List<Future<O>> futures)
+        {
+            if (futures.isEmpty())
+                return ImmediateFuture.success(null);
+
+            return ReducingFuture.reduce(futures, reduce);
         }
     }
 
@@ -87,6 +130,19 @@ public class SyncCommandStores extends CommandStores<SyncCommandStores.SyncComma
         try
         {
             mapReduceConsume(context, commandStoreIds, mapReduceConsume, SyncMapReduceAdapter.INSTANCE);
+        }
+        catch (Throwable t)
+        {
+            mapReduceConsume.accept(null, t);
+        }
+    }
+
+    @Override
+    public <O> void mapReduceConsume(PreLoadContext context, Routables<?, ?> keys, long minEpoch, long maxEpoch, AsyncMapReduceConsume<? super SafeCommandStore, O> mapReduceConsume)
+    {
+        try
+        {
+            mapReduceConsume(context, keys, minEpoch, maxEpoch, mapReduceConsume, SyncFutureMapReduceAdapter.INSTANCE);
         }
         catch (Throwable t)
         {

--- a/accord-core/src/main/java/accord/messages/AbstractEpochRequest.java
+++ b/accord-core/src/main/java/accord/messages/AbstractEpochRequest.java
@@ -50,10 +50,4 @@ public abstract class AbstractEpochRequest<R extends Reply> implements PreLoadCo
     {
         return Collections.singleton(txnId);
     }
-
-    @Override
-    public Seekables<?, ?> keys()
-    {
-        return Keys.EMPTY;
-    }
 }

--- a/accord-core/src/main/java/accord/messages/Apply.java
+++ b/accord-core/src/main/java/accord/messages/Apply.java
@@ -24,6 +24,7 @@ import accord.local.Command;
 import accord.local.Node.Id;
 import accord.api.Result;
 import accord.topology.Topologies;
+import accord.utils.MapReduceConsume;
 import com.google.common.collect.Iterables;
 
 import java.util.Collections;
@@ -33,7 +34,7 @@ import static accord.local.PreLoadContext.empty;
 import static accord.messages.MessageType.APPLY_REQ;
 import static accord.messages.MessageType.APPLY_RSP;
 
-public class Apply extends TxnRequest<ApplyReply>
+public class Apply extends TxnRequest implements MapReduceConsume<SafeCommandStore, ApplyReply>
 {
     public static class SerializationSupport
     {
@@ -115,12 +116,6 @@ public class Apply extends TxnRequest<ApplyReply>
     public Iterable<TxnId> txnIds()
     {
         return Iterables.concat(Collections.singleton(txnId), deps.txnIds());
-    }
-
-    @Override
-    public Seekables<?, ?> keys()
-    {
-        return Keys.EMPTY;
     }
 
     @Override

--- a/accord-core/src/main/java/accord/messages/BeginInvalidation.java
+++ b/accord-core/src/main/java/accord/messages/BeginInvalidation.java
@@ -72,12 +72,6 @@ public class BeginInvalidation extends AbstractEpochRequest<BeginInvalidation.In
     }
 
     @Override
-    public Seekables<?, ?> keys()
-    {
-        return Keys.EMPTY;
-    }
-
-    @Override
     public long waitForEpoch()
     {
         return txnId.epoch();

--- a/accord-core/src/main/java/accord/messages/CheckStatus.java
+++ b/accord-core/src/main/java/accord/messages/CheckStatus.java
@@ -85,12 +85,6 @@ public class CheckStatus extends AbstractEpochRequest<CheckStatus.CheckStatusOk>
         return Collections.singleton(txnId);
     }
 
-    @Override
-    public Seekables<?, ?> keys()
-    {
-        return Keys.EMPTY;
-    }
-
     public CheckStatus(Id to, Topologies topologies, TxnId txnId, Unseekables<?, ?> query, IncludeInfo includeInfo)
     {
         super(txnId);

--- a/accord-core/src/main/java/accord/messages/Commit.java
+++ b/accord-core/src/main/java/accord/messages/Commit.java
@@ -33,11 +33,12 @@ import javax.annotation.Nullable;
 import accord.utils.Invariants;
 
 import accord.topology.Topology;
+import accord.utils.MapReduceConsume;
 
 import static accord.local.Status.Committed;
 import static accord.local.Status.Known.DefinitionOnly;
 
-public class Commit extends TxnRequest<ReadNack>
+public class Commit extends TxnRequest implements MapReduceConsume<SafeCommandStore, ReadNack>
 {
     public static class SerializerSupport
     {
@@ -130,12 +131,6 @@ public class Commit extends TxnRequest<ReadNack>
     public Iterable<TxnId> txnIds()
     {
         return Collections.singleton(txnId);
-    }
-
-    @Override
-    public Seekables<?, ?> keys()
-    {
-        return Keys.EMPTY;
     }
 
     @Override
@@ -255,12 +250,6 @@ public class Commit extends TxnRequest<ReadNack>
         public Iterable<TxnId> txnIds()
         {
             return Collections.singleton(txnId);
-        }
-
-        @Override
-        public Seekables<?, ?> keys()
-        {
-            return Keys.EMPTY;
         }
 
         @Override

--- a/accord-core/src/main/java/accord/messages/Defer.java
+++ b/accord-core/src/main/java/accord/messages/Defer.java
@@ -17,12 +17,12 @@ class Defer implements CommandListener
     public enum Ready { No, Yes, Expired }
 
     final Function<Command, Ready> waitUntil;
-    final TxnRequest<?> request;
+    final TxnRequest request;
     final IntHashSet waitingOn = new IntHashSet(); // TODO (easy): use Agrona when available
     int waitingOnCount;
     boolean isDone;
 
-    Defer(Known waitUntil, Known expireAt, TxnRequest<?> request)
+    Defer(Known waitUntil, Known expireAt, TxnRequest request)
     {
         this(command -> {
             if (!waitUntil.isSatisfiedBy(command.known()))
@@ -33,7 +33,7 @@ class Defer implements CommandListener
         }, request);
     }
 
-    Defer(Function<Command, Ready> waitUntil, TxnRequest<?> request)
+    Defer(Function<Command, Ready> waitUntil, TxnRequest request)
     {
         this.waitUntil = waitUntil;
         this.request = request;

--- a/accord-core/src/main/java/accord/messages/InformDurable.java
+++ b/accord-core/src/main/java/accord/messages/InformDurable.java
@@ -8,6 +8,7 @@ import accord.local.SafeCommandStore;
 import accord.local.Status.Durability;
 import accord.primitives.*;
 import accord.topology.Topologies;
+import accord.utils.MapReduceConsume;
 
 import java.util.Collections;
 
@@ -17,7 +18,7 @@ import static accord.api.ProgressLog.ProgressShard.Local;
 import static accord.local.PreLoadContext.contextFor;
 import static accord.messages.SimpleReply.Ok;
 
-public class InformDurable extends TxnRequest<Reply> implements PreLoadContext
+public class InformDurable extends TxnRequest implements PreLoadContext, MapReduceConsume<SafeCommandStore, Reply>
 {
     public static class SerializationSupport
     {
@@ -114,11 +115,5 @@ public class InformDurable extends TxnRequest<Reply> implements PreLoadContext
     public Iterable<TxnId> txnIds()
     {
         return Collections.singleton(txnId);
-    }
-
-    @Override
-    public Seekables<?, ?> keys()
-    {
-        return Keys.EMPTY;
     }
 }

--- a/accord-core/src/main/java/accord/messages/ReadData.java
+++ b/accord-core/src/main/java/accord/messages/ReadData.java
@@ -254,12 +254,6 @@ public class ReadData extends AbstractEpochRequest<ReadData.ReadNack> implements
     }
 
     @Override
-    public Seekables<?, ?> keys()
-    {
-        return Keys.EMPTY;
-    }
-
-    @Override
     public MessageType type()
     {
         return MessageType.READ_REQ;

--- a/accord-core/src/main/java/accord/messages/TxnRequest.java
+++ b/accord-core/src/main/java/accord/messages/TxnRequest.java
@@ -38,9 +38,9 @@ import accord.topology.Topology;
 
 import static java.lang.Long.min;
 
-public abstract class TxnRequest<R> implements Request, PreLoadContext, MapReduceConsume<SafeCommandStore, R>
+public abstract class TxnRequest implements Request, PreLoadContext
 {
-    public static abstract class WithUnsynced<R> extends TxnRequest<R>
+    public static abstract class WithUnsynced extends TxnRequest
     {
         public final long minUnsyncedEpoch; // TODO (low priority, clarity): can this just always be TxnId.epoch?
         public final boolean doNotComputeProgressKey;

--- a/accord-core/src/main/java/accord/primitives/AbstractKeys.java
+++ b/accord-core/src/main/java/accord/primitives/AbstractKeys.java
@@ -14,6 +14,7 @@ import accord.utils.*;
 import net.nicoulaj.compilecommand.annotations.Inline;
 
 import static accord.primitives.Routable.Domain.Key;
+import static accord.utils.SortedArrays.Search.FAST;
 
 @SuppressWarnings("rawtypes")
 // TODO (desired, efficiency): check that foldl call-sites are inlined and optimised by HotSpot
@@ -92,6 +93,12 @@ public abstract class AbstractKeys<K extends RoutableKey, KS extends Routables<K
     public final boolean intersects(AbstractRanges<?> ranges)
     {
         return findNextIntersection(0, ranges, 0) >= 0;
+    }
+
+    @Override
+    public final boolean intersects(Range range)
+    {
+        return findNext(0, range, FAST) >= 0;
     }
 
     @Override

--- a/accord-core/src/main/java/accord/primitives/PartialDeps.java
+++ b/accord-core/src/main/java/accord/primitives/PartialDeps.java
@@ -10,6 +10,7 @@ public class PartialDeps extends Deps
     {
         return new Builder(covering);
     }
+
     public static class Builder extends AbstractBuilder<PartialDeps>
     {
         final Ranges covering;

--- a/accord-core/src/main/java/accord/primitives/Routables.java
+++ b/accord-core/src/main/java/accord/primitives/Routables.java
@@ -36,6 +36,7 @@ public interface Routables<K extends Routable, U extends Routables<K, ?>> extend
     boolean isEmpty();
     boolean intersects(AbstractRanges<?> ranges);
     boolean intersects(AbstractKeys<?, ?> keys);
+    boolean intersects(Range range);
     default boolean intersects(Routables<?, ?> routables)
     {
         switch (routables.domain())

--- a/accord-core/src/main/java/accord/utils/AsyncMapReduce.java
+++ b/accord-core/src/main/java/accord/utils/AsyncMapReduce.java
@@ -1,11 +1,12 @@
 package accord.utils;
 
+import org.apache.cassandra.utils.concurrent.Future;
+
 import java.util.function.Function;
 
-public interface MapReduce<I, O> extends Function<I, O>, Reduce<O>
+public interface AsyncMapReduce<I, O> extends Function<I, Future<O>>, Reduce<O>
 {
     // TODO (desired, safety): ensure mutual exclusivity when calling each of these methods
-    @Override
-    O apply(I in);
+    Future<O> apply(I in);
     O reduce(O o1, O o2);
 }

--- a/accord-core/src/main/java/accord/utils/AsyncMapReduceConsume.java
+++ b/accord-core/src/main/java/accord/utils/AsyncMapReduceConsume.java
@@ -1,0 +1,6 @@
+package accord.utils;
+
+public interface AsyncMapReduceConsume<I, O> extends AsyncMapReduce<I, O>, ReduceConsume<O>
+{
+    void accept(O result, Throwable failure);
+}

--- a/accord-core/src/main/java/accord/utils/MapReduceConsume.java
+++ b/accord-core/src/main/java/accord/utils/MapReduceConsume.java
@@ -3,7 +3,7 @@ package accord.utils;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-public interface MapReduceConsume<I, O> extends MapReduce<I, O>, BiConsumer<O, Throwable>
+public interface MapReduceConsume<I, O> extends MapReduce<I, O>, ReduceConsume<O>
 {
     @Override
     void accept(O result, Throwable failure);

--- a/accord-core/src/main/java/accord/utils/Reduce.java
+++ b/accord-core/src/main/java/accord/utils/Reduce.java
@@ -1,0 +1,6 @@
+package accord.utils;
+
+public interface Reduce<O>
+{
+    O reduce(O o1, O o2);
+}

--- a/accord-core/src/main/java/accord/utils/ReduceConsume.java
+++ b/accord-core/src/main/java/accord/utils/ReduceConsume.java
@@ -1,0 +1,8 @@
+package accord.utils;
+
+import java.util.function.BiConsumer;
+
+public interface ReduceConsume<O> extends Reduce<O>, BiConsumer<O, Throwable>
+{
+    void accept(O result, Throwable failure);
+}

--- a/accord-core/src/main/java/accord/utils/ReducingFuture.java
+++ b/accord-core/src/main/java/accord/utils/ReducingFuture.java
@@ -12,10 +12,10 @@ public class ReducingFuture<V> extends AsyncPromise<V>
 {
     private static final AtomicIntegerFieldUpdater<ReducingFuture> PENDING_UPDATER = AtomicIntegerFieldUpdater.newUpdater(ReducingFuture.class, "pending");
     private final List<? extends Future<V>> futures;
-    private final BiFunction<V, V, V> reducer;
+    private final Reduce<V> reducer;
     private volatile int pending;
 
-    private ReducingFuture(List<? extends Future<V>> futures, BiFunction<V, V, V> reducer)
+    private ReducingFuture(List<? extends Future<V>> futures, Reduce<V> reducer)
     {
         this.futures = futures;
         this.reducer = reducer;
@@ -36,13 +36,13 @@ public class ReducingFuture<V> extends AsyncPromise<V>
         {
             V result = futures.get(0).getNow();
             for (int i=1, mi=futures.size(); i<mi; i++)
-                result = reducer.apply(result, futures.get(i).getNow());
+                result = reducer.reduce(result, futures.get(i).getNow());
 
             trySuccess(result);
         }
     }
 
-    public static <T> Future<T> reduce(List<? extends Future<T>> futures, BiFunction<T, T, T> reducer)
+    public static <T> Future<T> reduce(List<? extends Future<T>> futures, Reduce<T> reducer)
     {
         Preconditions.checkArgument(!futures.isEmpty(), "future list is empty");
 

--- a/accord-core/src/main/java/accord/utils/RelationMultiMap.java
+++ b/accord-core/src/main/java/accord/utils/RelationMultiMap.java
@@ -125,14 +125,8 @@ public class RelationMultiMap
 
             if (keyCount == keys.length)
             {
-                K[] newKeys = cachedKeys.get(keyCount * 2);
-                System.arraycopy(keys, 0, newKeys, 0, keyCount);
-                cachedKeys.forceDiscard(keys, keyCount);
-                keys = newKeys;
-                int[] newKeyLimits = cachedInts.getInts(keyCount * 2);
-                System.arraycopy(keyLimits, 0, newKeyLimits, 0, keyCount);
-                cachedInts.forceDiscard(keyLimits);
-                keyLimits = newKeyLimits;
+                keys = cachedKeys.resize(keys, keyCount, keyCount * 2);
+                keyLimits = cachedInts.resize(keyLimits, keyCount, keyCount * 2);
             }
             keys[keyCount++] = key;
             hasOrderedValues = true;
@@ -180,12 +174,7 @@ public class RelationMultiMap
                 hasOrderedValues = false;
 
             if (totalCount >= keysToValues.length)
-            {
-                V[] newValues = cachedValues.get(keysToValues.length * 2);
-                System.arraycopy(keysToValues, 0, newValues, 0, totalCount);
-                cachedValues.forceDiscard(keysToValues, totalCount);
-                keysToValues = newValues;
-            }
+                keysToValues = cachedValues.resize(keysToValues, keysToValues.length, keysToValues.length * 2);
 
             keysToValues[totalCount++] = value;
         }

--- a/accord-core/src/test/java/accord/burn/BurnTest.java
+++ b/accord-core/src/test/java/accord/burn/BurnTest.java
@@ -298,7 +298,7 @@ public class BurnTest
     {
 //        Long overrideSeed = null;
         int count = 1;
-        Long overrideSeed = 8602265915508619975L;
+        Long overrideSeed = -5041252069608453510L;
         LongSupplier seedGenerator = ThreadLocalRandom.current()::nextLong;
         for (int i = 0 ; i < args.length ; i += 2)
         {


### PR DESCRIPTION
While messages are submitted to a CommandStore asynchronously, the processing of a message is then expected to be synchronous. However, it would be beneficial particularly for large range transactions, but also for recovery, to be able to defer some work that might involve IO to after the command store processing completes, e.g. for calculating dependencies.