### PR TITLE
CASSANDRA-19744 Accord migration and interop correctness

### DIFF
--- a/accord-core/src/main/java/accord/api/Agent.java
+++ b/accord-core/src/main/java/accord/api/Agent.java
@@ -18,6 +18,8 @@
 
 package accord.api;
 
+import javax.annotation.Nonnull;
+
 import accord.local.Command;
 import accord.local.Node;
 import accord.primitives.Ranges;
@@ -25,7 +27,6 @@ import accord.primitives.Seekables;
 import accord.primitives.Timestamp;
 import accord.primitives.Txn;
 import accord.primitives.TxnId;
-import javax.annotation.Nonnull;
 
 /**
  * Facility for augmenting node behaviour at specific points
@@ -90,7 +91,10 @@ public interface Agent extends UncaughtExceptionListener
      */
     int cfkPruneInterval();
 
-    Txn emptyTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges);
+    /**
+     * Create an empty transaction that Accord can use for its own internal transactions.
+     */
+    Txn emptySystemTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges);
 
     default EventsListener metricsEventsListener()
     {

--- a/accord-core/src/main/java/accord/config/LocalConfig.java
+++ b/accord-core/src/main/java/accord/config/LocalConfig.java
@@ -22,8 +22,22 @@ import java.time.Duration;
 
 public interface LocalConfig
 {
+    LocalConfig DEFAULT = new LocalConfig() {};
+
     default Duration getProgressLogScheduleDelay()
     {
         return Duration.ofSeconds(1);
+    }
+
+    // How long before we start notifying waiters on an epoch of timeout,
+    default Duration epochFetchInitialTimeout()
+    {
+        return Duration.ofSeconds(10);
+    }
+
+    // How often to check for timeout, and once an epoch has timed out, how often we timeout new waiters
+    default Duration epochFetchWatchdogInterval()
+    {
+        return Duration.ofSeconds(10);
     }
 }

--- a/accord-core/src/main/java/accord/coordinate/AbstractCoordinatePreAccept.java
+++ b/accord-core/src/main/java/accord/coordinate/AbstractCoordinatePreAccept.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.BiConsumer;
-
 import javax.annotation.Nullable;
 
 import accord.coordinate.tracking.QuorumTracker;
@@ -212,7 +211,12 @@ abstract class AbstractCoordinatePreAccept<T, R> extends SettableResult<T> imple
     {
         // TODO (desired, efficiency): check if we have already have a valid quorum for the future epoch
         //  (noting that nodes may have adopted new ranges, in which case they should be discounted, and quorums may have changed shape)
-        node.withEpoch(latestEpoch, () -> {
+        node.withEpoch(latestEpoch, (ignored, withEpochFailure) -> {
+            if (withEpochFailure != null)
+            {
+                tryFailure(CoordinationFailed.wrap(withEpochFailure));
+                return;
+            }
             TopologyMismatch mismatch = TopologyMismatch.checkForMismatch(node.topology().globalForEpoch(latestEpoch), txnId, route.homeKey(), keysOrRanges());
             if (mismatch != null)
             {

--- a/accord-core/src/main/java/accord/coordinate/CoordinatePreAccept.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinatePreAccept.java
@@ -152,7 +152,12 @@ abstract class CoordinatePreAccept<T> extends AbstractCoordinatePreAccept<T, Pre
     void onPreAccepted(Topologies topologies)
     {
         Timestamp executeAt = foldl(oks, (ok, prev) -> mergeMax(ok.witnessedAt, prev), Timestamp.NONE);
-        node.withEpoch(executeAt.epoch(), () -> onPreAccepted(topologies, executeAt, oks));
+        node.withEpoch(executeAt.epoch(), (ignored, withEpochFailure) -> {
+            if (withEpochFailure != null)
+                tryFailure(CoordinationFailed.wrap(withEpochFailure));
+            else
+                onPreAccepted(topologies, executeAt, oks);
+        });
     }
 
     abstract void onPreAccepted(Topologies topologies, Timestamp executeAt, List<PreAcceptOk> oks);

--- a/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
@@ -102,7 +102,7 @@ public class CoordinateSyncPoint<S extends Seekables<?, ?>> extends CoordinatePr
         TopologyMismatch mismatch = TopologyMismatch.checkForMismatch(node.topology().globalForEpoch(txnId.epoch()), txnId, route.homeKey(), keysOrRanges);
         if (mismatch != null)
             return AsyncResults.failure(mismatch);
-        CoordinateSyncPoint<S> coordinate = new CoordinateSyncPoint<>(node, txnId, node.agent().emptyTxn(txnId.kind(), keysOrRanges), route, adapter);
+        CoordinateSyncPoint<S> coordinate = new CoordinateSyncPoint<>(node, txnId, node.agent().emptySystemTxn(txnId.kind(), keysOrRanges), route, adapter);
         coordinate.start();
         return coordinate;
     }
@@ -138,7 +138,7 @@ public class CoordinateSyncPoint<S extends Seekables<?, ?>> extends CoordinatePr
     {
         TxnId txnId = syncPoint.syncId;
         Timestamp executeAt = txnId;
-        Txn txn = node.agent().emptyTxn(txnId.kind(), syncPoint.keysOrRanges);
+        Txn txn = node.agent().emptySystemTxn(txnId.kind(), syncPoint.keysOrRanges);
         Deps deps = syncPoint.waitFor;
         Apply.sendMaximal(node, to, txnId, syncPoint.route(), txn, executeAt, deps, txn.execute(txnId, executeAt, null), txn.result(txnId, executeAt, null));
     }

--- a/accord-core/src/main/java/accord/coordinate/EpochTimeout.java
+++ b/accord-core/src/main/java/accord/coordinate/EpochTimeout.java
@@ -18,33 +18,28 @@
 
 package accord.coordinate;
 
-import javax.annotation.Nullable;
-
-import accord.api.RoutingKey;
-import accord.primitives.TxnId;
-
 import static accord.utils.Invariants.checkState;
 
-/**
- * Thrown when a coordinator is preempted by another recovery
- * coordinator intending to complete the transaction
- */
-public class Preempted extends CoordinationFailed
+public class EpochTimeout extends Timeout
 {
-    public Preempted(TxnId txnId, @Nullable RoutingKey homeKey)
+    public final long epoch;
+
+    public EpochTimeout(long epoch)
     {
-        super(txnId, homeKey);
+        super(null, null);
+        this.epoch = epoch;
     }
 
-    private Preempted(TxnId txnId, @Nullable RoutingKey homeKey, Preempted cause)
+    private EpochTimeout(long epoch, EpochTimeout cause)
     {
-        super(txnId, homeKey, cause);
+        super(null, null, cause);
+        this.epoch = epoch;
     }
 
     @Override
-    public Preempted wrap()
+    public EpochTimeout wrap()
     {
-        checkState(this.getClass() == Preempted.class);
-        return new Preempted(txnId(), homeKey(), this);
+        checkState(this.getClass() == EpochTimeout.class);
+        return new EpochTimeout(epoch, this);
     }
 }

--- a/accord-core/src/main/java/accord/coordinate/ExecuteSyncPoint.java
+++ b/accord-core/src/main/java/accord/coordinate/ExecuteSyncPoint.java
@@ -57,7 +57,7 @@ public abstract class ExecuteSyncPoint<S extends Seekables<?, ?>> extends Settab
         @Override
         public void start()
         {
-            Txn txn = node.agent().emptyTxn(syncPoint.syncId.kind(), syncPoint.keysOrRanges);
+            Txn txn = node.agent().emptySystemTxn(syncPoint.syncId.kind(), syncPoint.keysOrRanges);
             Writes writes = txn.execute(syncPoint.syncId, syncPoint.syncId, null);
             Result result = txn.result(syncPoint.syncId, syncPoint.syncId, null);
             node.send(tracker.topologies().nodes(), to -> {

--- a/accord-core/src/main/java/accord/coordinate/Exhausted.java
+++ b/accord-core/src/main/java/accord/coordinate/Exhausted.java
@@ -18,10 +18,12 @@
 
 package accord.coordinate;
 
+import javax.annotation.Nullable;
+
 import accord.api.RoutingKey;
 import accord.primitives.TxnId;
 
-import javax.annotation.Nullable;
+import static accord.utils.Invariants.checkState;
 
 /**
  * Thrown when a transaction exceeds its specified timeout for obtaining a result for a client
@@ -36,5 +38,17 @@ public class Exhausted extends CoordinationFailed
     public Exhausted(TxnId txnId, @Nullable RoutingKey homeKey, String message)
     {
         super(txnId, homeKey, message);
+    }
+
+    protected Exhausted(TxnId txnId, @Nullable RoutingKey homeKey, Exhausted cause)
+    {
+        super(txnId, homeKey, cause);
+    }
+
+    @Override
+    public Exhausted wrap()
+    {
+        checkState(this.getClass() == Exhausted.class);
+        return new Exhausted(txnId(), homeKey(), this);
     }
 }

--- a/accord-core/src/main/java/accord/coordinate/Invalidated.java
+++ b/accord-core/src/main/java/accord/coordinate/Invalidated.java
@@ -18,10 +18,12 @@
 
 package accord.coordinate;
 
+import javax.annotation.Nullable;
+
 import accord.api.RoutingKey;
 import accord.primitives.TxnId;
 
-import javax.annotation.Nullable;
+import static accord.utils.Invariants.checkState;
 
 /**
  * Thrown when a transaction has been invalidated
@@ -31,5 +33,17 @@ public class Invalidated extends CoordinationFailed
     public Invalidated(TxnId txnId, @Nullable RoutingKey homeKey)
     {
         super(txnId, homeKey);
+    }
+
+    private Invalidated(TxnId txnId, @Nullable RoutingKey homeKey, Invalidated cause)
+    {
+        super(txnId, homeKey, cause);
+    }
+
+    @Override
+    public Invalidated wrap()
+    {
+        checkState(this.getClass() == Invalidated.class);
+        return new Invalidated(txnId(), homeKey(), this);
     }
 }

--- a/accord-core/src/main/java/accord/coordinate/Propose.java
+++ b/accord-core/src/main/java/accord/coordinate/Propose.java
@@ -176,7 +176,12 @@ abstract class Propose<R> implements Callback<AcceptReply>
                 }
                 else
                 {
-                    node.withEpoch(invalidateUntil.epoch(), () -> {
+                    node.withEpoch(invalidateUntil.epoch(), (ignored, withEpochFailure) -> {
+                        if (withEpochFailure != null)
+                        {
+                            callback.accept(null, CoordinationFailed.wrap(withEpochFailure));
+                            return;
+                        }
                         commitInvalidate(node, txnId, commitInvalidationTo, invalidateUntil);
                         callback.accept(null, new Invalidated(txnId, invalidateWithParticipant));
                     });

--- a/accord-core/src/main/java/accord/coordinate/RangeUnavailable.java
+++ b/accord-core/src/main/java/accord/coordinate/RangeUnavailable.java
@@ -18,8 +18,13 @@
 
 package accord.coordinate;
 
+import javax.annotation.Nullable;
+
+import accord.api.RoutingKey;
 import accord.primitives.Ranges;
 import accord.primitives.TxnId;
+
+import static accord.utils.Invariants.checkState;
 
 public class RangeUnavailable extends Exhausted
 {
@@ -29,6 +34,19 @@ public class RangeUnavailable extends Exhausted
     {
         super(txnId, null, buildMessage(unavailable));
         this.unavailable = unavailable;
+    }
+
+    private RangeUnavailable(Ranges unavailable, TxnId txnId, @Nullable RoutingKey homeKey, RangeUnavailable cause)
+    {
+        super(txnId, homeKey, cause);
+        this.unavailable = unavailable;
+    }
+
+    @Override
+    public RangeUnavailable wrap()
+    {
+        checkState(this.getClass() == RangeUnavailable.class);
+        return new RangeUnavailable(unavailable, txnId(), homeKey(), this);
     }
 
     private static String buildMessage(Ranges unavailable)

--- a/accord-core/src/main/java/accord/coordinate/ReadCoordinator.java
+++ b/accord-core/src/main/java/accord/coordinate/ReadCoordinator.java
@@ -18,20 +18,23 @@
 
 package accord.coordinate;
 
-import accord.coordinate.tracking.RequestStatus;
-import accord.messages.Callback;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
 import com.google.common.collect.Lists;
 
 import accord.coordinate.tracking.ReadTracker;
+import accord.coordinate.tracking.RequestStatus;
 import accord.local.Node;
 import accord.local.Node.Id;
+import accord.messages.Callback;
 import accord.messages.CheckStatus.WithQuorum;
 import accord.primitives.Ranges;
 import accord.primitives.TxnId;
 import accord.topology.Topologies;
 import accord.utils.Invariants;
-
-import java.util.*;
 
 import static accord.messages.CheckStatus.WithQuorum.HasQuorum;
 import static accord.messages.CheckStatus.WithQuorum.NoQuorum;
@@ -235,8 +238,9 @@ public abstract class ReadCoordinator<Reply extends accord.messages.Reply> exten
                 break;
             case Success:
                 Invariants.checkState(!isDone);
-                isDone = true;
                 onDone(waitingOnData == 0 ? Success.Success : Success.Quorum, null);
+                // isDone = true needs to be last or exceptions thrown by onDone are ignored and this never finishes
+                isDone = true;
                 break;
             case Failed:
                 finishOnExhaustion();

--- a/accord-core/src/main/java/accord/coordinate/Timeout.java
+++ b/accord-core/src/main/java/accord/coordinate/Timeout.java
@@ -23,13 +23,27 @@ import javax.annotation.Nullable;
 import accord.api.RoutingKey;
 import accord.primitives.TxnId;
 
+import static accord.utils.Invariants.checkState;
+
 /**
  * Thrown when a transaction exceeds its specified timeout for obtaining a result for a client
  */
 public class Timeout extends CoordinationFailed
 {
-    public Timeout(TxnId txnId, @Nullable RoutingKey homeKey)
+    public Timeout(@Nullable TxnId txnId, @Nullable RoutingKey homeKey)
     {
         super(txnId, homeKey);
+    }
+
+    protected Timeout(@Nullable TxnId txnId, @Nullable RoutingKey homeKey, Timeout cause)
+    {
+        super(txnId, homeKey, cause);
+    }
+
+    @Override
+    public Timeout wrap()
+    {
+        checkState(this.getClass() == Timeout.class);
+        return new Timeout(txnId(), homeKey(), this);
     }
 }

--- a/accord-core/src/main/java/accord/coordinate/TopologyMismatch.java
+++ b/accord-core/src/main/java/accord/coordinate/TopologyMismatch.java
@@ -19,7 +19,6 @@
 package accord.coordinate;
 
 import java.util.EnumSet;
-
 import javax.annotation.Nullable;
 
 import accord.api.RoutingKey;
@@ -27,6 +26,8 @@ import accord.primitives.Routables;
 import accord.primitives.TxnId;
 import accord.primitives.Unseekables;
 import accord.topology.Topology;
+
+import static accord.utils.Invariants.checkState;
 
 public class TopologyMismatch extends CoordinationFailed
 {
@@ -44,6 +45,19 @@ public class TopologyMismatch extends CoordinationFailed
     {
         super(null, null, buildMessage(t, select));
         this.reasons = reasons;
+    }
+
+    private TopologyMismatch(EnumSet<Reason> reasons, TxnId txnId, @Nullable RoutingKey homeKey, TopologyMismatch cause)
+    {
+        super(txnId, homeKey, cause);
+        this.reasons = reasons;
+    }
+
+    @Override
+    public TopologyMismatch wrap()
+    {
+        checkState(this.getClass() == TopologyMismatch.class);
+        return new TopologyMismatch(reasons, txnId(), homeKey(), this);
     }
 
     private static String buildMessage(EnumSet<Reason> reason, Topology topology, RoutingKey homeKey, Routables<?> keysOrRanges)

--- a/accord-core/src/main/java/accord/coordinate/Truncated.java
+++ b/accord-core/src/main/java/accord/coordinate/Truncated.java
@@ -23,6 +23,8 @@ import javax.annotation.Nullable;
 import accord.api.RoutingKey;
 import accord.primitives.TxnId;
 
+import static accord.utils.Invariants.checkState;
+
 /**
  * Thrown when a transaction's state has been truncated prior to the completion of some operation upon it
  */
@@ -36,5 +38,17 @@ public class Truncated extends CoordinationFailed
     public Truncated(TxnId txnId, @Nullable RoutingKey homeKey, String message)
     {
         super(txnId, homeKey, message);
+    }
+
+    private Truncated(TxnId txnId, @Nullable RoutingKey homeKey, Truncated cause)
+    {
+        super(txnId, homeKey, cause);
+    }
+
+    @Override
+    public Truncated wrap()
+    {
+        checkState(this.getClass() == Truncated.class);
+        return new Truncated(txnId(), homeKey(), this);
     }
 }

--- a/accord-core/src/main/java/accord/impl/SimpleProgressLog.java
+++ b/accord-core/src/main/java/accord/impl/SimpleProgressLog.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import accord.api.ProgressLog;
+import accord.coordinate.CoordinationFailed;
 import accord.coordinate.FetchData;
 import accord.coordinate.Outcome;
 import accord.local.Command;
@@ -39,7 +40,6 @@ import accord.local.Node;
 import accord.local.SafeCommand;
 import accord.local.SafeCommandStore;
 import accord.local.SaveStatus;
-
 import accord.local.SaveStatus.LocalExecution;
 import accord.local.Status.Known;
 import accord.primitives.EpochSupplier;
@@ -58,8 +58,8 @@ import accord.utils.async.AsyncResult;
 
 import static accord.api.ProgressLog.ProgressShard.Unsure;
 import static accord.coordinate.InformHomeOfTxn.inform;
-import static accord.impl.SimpleProgressLog.CoordinateStatus.ReadyToExecute;
 import static accord.impl.SimpleProgressLog.CoordinateStatus.NotStable;
+import static accord.impl.SimpleProgressLog.CoordinateStatus.ReadyToExecute;
 import static accord.impl.SimpleProgressLog.Progress.Done;
 import static accord.impl.SimpleProgressLog.Progress.Expected;
 import static accord.impl.SimpleProgressLog.Progress.Investigating;
@@ -254,7 +254,19 @@ public class SimpleProgressLog implements ProgressLog.Factory
                             Invariants.checkState(!command.durability().isDurableOrInvalidated(), "Command is durable or invalidated, but we have not cleared the ProgressLog");
 
                             Route<?> route = Invariants.nonNull(command.route()).withHomeKey();
-                            node.withEpoch(txnId.epoch(), () -> {
+                            node.withEpoch(txnId.epoch(), (ignored, withEpochFailure) -> {
+                                if (withEpochFailure != null)
+                                {
+                                    node.agent().onUncaughtException(CoordinationFailed.wrap(withEpochFailure));
+                                    commandStore.execute(contextFor(txnId), safeStore0 -> {
+                                        if (status.isAtMostReadyToExecute() && progress() == Investigating)
+                                        {
+                                            setProgress(Expected);
+                                        }
+                                    }).begin(node.agent());
+                                    return;
+                                }
+
                                 AsyncResult<? extends Outcome> recover = node.maybeRecover(txnId, route, token);
                                 recover.addCallback((success, fail) -> {
                                     // TODO (expected): callback should be on safeStore, and should provide safeStore as a parameter
@@ -345,7 +357,12 @@ public class SimpleProgressLog implements ProgressLog.Factory
                         }).begin(commandStore.agent());
                     };
 
-                    node.withEpoch(blockedUntil.fetchEpoch(txnId, executeAt), () -> {
+                    node.withEpoch(blockedUntil.fetchEpoch(txnId, executeAt), (ignored, withEpochFailure) -> {
+                        if (withEpochFailure != null)
+                        {
+                            callback.accept(null, CoordinationFailed.wrap(withEpochFailure));
+                            return;
+                        }
                         FetchData.fetch(blockedUntil.requires, node, txnId, fetchKeys, forLocalEpoch, executeAt, callback);
                     });
                 }
@@ -673,10 +690,7 @@ public class SimpleProgressLog implements ProgressLog.Factory
             try
             {
                 if (PAUSE_FOR_TEST)
-                {
-                    logger.info("Skipping progress log because it is paused for test");
                     return;
-                }
 
                 for (State.Monitoring run : this)
                 {

--- a/accord-core/src/main/java/accord/local/Commands.java
+++ b/accord-core/src/main/java/accord/local/Commands.java
@@ -390,7 +390,7 @@ public class Commands
 
         Ranges coordinateRanges = coordinateRanges(safeStore, localSyncId);
         // TODO (desired, consider): in the case of sync points, the coordinator is unlikely to be a home shard, do we mind this? should document at least
-        Txn emptyTxn = safeStore.agent().emptyTxn(localSyncId.kind(), keys);
+        Txn emptyTxn = safeStore.agent().emptySystemTxn(localSyncId.kind(), keys);
         PartialDeps none = Deps.NONE.intersecting(route);
         PartialTxn partialTxn = emptyTxn.slice(coordinateRanges, true);
         Invariants.checkState(validate(SaveStatus.Stable, command, coordinateRanges, route, partialTxn, none, null));
@@ -425,7 +425,7 @@ public class Commands
             return;
 
         // NOTE: if this is ever made a non-empty txn this will introduce a potential bug where the txn is registered against CommandsForKeys
-        Txn emptyTxn = safeStore.agent().emptyTxn(localSyncId.kind(), keys);
+        Txn emptyTxn = safeStore.agent().emptySystemTxn(localSyncId.kind(), keys);
         safeCommand.preapplied(safeStore, command, command.executeAt(), command.waitingOn(), emptyTxn.execute(localSyncId, localSyncId, null), emptyTxn.result(localSyncId, localSyncId, null));
         maybeExecute(safeStore, safeCommand, true, false);
     }

--- a/accord-core/src/main/java/accord/topology/Topology.java
+++ b/accord-core/src/main/java/accord/topology/Topology.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
+import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -45,13 +46,10 @@ import accord.utils.IndexedConsumer;
 import accord.utils.IndexedIntFunction;
 import accord.utils.IndexedTriFunction;
 import accord.utils.SimpleBitSet;
-import accord.utils.SortedArrays;
 import accord.utils.SortedArrays.SortedArrayList;
 import accord.utils.Utils;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.IntArrayList;
-
-import javax.annotation.Nullable;
 
 import static accord.utils.Invariants.illegalArgument;
 import static accord.utils.SortedArrays.Search.FLOOR;

--- a/accord-core/src/main/java/accord/topology/Topology.java
+++ b/accord-core/src/main/java/accord/topology/Topology.java
@@ -45,6 +45,7 @@ import accord.utils.IndexedConsumer;
 import accord.utils.IndexedIntFunction;
 import accord.utils.IndexedTriFunction;
 import accord.utils.SimpleBitSet;
+import accord.utils.SortedArrays;
 import accord.utils.SortedArrays.SortedArrayList;
 import accord.utils.Utils;
 import org.agrona.collections.Int2ObjectHashMap;

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -24,14 +24,22 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.function.ToLongFunction;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import accord.api.Agent;
 import accord.api.ConfigurationService.EpochReady;
 import accord.api.RoutingKey;
+import accord.api.Scheduler;
 import accord.api.TopologySorter;
+import accord.config.LocalConfig;
+import accord.coordinate.EpochTimeout;
 import accord.coordinate.TopologyMismatch;
 import accord.coordinate.tracking.QuorumTracker;
 import accord.local.CommandStore;
@@ -46,12 +54,11 @@ import accord.utils.async.AsyncChain;
 import accord.utils.async.AsyncResult;
 import accord.utils.async.AsyncResults;
 
-import javax.annotation.Nullable;
-
 import static accord.coordinate.tracking.RequestStatus.Success;
 import static accord.primitives.AbstractRanges.UnionMode.MERGE_ADJACENT;
 import static accord.primitives.Routables.Slice.Minimal;
 import static accord.utils.Invariants.checkArgument;
+import static accord.utils.Invariants.checkState;
 import static accord.utils.Invariants.illegalState;
 import static accord.utils.Invariants.nonNull;
 
@@ -70,7 +77,13 @@ import static accord.utils.Invariants.nonNull;
  */
 public class TopologyManager
 {
-    private static final AsyncResult<Void> SUCCESS = AsyncResults.success(null);
+    private static final FutureEpoch SUCCESS;
+
+    static
+    {
+        SUCCESS = new FutureEpoch(-1L, Long.MAX_VALUE);
+        SUCCESS.future.trySuccess(null);
+    }
 
     static class EpochState
     {
@@ -107,7 +120,7 @@ public class TopologyManager
             newPrevSyncComplete = newPrevSyncComplete.union(MERGE_ADJACENT, addedRanges).subtract(removedRanges);
             if (prevSyncComplete.containsAll(newPrevSyncComplete))
                 return false;
-            Invariants.checkState(newPrevSyncComplete.containsAll(prevSyncComplete), "Expected %s to contain all ranges in %s; but did not", newPrevSyncComplete, prevSyncComplete);
+            checkState(newPrevSyncComplete.containsAll(prevSyncComplete), "Expected %s to contain all ranges in %s; but did not", newPrevSyncComplete, prevSyncComplete);
             prevSyncComplete = newPrevSyncComplete;
             syncComplete = curSyncComplete.slice(newPrevSyncComplete, Minimal).union(MERGE_ADJACENT, addedRanges);
             return true;
@@ -221,13 +234,13 @@ public class TopologyManager
         // list of promises to be completed as newer epochs become active. This is to support processes that
         // are waiting on future epochs to begin (ie: txn requests from futures epochs). Index 0 is for
         // currentEpoch + 1
-        private final List<AsyncResult.Settable<Void>> futureEpochFutures;
+        private final List<FutureEpoch> futureEpochs;
 
-        private Epochs(EpochState[] epochs, List<Notifications> pending, List<AsyncResult.Settable<Void>> futureEpochFutures)
+        private Epochs(EpochState[] epochs, List<Notifications> pending, List<FutureEpoch> futureEpochs)
         {
             this.currentEpoch = epochs.length > 0 ? epochs[0].epoch() : 0;
             this.pending = pending;
-            this.futureEpochFutures = futureEpochFutures;
+            this.futureEpochs = futureEpochs;
             for (int i=1; i<epochs.length; i++)
                 checkArgument(epochs[i].epoch() == epochs[i-1].epoch() - 1);
             this.epochs = epochs;
@@ -238,16 +251,24 @@ public class TopologyManager
             this(epochs, new ArrayList<>(), new ArrayList<>());
         }
 
-        public AsyncResult<Void> awaitEpoch(long epoch)
+        private FutureEpoch awaitEpoch(long epoch, Agent agent, ToLongFunction<TimeUnit> nowTimeUnit, LocalConfig localConfig)
         {
             if (epoch <= currentEpoch)
                 return SUCCESS;
 
+            long now = nowTimeUnit.applyAsLong(TimeUnit.MILLISECONDS);
+            long deadline = now + localConfig.epochFetchInitialTimeout().toMillis();
             int diff = (int) (epoch - currentEpoch);
-            while (futureEpochFutures.size() < diff)
-                futureEpochFutures.add(AsyncResults.settable());
+            long epochIndex = epoch - diff + 1;
+            while (futureEpochs.size() < diff)
+            {
+                FutureEpoch futureEpoch = new FutureEpoch(epochIndex++, deadline);
+                futureEpochs.add(futureEpoch);
+                // Always make a topology timeout visible
+                futureEpoch.future.addCallback(agent);
+            }
 
-            return futureEpochFutures.get(diff - 1);
+            return futureEpochs.get(diff - 1);
         }
 
         public long nextEpoch()
@@ -371,15 +392,89 @@ public class TopologyManager
         }
     }
 
-    private final TopologySorter.Supplier sorter;
-    private final Id node;
-    private volatile Epochs epochs;
+    private static class FutureEpoch
+    {
+        private final long epoch;
+        private volatile AsyncResult.Settable<Void> future;
+        private long deadlineMillis;
 
-    public TopologyManager(TopologySorter.Supplier sorter, Id node)
+        public FutureEpoch(long epoch, long deadlineMillis)
+        {
+            this.epoch = epoch;
+            this.future = AsyncResults.settable();
+            this.deadlineMillis = deadlineMillis;
+        }
+
+        /*
+         * Notify any listeners that are waiting for the epoch that is has been a long time since
+         * we started waiting for the epoch. We may still eventually get the epoch so also create
+         * a new future so subsequent operations may have a chance at seeing the epoch if it ever appears.
+         *
+         * Subsequent waiters may get a timeout notification far sooner (WATCHDOG_INTERVAL_MILLISS)
+         * instead of EPOCH_INITIAL_TIMEOUT_MILLIS
+         */
+        @GuardedBy("TopologyManager.this")
+        private void timeOutCurrentListeners(long newDeadline, Agent agent)
+        {
+            deadlineMillis = newDeadline;
+            AsyncResult.Settable<Void> oldFuture = future;
+            if (oldFuture.isDone())
+                return;
+            future = AsyncResults.settable();
+            future.addCallback(agent);
+            oldFuture.tryFailure(new EpochTimeout(epoch));
+        }
+    }
+
+    private final TopologySorter.Supplier sorter;
+    private final Agent agent;
+    private final Id node;
+    private final Scheduler scheduler;
+    private final ToLongFunction<TimeUnit> nowTimeUnit;
+    private volatile Epochs epochs;
+    private Scheduler.Scheduled topologyUpdateWatchdog;
+
+    private final LocalConfig localConfig;
+
+    public TopologyManager(TopologySorter.Supplier sorter, Agent agent, Id node, Scheduler scheduler, ToLongFunction<TimeUnit> nowTimeUnit, LocalConfig localConfig)
     {
         this.sorter = sorter;
+        this.agent = agent;
         this.node = node;
+        this.scheduler = scheduler;
+        this.nowTimeUnit = nowTimeUnit;
         this.epochs = Epochs.EMPTY;
+        this.localConfig = localConfig;
+    }
+
+    public void shutdown()
+    {
+        topologyUpdateWatchdog.cancel();
+    }
+
+    public void scheduleTopologyUpdateWatchdog()
+    {
+        topologyUpdateWatchdog = scheduler.recurring(() -> {
+            synchronized (TopologyManager.this)
+            {
+                Epochs current = epochs;
+                if (current.futureEpochs.isEmpty())
+                    return;
+
+                long now = nowTimeUnit.applyAsLong(TimeUnit.MILLISECONDS);
+                if (now > current.futureEpochs.get(0).deadlineMillis)
+                {
+                    for (int i = 0; i < current.futureEpochs.size(); i++)
+                    {
+                        FutureEpoch futureEpoch = current.futureEpochs.get(i);
+                        if (now <= futureEpoch.deadlineMillis)
+                            break;
+                        else
+                            futureEpoch.timeOutCurrentListeners(now + localConfig.epochFetchInitialTimeout().toMillis(), agent);
+                    }
+                }
+            }
+        }, localConfig.epochFetchWatchdogInterval().toMillis(), TimeUnit.MILLISECONDS);
     }
 
     public synchronized EpochReady onTopologyUpdate(Topology topology, Supplier<EpochReady> bootstrap)
@@ -406,21 +501,21 @@ public class TopologyManager
         nextEpochs[0].recordClosed(notifications.closed);
         nextEpochs[0].recordComplete(notifications.complete);
 
-        List<AsyncResult.Settable<Void>> futureEpochFutures = new ArrayList<>(current.futureEpochFutures);
-        AsyncResult.Settable<Void> toComplete = !futureEpochFutures.isEmpty() ? futureEpochFutures.remove(0) : null;
-        epochs = new Epochs(nextEpochs, pending, futureEpochFutures);
+        List<FutureEpoch> futureEpochs = new ArrayList<>(current.futureEpochs);
+        FutureEpoch toComplete = !futureEpochs.isEmpty() ? futureEpochs.remove(0) : null;
+        epochs = new Epochs(nextEpochs, pending, futureEpochs);
         if (toComplete != null)
-            toComplete.trySuccess(null);
+            toComplete.future.trySuccess(null);
 
         return nextEpochs[0].ready = bootstrap.get();
     }
 
     public AsyncChain<Void> awaitEpoch(long epoch)
     {
-        AsyncResult<Void> result;
+        AsyncResult<Void> result = null;
         synchronized (this)
         {
-            result = epochs.awaitEpoch(epoch);
+            result = epochs.awaitEpoch(epoch, agent, nowTimeUnit, localConfig).future;
         }
         CommandStore current = CommandStore.maybeCurrent();
         return current == null || result.isDone() ? result : result.withExecutor(current);
@@ -477,11 +572,11 @@ public class TopologyManager
             return;
 
         int newLen = current.epochs.length - (int) (epoch - current.minEpoch());
-        Invariants.checkState(current.epochs[newLen - 1].syncComplete(), "Epoch %d's sync is not complete", current.epochs[newLen - 1].epoch());
+        checkState(current.epochs[newLen - 1].syncComplete(), "Epoch %d's sync is not complete", current.epochs[newLen - 1].epoch());
 
         EpochState[] nextEpochs = new EpochState[newLen];
         System.arraycopy(current.epochs, 0, nextEpochs, 0, newLen);
-        epochs = new Epochs(nextEpochs, current.pending, current.futureEpochFutures);
+        epochs = new Epochs(nextEpochs, current.pending, current.futureEpochs);
     }
 
     public synchronized void onEpochClosed(Ranges ranges, long epoch)
@@ -556,7 +651,7 @@ public class TopologyManager
             throw tm;
 
         if (maxEpoch == Long.MAX_VALUE) maxEpoch = snapshot.currentEpoch;
-        else Invariants.checkState(snapshot.currentEpoch >= maxEpoch, "current epoch %d < max %d", snapshot.currentEpoch, maxEpoch);
+        else checkState(snapshot.currentEpoch >= maxEpoch, "current epoch %d < max %d", snapshot.currentEpoch, maxEpoch);
 
         EpochState maxEpochState = nonNull(snapshot.get(maxEpoch));
         if (minEpoch == maxEpoch && isSufficientFor.apply(maxEpochState).containsAll(select))
@@ -620,7 +715,7 @@ public class TopologyManager
         Epochs snapshot = epochs;
 
         EpochState maxState = snapshot.get(maxEpoch);
-        Invariants.checkState(maxState != null, "Unable to find epoch %d; known epochs are %d -> %d", maxEpoch, snapshot.minEpoch(), snapshot.currentEpoch);
+        checkState(maxState != null, "Unable to find epoch %d; known epochs are %d -> %d", maxEpoch, snapshot.minEpoch(), snapshot.currentEpoch);
         TopologyMismatch tm = TopologyMismatch.checkForMismatch(maxState.global(), select);
         if (tm != null)
             throw tm;
@@ -636,7 +731,7 @@ public class TopologyManager
             topologies.add(epochState.global.forSelection(select));
             select = select.subtract(epochState.addedRanges);
         }
-        Invariants.checkState(!topologies.isEmpty(), "Unable to find an epoch that contained %s", select);
+        checkState(!topologies.isEmpty(), "Unable to find an epoch that contained %s", select);
 
         return topologies.build(sorter);
     }

--- a/accord-core/src/test/java/accord/Utils.java
+++ b/accord-core/src/test/java/accord/Utils.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Sets;
 import accord.api.Key;
 import accord.api.MessageSink;
 import accord.api.Scheduler;
+import accord.api.TopologySorter;
 import accord.config.LocalConfig;
 import accord.config.MutableLocalConfig;
 import accord.coordinate.CoordinationAdapter;
@@ -57,6 +58,7 @@ import accord.primitives.Txn;
 import accord.topology.Shard;
 import accord.topology.Topologies;
 import accord.topology.Topology;
+import accord.topology.TopologyManager;
 import accord.utils.DefaultRandom;
 import accord.utils.EpochFunction;
 import accord.utils.Invariants;
@@ -170,7 +172,7 @@ public class Utils
                              LocalRequest::simpleHandler,
                              new MockConfigurationService(messageSink, EpochFunction.noop(), topology),
                              clock,
-                             NodeTimeService.unixWrapper(TimeUnit.MICROSECONDS, clock),
+                             NodeTimeService.elapsedWrapperFromNonMonotonicSource(TimeUnit.MICROSECONDS, clock),
                              () -> store,
                              new ShardDistributor.EvenSplit(8, ignore -> new IntKey.Splitter()),
                              new TestAgent(),
@@ -197,5 +199,10 @@ public class Utils
                   .atMost(timeoutInSeconds, TimeUnit.SECONDS)
                   .ignoreExceptions()
                   .untilAsserted(runnable);
+    }
+
+    public static TopologyManager testTopologyManager(TopologySorter.Supplier sorter, Id node)
+    {
+        return new TopologyManager(sorter, new TestAgent.RethrowAgent(), node, Scheduler.NEVER_RUN_SCHEDULED, NodeTimeService.elapsedWrapperFromNonMonotonicSource(TimeUnit.MILLISECONDS, () -> 0), LocalConfig.DEFAULT);
     }
 }

--- a/accord-core/src/test/java/accord/coordinate/CoordinateTransactionTest.java
+++ b/accord-core/src/test/java/accord/coordinate/CoordinateTransactionTest.java
@@ -250,14 +250,14 @@ public class CoordinateTransactionTest
             // Create a txn to block the one we are about to create after this
             SimpleProgressLog.PAUSE_FOR_TEST = true;
             TxnId blockingTxnId = new TxnId(txnId.epoch(), 1, Read, Key, new Id(1));
-            Txn blockingTxn = agent.emptyTxn(Read, keys);
+            Txn blockingTxn = agent.emptySystemTxn(Read, keys);
             PreLoadContext blockingTxnContext = PreLoadContext.contextFor(blockingTxnId, keys);
             for (Node n : cluster)
                 assertEquals(AcceptOutcome.Success, getUninterruptibly(n.unsafeForKey(key).submit(blockingTxnContext, store ->
                         Commands.preaccept(store, store.get(blockingTxnId, homeKey), blockingTxnId, blockingTxnId.epoch(), blockingTxn.slice(store.ranges().allAt(blockingTxnId), true), route, null))));
 
             // Now create the transaction that should be blocked by the previous one
-            Txn txn = agent.emptyTxn(Write, keys);
+            Txn txn = agent.emptySystemTxn(Write, keys);
             PreLoadContext context = PreLoadContext.contextFor(txnId, keys);
             for (Node n : cluster)
                 assertEquals(AcceptOutcome.Success, getUninterruptibly(n.unsafeForKey(key).submit(context, store ->

--- a/accord-core/src/test/java/accord/impl/TestAgent.java
+++ b/accord-core/src/test/java/accord/impl/TestAgent.java
@@ -21,6 +21,7 @@ package accord.impl;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nonnull;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,7 +37,6 @@ import accord.primitives.Seekables;
 import accord.primitives.Timestamp;
 import accord.primitives.Txn;
 import accord.primitives.TxnId;
-import javax.annotation.Nonnull;
 
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -133,7 +133,7 @@ public class TestAgent implements Agent
     }
 
     @Override
-    public Txn emptyTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
+    public Txn emptySystemTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
     {
         return new Txn.InMemory(kind, keysOrRanges, MockStore.read(Keys.EMPTY), MockStore.QUERY, null);
     }

--- a/accord-core/src/test/java/accord/impl/basic/Cluster.java
+++ b/accord-core/src/test/java/accord/impl/basic/Cluster.java
@@ -410,7 +410,7 @@ public class Cluster implements Scheduler
                 journalMap.put(id, journal);
                 BurnTestConfigurationService configService = new BurnTestConfigurationService(id, nodeExecutor, randomSupplier, topology, nodeMap::get, topologyUpdates);
                 BooleanSupplier isLoadedCheck = Gens.supplier(Gens.bools().mixedDistribution().next(random), random);
-                Node node = new Node(id, messageSink, journal, configService, nowSupplier, NodeTimeService.unixWrapper(TimeUnit.MILLISECONDS, nowSupplier),
+                Node node = new Node(id, messageSink, journal, configService, nowSupplier, NodeTimeService.elapsedWrapperFromNonMonotonicSource(TimeUnit.MILLISECONDS, nowSupplier),
                                      () -> new ListStore(id), new ShardDistributor.EvenSplit<>(8, ignore -> new PrefixedIntHashKey.Splitter()),
                                      nodeExecutor.agent(),
                                      randomSupplier.get(), sinks, SizeOfIntersectionSorter.SUPPLIER,

--- a/accord-core/src/test/java/accord/impl/list/ListAgent.java
+++ b/accord-core/src/test/java/accord/impl/list/ListAgent.java
@@ -115,7 +115,7 @@ public class ListAgent implements Agent
     }
 
     @Override
-    public Txn emptyTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
+    public Txn emptySystemTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
     {
         return new Txn.InMemory(kind, keysOrRanges, new ListRead(identity(), false, Keys.EMPTY, Keys.EMPTY), new ListQuery(NONE, Integer.MIN_VALUE, false), null);
     }

--- a/accord-core/src/test/java/accord/impl/mock/MockCluster.java
+++ b/accord-core/src/test/java/accord/impl/mock/MockCluster.java
@@ -34,8 +34,9 @@ import org.slf4j.LoggerFactory;
 
 import accord.NetworkFilter;
 import accord.api.MessageSink;
-import accord.coordinate.CoordinationAdapter;
 import accord.config.LocalConfig;
+import accord.config.MutableLocalConfig;
+import accord.coordinate.CoordinationAdapter;
 import accord.impl.InMemoryCommandStores;
 import accord.impl.IntKey;
 import accord.impl.SimpleProgressLog;
@@ -46,7 +47,6 @@ import accord.local.Node;
 import accord.local.Node.Id;
 import accord.local.NodeTimeService;
 import accord.local.ShardDistributor;
-import accord.config.MutableLocalConfig;
 import accord.messages.Callback;
 import accord.messages.LocalRequest;
 import accord.messages.Reply;
@@ -128,7 +128,7 @@ public class MockCluster implements Network, AutoCloseable, Iterable<Node>
                              LocalRequest::simpleHandler,
                              configurationService,
                              nowSupplier,
-                             NodeTimeService.unixWrapper(TimeUnit.MILLISECONDS, nowSupplier),
+                             NodeTimeService.elapsedWrapperFromNonMonotonicSource(TimeUnit.MILLISECONDS, nowSupplier),
                              () -> store,
                              new ShardDistributor.EvenSplit(8, ignore -> new IntKey.Splitter()),
                              new TestAgent(),

--- a/accord-core/src/test/java/accord/local/ImmutableCommandTest.java
+++ b/accord-core/src/test/java/accord/local/ImmutableCommandTest.java
@@ -119,7 +119,7 @@ public class ImmutableCommandTest
         MockCluster.Clock clock = new MockCluster.Clock(100);
         LocalConfig localConfig = new MutableLocalConfig();
         Node node = new Node(id, null, null, new MockConfigurationService(null, (epoch, service) -> { }, storeSupport.local.get()),
-                             clock, NodeTimeService.unixWrapper(TimeUnit.MICROSECONDS, clock),
+                             clock, NodeTimeService.elapsedWrapperFromNonMonotonicSource(TimeUnit.MICROSECONDS, clock),
                              () -> storeSupport.data, new ShardDistributor.EvenSplit(8, ignore -> new IntKey.Splitter()), new TestAgent(), new DefaultRandom(), Scheduler.NEVER_RUN_SCHEDULED,
                              SizeOfIntersectionSorter.SUPPLIER, ignore -> ignore2 -> new NoOpProgressLog(), InMemoryCommandStores.Synchronized::new,
                              new CoordinationAdapter.DefaultFactory(),

--- a/accord-core/src/test/java/accord/local/cfk/CommandsForKeyTest.java
+++ b/accord-core/src/test/java/accord/local/cfk/CommandsForKeyTest.java
@@ -28,12 +28,10 @@ import java.util.TreeSet;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1027,7 +1025,7 @@ public class CommandsForKeyTest
         }
 
         @Override
-        public Txn emptyTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
+        public Txn emptySystemTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
         {
             throw new UnsupportedOperationException();
         }

--- a/accord-core/src/test/java/accord/primitives/RangeDepsTest.java
+++ b/accord-core/src/test/java/accord/primitives/RangeDepsTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import accord.impl.IntKey;
 import accord.local.Node;
 import accord.primitives.Routable.Domain;
+import accord.utils.RandomTestRunner;
 
 import static accord.primitives.Txn.Kind.Write;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/accord-core/src/test/java/accord/primitives/RangeDepsTest.java
+++ b/accord-core/src/test/java/accord/primitives/RangeDepsTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import accord.impl.IntKey;
 import accord.local.Node;
 import accord.primitives.Routable.Domain;
-import accord.utils.RandomTestRunner;
 
 import static accord.primitives.Txn.Kind.Write;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/accord-core/src/test/java/accord/topology/TopologyManagerTest.java
+++ b/accord-core/src/test/java/accord/topology/TopologyManagerTest.java
@@ -18,29 +18,6 @@
 
 package accord.topology;
 
-import accord.burn.TopologyUpdates;
-import accord.impl.PrefixedIntHashKey;
-import accord.impl.TestAgent;
-import accord.local.AgentExecutor;
-import accord.primitives.Ranges;
-import accord.primitives.Unseekables;
-import accord.utils.AccordGens;
-import accord.utils.Gen;
-import accord.utils.Gens;
-import accord.utils.RandomSource;
-import com.google.common.collect.AbstractIterator;
-import com.google.common.collect.Iterators;
-
-import accord.utils.SortedArrays.SortedArrayList;
-import org.agrona.collections.Long2ObjectHashMap;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-import accord.local.Node;
-import accord.primitives.Range;
-import accord.primitives.RoutingKeys;
-import org.mockito.Mockito;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumMap;
@@ -52,10 +29,34 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 
+import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.Iterators;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import accord.burn.TopologyUpdates;
+import accord.impl.PrefixedIntHashKey;
+import accord.impl.TestAgent;
+import accord.local.AgentExecutor;
+import accord.local.Node;
+import accord.primitives.Range;
+import accord.primitives.Ranges;
+import accord.primitives.RoutingKeys;
+import accord.primitives.Unseekables;
+import accord.utils.AccordGens;
+import accord.utils.Gen;
+import accord.utils.Gens;
+import accord.utils.RandomSource;
+
+import accord.utils.SortedArrays.SortedArrayList;
+import org.agrona.collections.Long2ObjectHashMap;
+import org.mockito.Mockito;
+
 import static accord.Utils.id;
 import static accord.Utils.idList;
 import static accord.Utils.idSet;
 import static accord.Utils.shard;
+import static accord.Utils.testTopologyManager;
 import static accord.Utils.topologies;
 import static accord.Utils.topology;
 import static accord.impl.IntKey.keys;
@@ -81,7 +82,7 @@ public class TopologyManagerTest
                                shard(range(100, 200), idList(2, 3, 5), idSet(2, 3, 5)));
         int[] unmoved = { 1, 3, 5 };
         int[] moved = { 2, 4 };
-        TopologyManager service = new TopologyManager(SUPPLIER, ID);
+        TopologyManager service = testTopologyManager(SUPPLIER, ID);
         service.onTopologyUpdate(t1, () -> null);
         service.onTopologyUpdate(t2, () -> null);
 
@@ -107,7 +108,7 @@ public class TopologyManagerTest
         Topology topology1 = topology(1, shard(range, idList(1, 2, 3), idSet(1, 2)));
         Topology topology2 = topology(2, shard(range, idList(1, 2, 3), idSet(2, 3)));
 
-        TopologyManager service = new TopologyManager(SUPPLIER, ID);
+        TopologyManager service = testTopologyManager(SUPPLIER, ID);
 
         Assertions.assertSame(Topology.EMPTY, service.current());
         service.onTopologyUpdate(topology1, () -> null);
@@ -132,7 +133,7 @@ public class TopologyManagerTest
                                       shard(range(100, 200), idList(1, 2, 3), idSet(3, 4)),
                                       shard(range(200, 300), idList(4, 5, 6), idSet(4, 5)));
 
-        TopologyManager service = new TopologyManager(SUPPLIER, ID);
+        TopologyManager service = testTopologyManager(SUPPLIER, ID);
         service.onTopologyUpdate(topology1, () -> null);
         service.onTopologyUpdate(topology2, () -> null);
 
@@ -163,7 +164,7 @@ public class TopologyManagerTest
         Topology topology2 = topology(2, shard(range, idList(1, 2, 3), idSet(2, 3)));
         Topology topology3 = topology(3, shard(range, idList(1, 2, 3), idSet(1, 2)));
 
-        TopologyManager service = new TopologyManager(SUPPLIER, ID);
+        TopologyManager service = testTopologyManager(SUPPLIER, ID);
         service.onTopologyUpdate(topology1, () -> null);
         service.onTopologyUpdate(topology2, () -> null);
         service.onTopologyUpdate(topology3, () -> null);
@@ -200,7 +201,7 @@ public class TopologyManagerTest
         Topology topology2 = topology(2, shard(range, idList(1, 2, 3), idSet(2, 3)));
 //        Topology topology3 = topology(3, shard(range, idList(1, 2, 3), idSet(3, 4)));
 
-        TopologyManager service = new TopologyManager(SUPPLIER, ID);
+        TopologyManager service = testTopologyManager(SUPPLIER, ID);
         service.onTopologyUpdate(topology1, () -> null);
 
         // sync epoch 2
@@ -222,7 +223,7 @@ public class TopologyManagerTest
         Topology topology2 = topology(2, shard(range, idList(1, 2, 3), idSet(1, 2)));
         Topology topology3 = topology(3, shard(range, idList(1, 2, 3), idSet(2, 3)));
 
-        TopologyManager service = new TopologyManager(SUPPLIER, ID);
+        TopologyManager service = testTopologyManager(SUPPLIER, ID);
 
         Assertions.assertSame(Topology.EMPTY, service.current());
         service.onTopologyUpdate(topology1, () -> null);
@@ -252,7 +253,7 @@ public class TopologyManagerTest
                                       shard(range(100, 200), idList(1, 2, 3), idSet(1, 2)),
                                       shard(range(200, 300), idList(4, 5, 6), idSet(5, 6)));
 
-        TopologyManager service = new TopologyManager(SUPPLIER, ID);
+        TopologyManager service = testTopologyManager(SUPPLIER, ID);
         service.onTopologyUpdate(topology5, () -> null);
         service.onTopologyUpdate(topology6, () -> null);
 
@@ -280,7 +281,7 @@ public class TopologyManagerTest
     void truncateTopologyHistory()
     {
         Range range = range(100, 200);
-        TopologyManager service = new TopologyManager(SUPPLIER, ID);
+        TopologyManager service = testTopologyManager(SUPPLIER, ID);
         addAndMarkSynced(service, topology(1, shard(range, idList(1, 2, 3), idSet(1, 2))));
         addAndMarkSynced(service, topology(2, shard(range, idList(1, 2, 3), idSet(2, 3))));
         addAndMarkSynced(service, topology(3, shard(range, idList(1, 2, 3), idSet(1, 2))));
@@ -321,7 +322,7 @@ public class TopologyManagerTest
                                         shard(PrefixedIntHashKey.range(1, 0, 100), idList(1, 2, 3), idSet(1, 2))));
             topologies.add(topology(epochCounter++,
                                     shard(PrefixedIntHashKey.range(1, 0, 100), idList(1, 2, 3), idSet(1, 2))));;
-            History history = new History(new TopologyManager(SUPPLIER, ID), topologies.iterator()) {
+            History history = new History(testTopologyManager(SUPPLIER, ID), topologies.iterator()) {
 
                 @Override
                 protected void postTopologyUpdate(int id, Topology t)
@@ -367,7 +368,7 @@ public class TopologyManagerTest
     @Test
     void aba()
     {
-        TopologyManager service = new TopologyManager(SUPPLIER, ID);
+        TopologyManager service = testTopologyManager(SUPPLIER, ID);
         SortedArrayList<Node.Id> dc1Nodes = idList(1, 2, 3);
         Set<Node.Id> dc1Fp = idSet(1, 2);
         SortedArrayList<Node.Id> dc2Nodes = idList(4, 5, 6);
@@ -418,7 +419,7 @@ public class TopologyManagerTest
                     return t == null ? endOfData() : t;
                 }
             }, 42);
-            History history = new History(new TopologyManager(SUPPLIER, ID), next) {
+            History history = new History(testTopologyManager(SUPPLIER, ID), next) {
 
                 @Override
                 protected void postTopologyUpdate(int id, Topology t)

--- a/accord-core/src/test/java/accord/utils/ExtendedAssertions.java
+++ b/accord-core/src/test/java/accord/utils/ExtendedAssertions.java
@@ -43,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 

--- a/accord-core/src/test/java/accord/utils/ExtendedAssertions.java
+++ b/accord-core/src/test/java/accord/utils/ExtendedAssertions.java
@@ -18,6 +18,10 @@
 
 package accord.utils;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+
 import accord.api.RoutingKey;
 import accord.local.Node;
 import accord.messages.PreAccept;
@@ -41,11 +45,6 @@ import org.assertj.core.error.ShouldHaveSize;
 import org.assertj.core.error.ShouldNotBeEmpty;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.Consumer;
 
 public class ExtendedAssertions
 {

--- a/accord-maelstrom/src/main/java/accord/maelstrom/Cluster.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/Cluster.java
@@ -322,7 +322,7 @@ public class Cluster implements Scheduler
                 LongSupplier nowSupplier = nowSupplierSupplier.get();
                 LocalConfig localConfig = new MutableLocalConfig();
                 lookup.put(node, new Node(node, messageSink, LocalRequest::simpleHandler, new SimpleConfigService(topology),
-                                          nowSupplier, NodeTimeService.unixWrapper(TimeUnit.MICROSECONDS, nowSupplier),
+                                          nowSupplier, NodeTimeService.elapsedWrapperFromNonMonotonicSource(TimeUnit.MICROSECONDS, nowSupplier),
                                           MaelstromStore::new, new ShardDistributor.EvenSplit(8, ignore -> new MaelstromKey.Splitter()),
                                           MaelstromAgent.INSTANCE,
                                           randomSupplier.get(), sinks, SizeOfIntersectionSorter.SUPPLIER,

--- a/accord-maelstrom/src/main/java/accord/maelstrom/MaelstromAgent.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/MaelstromAgent.java
@@ -28,10 +28,9 @@ import accord.primitives.Seekables;
 import accord.primitives.Timestamp;
 import accord.primitives.Txn;
 
+import static accord.utils.Invariants.checkState;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
-
-import static accord.utils.Invariants.checkState;
 
 public class MaelstromAgent implements Agent
 {
@@ -98,7 +97,7 @@ public class MaelstromAgent implements Agent
     }
 
     @Override
-    public Txn emptyTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
+    public Txn emptySystemTxn(Txn.Kind kind, Seekables<?, ?> keysOrRanges)
     {
         return new Txn.InMemory(kind, keysOrRanges, new MaelstromRead(Keys.EMPTY, Keys.EMPTY), new MaelstromQuery(Node.Id.NONE, -1), null);
     }

--- a/accord-maelstrom/src/main/java/accord/maelstrom/Main.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/Main.java
@@ -178,7 +178,7 @@ public class Main
             sink = new StdoutSink(System::currentTimeMillis, scheduler, start, init.self, out, err);
             LocalConfig localConfig = new MutableLocalConfig();
             on = new Node(init.self, sink, LocalRequest::simpleHandler, new SimpleConfigService(topology),
-                          System::currentTimeMillis, NodeTimeService.unixWrapper(TimeUnit.MILLISECONDS, System::currentTimeMillis),
+                          System::currentTimeMillis, NodeTimeService.elapsedWrapperFromNonMonotonicSource(TimeUnit.MILLISECONDS, System::currentTimeMillis),
                           MaelstromStore::new, new ShardDistributor.EvenSplit(8, ignore -> new MaelstromKey.Splitter()),
                           MaelstromAgent.INSTANCE, new DefaultRandom(), scheduler, SizeOfIntersectionSorter.SUPPLIER,
                           SimpleProgressLog::new, InMemoryCommandStores.SingleThread::new, new CoordinationAdapter.DefaultFactory(),


### PR DESCRIPTION
[CASSANDRA-19744](https://issues.apache.org/jira/browse/CASSANDRA-19744)


The only Accord change here is adding timeouts to `TopologyManager`. We need those timeouts, but this was largely driven by it being basically untestable to have a coordinator be behind when attempting to execute an Accord transaction. It will learn about the new epoch from the other nodes during `PreAccept` and then block forever trying to adopt it so you can't test the timeout handling code paths in Cassandra for things like batches and hints.
