### PR TITLE
transition Node.Id from long to int

### DIFF
--- a/accord-core/build.gradle
+++ b/accord-core/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     // Dependencies we depend on that are not part of our API.
     // These act as runtimeOnly dependencies to users
     implementation 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'com.carrotsearch:hppc:0.8.1'
+    implementation 'org.agrona:agrona:1.17.1'
 }
 
 task burn(type: JavaExec) {

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -26,9 +26,9 @@ import accord.utils.MapReduce;
 import accord.utils.MapReduceConsume;
 
 import accord.utils.ReducingFuture;
-import com.carrotsearch.hppc.IntObjectMap;
-import com.carrotsearch.hppc.IntObjectScatterMap;
 import com.google.common.annotations.VisibleForTesting;
+import org.agrona.collections.Hashing;
+import org.agrona.collections.Int2ObjectHashMap;
 import org.apache.cassandra.utils.concurrent.Future;
 
 import java.util.ArrayList;
@@ -200,14 +200,14 @@ public abstract class CommandStores<S extends CommandStore>
     static class Snapshot
     {
         final ShardHolder[] shards;
-        final IntObjectMap<CommandStore> byId;
+        final Int2ObjectHashMap<CommandStore> byId;
         final Topology local;
         final Topology global;
 
         Snapshot(ShardHolder[] shards, Topology local, Topology global)
         {
             this.shards = shards;
-            this.byId = new IntObjectScatterMap<>(shards.length);
+            this.byId = new Int2ObjectHashMap<>(shards.length, Hashing.DEFAULT_LOAD_FACTOR, true);
             for (ShardHolder shard : shards)
                 byId.put(shard.store.id(), shard.store);
             this.local = local;

--- a/accord-core/src/main/java/accord/local/Node.java
+++ b/accord-core/src/main/java/accord/local/Node.java
@@ -57,18 +57,16 @@ import net.nicoulaj.compilecommand.annotations.Inline;
 import org.apache.cassandra.utils.concurrent.AsyncFuture;
 import org.apache.cassandra.utils.concurrent.Future;
 
-import static accord.primitives.Routable.Domain.Key;
-
 public class Node implements ConfigurationService.Listener, NodeTimeService
 {
     public static class Id implements Comparable<Id>
     {
         public static final Id NONE = new Id(0);
-        public static final Id MAX = new Id(Long.MAX_VALUE);
+        public static final Id MAX = new Id(Integer.MAX_VALUE);
 
-        public final long id;
+        public final int id;
 
-        public Id(long id)
+        public Id(int id)
         {
             this.id = id;
         }
@@ -76,7 +74,7 @@ public class Node implements ConfigurationService.Listener, NodeTimeService
         @Override
         public int hashCode()
         {
-            return Long.hashCode(id);
+            return Integer.hashCode(id);
         }
 
         @Override
@@ -93,12 +91,12 @@ public class Node implements ConfigurationService.Listener, NodeTimeService
         @Override
         public int compareTo(Id that)
         {
-            return Long.compare(this.id, that.id);
+            return Integer.compare(this.id, that.id);
         }
 
         public String toString()
         {
-            return Long.toString(id);
+            return Integer.toString(id);
         }
     }
 

--- a/accord-core/src/main/java/accord/local/Status.java
+++ b/accord-core/src/main/java/accord/local/Status.java
@@ -51,7 +51,8 @@ public enum Status
      * So, for execution of other transactions we may treat a PreCommitted transaction as Committed,
      * using the timestamp to update our dependency set to rule it out as a dependency.
      * But we do not have enough information to execute the transaction, and when recovery calculates
-     * {@link BeginRecovery#acceptedStartedBeforeWithoutWitnessing}, {@link BeginRecovery#committedExecutesAfterWithoutWitnessing}
+     * {@link BeginRecovery#acceptedStartedBeforeWithoutWitnessing}, {@link BeginRecovery#hasCommittedExecutesAfterWithoutWitnessing}
+     *
      * and {@link BeginRecovery#committedStartedBeforeAndWitnessed} we may not have the dependencies
      * to calculate the result. For these operations we treat ourselves as whatever Accepted status
      * we may have previously taken, using any proposed dependencies to compute the result.

--- a/accord-core/src/main/java/accord/messages/Defer.java
+++ b/accord-core/src/main/java/accord/messages/Defer.java
@@ -24,7 +24,7 @@ import accord.local.*;
 import accord.local.Status.Known;
 import accord.primitives.TxnId;
 import accord.utils.Invariants;
-import com.carrotsearch.hppc.IntHashSet;
+import org.agrona.collections.IntHashSet;
 
 import static accord.messages.Defer.Ready.Expired;
 import static accord.messages.Defer.Ready.No;
@@ -36,7 +36,7 @@ class Defer implements CommandListener
 
     final Function<Command, Ready> waitUntil;
     final TxnRequest<?> request;
-    final IntHashSet waitingOn = new IntHashSet(); // TODO (easy): use Agrona when available
+    final IntHashSet waitingOn = new IntHashSet();
     int waitingOnCount;
     boolean isDone;
 

--- a/accord-core/src/main/java/accord/utils/ArrayBuffers.java
+++ b/accord-core/src/main/java/accord/utils/ArrayBuffers.java
@@ -33,7 +33,7 @@ import static accord.utils.Invariants.checkArgument;
  * A set of utility classes and interfaces for managing a collection of buffers for arrays of certain types.
  *
  * These buffers are designed to be used to combine simple one-shot methods that consume and produce one or more arrays
- * with methods that may (or may not) call them repeatedly. Specifically, {@link accord.primitives.Deps#linearUnion},
+ * with methods that may (or may not) call them repeatedly. Specifically, {@link accord.utils.RelationMultiMap#linearUnion},
  * {@link SortedArrays#linearUnion} and {@link SortedArrays#linearIntersection}
  *
  * To support this efficiently and ergonomically for users of the one-shot methods, the cache management must

--- a/accord-maelstrom/src/main/java/accord/maelstrom/Json.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/Json.java
@@ -79,8 +79,8 @@ public class Json
     {
         switch (id.charAt(0))
         {
-            case 'c': return new Id(-Long.parseLong(id.substring(1)));
-            case 'n':return  new Id( Long.parseLong(id.substring(1)));
+            case 'c': return new Id(-Integer.parseInt(id.substring(1)));
+            case 'n':return  new Id( Integer.parseInt(id.substring(1)));
             default: throw new IllegalStateException();
         }
     }


### PR DESCRIPTION
Trimmed down version of the patch, swapping long for int, but still keeping Node.Id class. Delaying the rest (elimination of Node.Id as a class) until immutability work lands, to ease rebase pain.