### PR TITLE
C*-18806 Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,22 @@
 Cassandra Accord
-----------------
+================
 Distributed consensus protocol for Apache Cassandra. Accord is the first protocol to achieve the same steady-state performance as leader-based protocols under important conditions such as contention and failure, while delivering the benefits of leaderless approaches to scaling, transaction isolation and geo-distributed client latency. See [the Accord whitepaper](https://cwiki.apache.org/confluence/download/attachments/188744725/Accord.pdf?version=2&modificationDate=1637000779000&api=v2).
+
+Accord Protocol
+---------------
+Key Features:
+- Leaderless - There is no designated leader node. Any node can coordinate transactions. This removes bottlenecks and improves scalability.
+- Single round-trip commits - Most transactions can commit in a single message round-trip between coordinating node and replicas. This minimizes latency.
+- High contention performance - Special techniques allow it to avoid slowed performance when many transactions conflict.
+- Configurable failure tolerance - The protocol can be dynamically reconfigured to maintain fast performance even after node failures.
+- Strong consistency guarantees - Provides strict serializability, the strongest isolation level. Transactions behave as if they execute one at a time.
+- General purpose transactions - Supports cross-shard multi-statement ACID transactions, not just single partition reads/writes.
+
+At a high level, it works as follows:
+1. A coordinator node is chosen to handle each transaction (typically nearby the client for low latency).
+2. The coordinator gets votes from replica nodes on an execution timestamp and set of conflicts for the transaction.
+3. With enough votes, the transaction can commit in a single round-trip.
+4. The coordinator waits for conflicting transactions, then tells the replicas to execute and persist the changes.
 
 Build
 -----

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 Cassandra Accord
 ----------------
-
 Distributed consensus protocol for Apache Cassandra. Accord is the first protocol to achieve the same steady-state performance as leader-based protocols under important conditions such as contention and failure, while delivering the benefits of leaderless approaches to scaling, transaction isolation and geo-distributed client latency. See [the Accord whitepaper](https://cwiki.apache.org/confluence/download/attachments/188744725/Accord.pdf?version=2&modificationDate=1637000779000&api=v2).
 
 Build
 -----
-This repo is used as a git submodule in Cassandra, see [C*/CONTRIBUTING.md](https://github.com/apache/cassandra/blob/607302aaa8c1816a75a70173ae39a7d96ce1b18a/CONTRIBUTING.md#working-with-submodules) for instructions.
+This repo is used as a submodule for Cassandra, see [C*/CONTRIBUTING.md](https://github.com/apache/cassandra/blob/607302aaa8c1816a75a70173ae39a7d96ce1b18a/CONTRIBUTING.md#working-with-submodules) for instructions on how to include it.
 
 To build this repo:
 ```bash
@@ -13,6 +12,27 @@ To build this repo:
 ./gradlew check
 ```
 
-Maelstrom testing
------------------
+Maelstrom
+---------
+Jepsen Maelstrom is a workbench for writing toy implementations of distributed systems. It's used for running dtests (distributed tests) against Accord. 
 
+First, build `accord-maelstrom`:
+```bash
+cd ./accord-maelstrom
+./build.sh
+```
+Save the path to the server script in an environment variable:
+```bash
+cd ./accord-maelstrom
+export ACCORD_MAELSTROM_SERVER=$(pwd)/server.sh
+```
+
+Clone Maelstrom repo or get the binary, see [Maelstrom installation](https://github.com/jepsen-io/maelstrom/blob/main/doc/01-getting-ready/index.md#installation) for more. If cloned, use `lein run` instead of `./maelstrom` below.
+```bash
+# Single-node KV store test
+./maelstrom test -w lin-kv --bin $ACCORD_MAELSTROM_SERVER --time-limit 10 --rate 10 --node-count 1 --concurrency 2n
+# Multi-node KV store test
+./maelstrom test -w lin-kv --bin $ACCORD_MAELSTROM_SERVER --time-limit 10 --rate 10 --node-count 3 --concurrency 2n
+# Multi-node with partitions
+./maelstrom test -w lin-kv --bin $ACCORD_MAELSTROM_SERVER --time-limit 60 --rate 30 --node-count 3 --concurrency 4n --nemesis partition --nemesis-interval 10 --test-count 10
+```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ At a high level, it works as follows:
 3. With enough votes, the transaction can commit in a single round-trip.
 4. The coordinator waits for conflicting transactions, then tells the replicas to execute and persist the changes.
 
+Code structure
+--------------
+`accord-core` is the implementation of the Accord protocol that is imported in Cassandra. See [cep-15-accord branch](https://github.com/apache/cassandra/tree/cep-15-accord) in Cassandra.
+
+`accord-maelstrom` is a wrapper for running Accord within [Jepsen Maelstrom](https://github.com/jepsen-io/maelstrom) which uses STDIN for ingress and STDOUT for egress. 
+
 Build
 -----
 This repo is used as a submodule for Cassandra, see [C*/CONTRIBUTING.md](https://github.com/apache/cassandra/blob/607302aaa8c1816a75a70173ae39a7d96ce1b18a/CONTRIBUTING.md#working-with-submodules) for instructions on how to include it.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+Cassandra Accord
+----------------
+
+Distributed consensus protocol for Apache Cassandra. Accord is the first protocol to achieve the same steady-state performance as leader-based protocols under important conditions such as contention and failure, while delivering the benefits of leaderless approaches to scaling, transaction isolation and geo-distributed client latency. See [the Accord whitepaper](https://cwiki.apache.org/confluence/download/attachments/188744725/Accord.pdf?version=2&modificationDate=1637000779000&api=v2).
+
+Build
+-----
+This repo is used as a git submodule in Cassandra, see [C*/CONTRIBUTING.md](https://github.com/apache/cassandra/blob/607302aaa8c1816a75a70173ae39a7d96ce1b18a/CONTRIBUTING.md#working-with-submodules) for instructions.
+
+To build this repo:
+```bash
+./gradlew dependencies
+./gradlew check
+```
+
+Maelstrom testing
+-----------------
+

--- a/accord-maelstrom/build.gradle
+++ b/accord-maelstrom/build.gradle
@@ -39,6 +39,7 @@ jar {
 task fatJar(type: Jar) {
     manifest.from jar.manifest
     archiveClassifier = 'all'
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     } {

--- a/accord-maelstrom/build.sh
+++ b/accord-maelstrom/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+gradle fatJar

--- a/accord-maelstrom/server.sh
+++ b/accord-maelstrom/server.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# http://mywiki.wooledge.org/BashFAQ/028
+if [[ $BASH_SOURCE = */* ]]; then
+    DIR=${BASH_SOURCE%/*}/
+else
+    DIR=./
+fi
+
+exec java -Xmx256M -jar "$DIR/build/libs/accord-maelstrom-1.0-SNAPSHOT-all.jar"

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ rat {
     // List of Gradle exclude directives, defaults to ['**/.gradle/**']
     excludes.add("**/build/**")
     excludes.add(".idea/**")
+    excludes.add("README.md")
     if (layout.projectDirectory.file(".rat-excludes.txt").asFile.exists())
     {
         excludeFile.set(layout.projectDirectory.file(".rat-excludes.txt"))


### PR DESCRIPTION
Initializes README.md with the following:
 - Summary of Accord
 - Short description of code structure
 - Build instructions
 - Maelstrom testing instructions

Some clarifications on why there are other changes besides README.md:
 - RAT (Release Audit Tool) was failing because README.md doesn't include a license header, so I had to exclude the file from RAT
 - Jepsen Maelstrom runner expects an executable script, so I added "server.sh" similar to the Maelstrom Java demo https://github.com/jepsen-io/maelstrom/tree/main/demo/java. And I added "build.sh" for completeness.

patch by @zaaath; reviewed by ??? for [CASSANDRA-18806](https://issues.apache.org/jira/browse/CASSANDRA-18806)