### PR TITLE
Minor fixes in the burn

### DIFF
--- a/accord-core/src/test/java/accord/burn/BurnTest.java
+++ b/accord-core/src/test/java/accord/burn/BurnTest.java
@@ -119,7 +119,7 @@ public class BurnTest
             {
                 boolean isWrite = random.nextBoolean();
                 int readCount = 1 + random.nextInt(2);
-                int writeCount = isWrite ? random.nextInt(3) : 0;
+                int writeCount = isWrite ? 1 + random.nextInt(2) : 0;
 
                 TreeSet<Key> requestKeys = new TreeSet<>();
                 while (readCount-- > 0)
@@ -400,7 +400,7 @@ public class BurnTest
 
             List<Id> nodes = generateIds(false, random.nextInt(rf, rf * 3));
 
-            burn(random, new TopologyFactory(rf, IntHashKey.ranges(random.nextInt(Math.max(nodes.size() + 1, rf), nodes.size() * 3))),
+            burn(random, new TopologyFactory(rf, IntHashKey.ranges(random.nextInt(nodes.size() + 1, nodes.size() * 3))),
                     clients,
                     nodes,
                     5 + random.nextInt(15),


### PR DESCRIPTION
1. Fixed a problem that `writeCount` might be `0` even though `isWrite` is true.
2. Since the number of nodes is in `[rf, 3 * rf)`, `Math.max(nodes.size() + 1, rf)` always returns `nodes.size() + 1` when determining the number of ranges in a cluster. Therefore, the unnecessary `max` has been removed.

## Note

The following is not included in this commit for now.
Furthermore, I would suggest the number of ranges should include `nodes.size()` therefore the following line:
```java
IntHashKey.ranges(random.nextInt(nodes.size() + 1, nodes.size() * 3))
```
should be:
```java
IntHashKey.ranges(random.nextInt(nodes.size(), nodes.size() * 3))
```
