### PR TITLE
Fix various bugs, improving burn test stability

### DIFF
--- a/accord-core/src/main/java/accord/api/Key.java
+++ b/accord-core/src/main/java/accord/api/Key.java
@@ -18,6 +18,8 @@
 
 package accord.api;
 
+import javax.annotation.Nonnull;
+
 import accord.primitives.Range;
 import accord.primitives.RoutableKey;
 import accord.primitives.Seekable;
@@ -35,4 +37,6 @@ public interface Key extends Seekable, RoutableKey
 
     @Override
     default Range asRange() { throw new UnsupportedOperationException(); }
+
+    default int compareAsRoutingKey(@Nonnull RoutingKey that) { return toUnseekable().compareTo(that); }
 }

--- a/accord-core/src/main/java/accord/api/Read.java
+++ b/accord-core/src/main/java/accord/api/Read.java
@@ -19,6 +19,7 @@
 package accord.api;
 
 import accord.local.SafeCommandStore;
+import accord.primitives.Participants;
 import accord.primitives.Ranges;
 import accord.primitives.Seekable;
 import accord.primitives.Seekables;
@@ -33,5 +34,7 @@ public interface Read
     Seekables<?, ?> keys();
     AsyncChain<Data> read(Seekable key, SafeCommandStore commandStore, Timestamp executeAt, DataStore store);
     Read slice(Ranges ranges);
+    Read intersecting(Participants<?> participants);
     Read merge(Read other);
+
 }

--- a/accord-core/src/main/java/accord/api/Update.java
+++ b/accord-core/src/main/java/accord/api/Update.java
@@ -18,6 +18,7 @@
 
 package accord.api;
 
+import accord.primitives.Participants;
 import accord.primitives.Ranges;
 import accord.primitives.Seekables;
 import accord.primitives.Timestamp;
@@ -35,5 +36,7 @@ public interface Update
     // null is provided only if nothing was read
     Write apply(Timestamp executeAt, @Nullable Data data);
     Update slice(Ranges ranges);
+    Update intersecting(Participants<?> participants);
     Update merge(Update other);
+
 }

--- a/accord-core/src/main/java/accord/coordinate/AbstractCoordinatePreAccept.java
+++ b/accord-core/src/main/java/accord/coordinate/AbstractCoordinatePreAccept.java
@@ -18,9 +18,9 @@
 
 package accord.coordinate;
 
-import java.util.LinkedHashMap;
+import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.BiConsumer;
 
 import javax.annotation.Nullable;
@@ -103,7 +103,7 @@ abstract class AbstractCoordinatePreAccept<T, R> extends SettableResult<T> imple
     private Topologies topologies;
     private boolean initialRoundIsDone;
     private ExtraEpochs extraEpochs;
-    private Map<Id, Object> debug = Invariants.debug() ? new LinkedHashMap<>() : null;
+    private Map<Id, Object> debug = Invariants.debug() ? new TreeMap<>() : null;
 
     AbstractCoordinatePreAccept(Node node, FullRoute<?> route, TxnId txnId)
     {
@@ -124,7 +124,7 @@ abstract class AbstractCoordinatePreAccept<T, R> extends SettableResult<T> imple
     }
 
     abstract Seekables<?, ?> keysOrRanges();
-    abstract void contact(Set<Id> nodes, Topologies topologies, Callback<R> callback);
+    abstract void contact(Collection<Id> nodes, Topologies topologies, Callback<R> callback);
     abstract void onSuccessInternal(Id from, R reply);
     /**
      * The tracker for the extra rounds only is provided by the AbstractCoordinatePreAccept, so we expect a boolean back

--- a/accord-core/src/main/java/accord/coordinate/Barrier.java
+++ b/accord-core/src/main/java/accord/coordinate/Barrier.java
@@ -259,7 +259,7 @@ public class Barrier<S extends Seekables<?, ?>> extends AsyncResults.AbstractRes
         @Override
         public BarrierTxn apply(SafeCommandStore safeStore)
         {
-            // TODO (required): consider these semantics
+            // TODO (required, consider): consider these semantics
             BarrierTxn found = safeStore.mapReduceFull(
             seekables,
             safeStore.ranges().allAfter(minEpoch),

--- a/accord-core/src/main/java/accord/coordinate/CoordinateEphemeralRead.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinateEphemeralRead.java
@@ -19,8 +19,8 @@
 package accord.coordinate;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import accord.api.Result;
 import accord.coordinate.tracking.QuorumTracker;
@@ -90,7 +90,7 @@ public class CoordinateEphemeralRead extends AbstractCoordinatePreAccept<Result,
     }
 
     @Override
-    void contact(Set<Node.Id> nodes, Topologies topologies, Callback<GetEphemeralReadDepsOk> callback)
+    void contact(Collection<Node.Id> nodes, Topologies topologies, Callback<GetEphemeralReadDepsOk> callback)
     {
         CommandStore commandStore = CommandStore.maybeCurrent();
         if (commandStore == null) commandStore = node.commandStores().select(route.homeKey());

--- a/accord-core/src/main/java/accord/coordinate/CoordinatePreAccept.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinatePreAccept.java
@@ -19,8 +19,8 @@
 package accord.coordinate;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 import accord.coordinate.tracking.FastPathTracker;
 import accord.local.CommandStore;
@@ -67,7 +67,7 @@ abstract class CoordinatePreAccept<T> extends AbstractCoordinatePreAccept<T, Pre
         this.txn = txn;
     }
 
-    void contact(Set<Id> nodes, Topologies topologies, Callback<PreAcceptReply> callback)
+    void contact(Collection<Id> nodes, Topologies topologies, Callback<PreAcceptReply> callback)
     {
         // TODO (desired, efficiency): consider sending only to electorate of most recent topology (as only these PreAccept votes matter)
         // note that we must send to all replicas of old topology, as electorate may not be reachable
@@ -141,7 +141,7 @@ abstract class CoordinatePreAccept<T> extends AbstractCoordinatePreAccept<T, Pre
          * We cannot execute the transaction because the execution epoch's topology no longer contains all of the
          * participating keys/ranges, so we propose that the transaction is invalidated in its coordination epoch
          */
-        Propose.Invalidate.proposeInvalidate(node, new Ballot(node.uniqueNow()), txnId, route.someParticipatingKey(), (outcome, failure) -> {
+        Propose.Invalidate.proposeInvalidate(node, new Ballot(node.uniqueNow()), txnId, route.homeKey(), (outcome, failure) -> {
             if (failure != null)
                 mismatch.addSuppressed(failure);
             accept(null, mismatch);

--- a/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
@@ -126,7 +126,7 @@ public class CoordinateSyncPoint<S extends Seekables<?, ?>> extends CoordinatePr
         {
             // we don't need to fetch deps from Accept replies, so we don't need to contact unsynced epochs
             topologies = node.topology().forEpoch(route, txnId.epoch());
-            // TODO (required): consider the required semantics of a SyncPoint
+            // TODO (required, consider): consider the required semantics of a SyncPoint
             if (tracker.hasFastPathAccepted() && txnId.kind() == Kind.SyncPoint)
                 execute(adapter, node, topologies, route, FAST, txnId, txn, txnId, deps, this);
             else

--- a/accord-core/src/main/java/accord/coordinate/CoordinationAdapter.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinationAdapter.java
@@ -115,7 +115,6 @@ public interface CoordinationAdapter<R>
         {
             if (any.oldestEpoch() <= txnId.epoch() && any.currentEpoch() >= executeAt.epoch()) any = any.forEpochs(txnId.epoch(), executeAt.epoch());
             else any = node.topology().preciseEpochs(route, txnId.epoch(), executeAt.epoch());
-            Topologies executes = any.forEpochs(executeAt.epoch(), executeAt.epoch());
 
             adapter.persist(node, any, route, txnId, txn, executeAt, deps, writes, result, callback);
         }
@@ -248,7 +247,7 @@ public interface CoordinationAdapter<R>
             @Override
             public void execute(Node node, Topologies all, FullRoute<?> route, ExecutePath path, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, BiConsumer<? super SyncPoint<S>, Throwable> callback)
             {
-                // TODO (required): remember and document why we don't use fast path for exclusive sync points
+                // TODO (required, consider): remember and document why we don't use fast path for exclusive sync points
                 if (path == FAST)
                 {
                     Invoke.stabilise(this, node, all, route, Ballot.ZERO, txnId, txn, executeAt, deps, callback);

--- a/accord-core/src/main/java/accord/coordinate/ExecuteEphemeralRead.java
+++ b/accord-core/src/main/java/accord/coordinate/ExecuteEphemeralRead.java
@@ -38,10 +38,12 @@ import accord.primitives.Ranges;
 import accord.primitives.Txn;
 import accord.primitives.TxnId;
 import accord.topology.Topologies;
+import accord.utils.Invariants;
 
 import static accord.coordinate.ReadCoordinator.Action.Aborted;
 import static accord.coordinate.ReadCoordinator.Action.Approve;
 import static accord.coordinate.ReadCoordinator.Action.ApprovePartial;
+import static accord.primitives.Txn.Kind.EphemeralRead;
 import static accord.utils.Invariants.illegalState;
 
 public class ExecuteEphemeralRead extends ReadCoordinator<ReadReply>
@@ -60,7 +62,8 @@ public class ExecuteEphemeralRead extends ReadCoordinator<ReadReply>
     {
         // we need to send Stable to the origin epoch as well as the execution epoch
         // TODO (desired): permit slicing Topologies by key (though unnecessary if we eliminate the concept of non-participating home keys)
-        super(node, route.isParticipatingHomeKey() ? topologies : node.topology().preciseEpochs(route, txnId.epoch(), executionEpoch), txnId);
+        super(node, topologies, txnId);
+        Invariants.checkArgument(txnId.kind() == EphemeralRead);
         this.txn = txn;
         this.route = route;
         this.allTopologies = topologies;

--- a/accord-core/src/main/java/accord/coordinate/ExecuteSyncPoint.java
+++ b/accord-core/src/main/java/accord/coordinate/ExecuteSyncPoint.java
@@ -109,7 +109,7 @@ public abstract class ExecuteSyncPoint<S extends Seekables<?, ?>> extends Settab
         }
         else
         {
-            // TODO (required): we also need to handle ranges not being safe to read
+            // TODO (required, consider): do we need to handle ranges not being safe to read
             if (tracker.recordSuccess(from) == RequestStatus.Success)
                 onSuccess();
         }

--- a/accord-core/src/main/java/accord/coordinate/ExecuteTxn.java
+++ b/accord-core/src/main/java/accord/coordinate/ExecuteTxn.java
@@ -69,7 +69,7 @@ public class ExecuteTxn extends ReadCoordinator<ReadReply>
     {
         // we need to send Stable to the origin epoch as well as the execution epoch
         // TODO (desired): permit slicing Topologies by key (though unnecessary if we eliminate the concept of non-participating home keys)
-        super(node, route.isParticipatingHomeKey() ? topologies : node.topology().preciseEpochs(readScope, txnId.epoch(), executeAt.epoch()), txnId);
+        super(node, topologies, txnId);
         this.path = path;
         this.txn = txn;
         this.route = route;

--- a/accord-core/src/main/java/accord/coordinate/FetchMaxConflict.java
+++ b/accord-core/src/main/java/accord/coordinate/FetchMaxConflict.java
@@ -18,7 +18,7 @@
 
 package accord.coordinate;
 
-import java.util.Set;
+import java.util.Collection;
 
 import accord.coordinate.tracking.QuorumTracker;
 import accord.local.Node;
@@ -83,7 +83,7 @@ public class FetchMaxConflict extends AbstractCoordinatePreAccept<Timestamp, Get
     }
 
     @Override
-    void contact(Set<Node.Id> nodes, Topologies topologies, Callback<GetMaxConflictOk> callback)
+    void contact(Collection<Node.Id> nodes, Topologies topologies, Callback<GetMaxConflictOk> callback)
     {
         node.send(nodes, to -> new GetMaxConflict(to, topologies, route, keysOrRanges, executionEpoch), callback);
     }

--- a/accord-core/src/main/java/accord/coordinate/MaybeRecover.java
+++ b/accord-core/src/main/java/accord/coordinate/MaybeRecover.java
@@ -21,6 +21,7 @@ package accord.coordinate;
 import java.util.function.BiConsumer;
 
 import accord.local.Status.Known;
+import accord.messages.InformDurable;
 import accord.primitives.*;
 import accord.utils.Invariants;
 
@@ -104,6 +105,8 @@ public class MaybeRecover extends CheckShards<Route<?>>
                     // we have included the home key, and one that witnessed the definition has responded, so it should also know the full route
                     if (hasMadeProgress(full))
                     {
+                        if (full.durability.isDurable())
+                            node.send(topologies.forEpoch(txnId.epoch()).forKey(route.homeKey()).nodes, to -> new InformDurable(to, topologies, route, txnId, full.executeAtIfKnown(), full.durability));
                         callback.accept(full.toProgressToken(), null);
                     }
                     else

--- a/accord-core/src/main/java/accord/coordinate/Propose.java
+++ b/accord-core/src/main/java/accord/coordinate/Propose.java
@@ -19,9 +19,9 @@
 package accord.coordinate;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.BiConsumer;
 
 import accord.api.RoutingKey;
@@ -60,7 +60,7 @@ abstract class Propose<R> implements Callback<AcceptReply>
     final Deps deps;
 
     final List<AcceptReply> acceptOks;
-    private final Map<Id, AcceptReply> debug = debug() ? new HashMap<>() : null;
+    private final Map<Id, AcceptReply> debug = debug() ? new TreeMap<>() : null;
     final Timestamp executeAt;
     final QuorumTracker acceptTracker;
     final BiConsumer<? super R, Throwable> callback;
@@ -144,7 +144,7 @@ abstract class Propose<R> implements Callback<AcceptReply>
         final TxnId txnId;
         final RoutingKey someParticipant;
         final BiConsumer<Void, Throwable> callback;
-        final Map<Id, AcceptReply> debug = debug() ? new HashMap<>() : null;
+        final Map<Id, AcceptReply> debug = debug() ? new TreeMap<>() : null;
 
         private final QuorumShardTracker acceptTracker;
         private boolean isDone;

--- a/accord-core/src/main/java/accord/coordinate/ReadCoordinator.java
+++ b/accord-core/src/main/java/accord/coordinate/ReadCoordinator.java
@@ -95,7 +95,7 @@ public abstract class ReadCoordinator<Reply extends accord.messages.Reply> exten
     protected final TxnId txnId;
     private boolean isDone;
     private Throwable failure;
-    final Map<Id, Object> debug = debug() ? new HashMap<>() : null;
+    final Map<Id, Object> debug = debug() ? new TreeMap<>() : null;
 
     protected ReadCoordinator(Node node, Topologies topologies, TxnId txnId)
     {

--- a/accord-core/src/main/java/accord/coordinate/RecoverWithRoute.java
+++ b/accord-core/src/main/java/accord/coordinate/RecoverWithRoute.java
@@ -186,8 +186,8 @@ public class RecoverWithRoute extends CheckShards<FullRoute<?>>
                             // so that we know to WasApply, but not
                             if (known.executeAt == ExecuteAtKnown && known.deps == DepsKnown && known.outcome == Apply)
                             {
-                                Invariants.checkState(full.stableDeps.covering.containsAll(sendTo));
-                                Invariants.checkState(full.partialTxn.covering().containsAll(sendTo));
+                                Invariants.checkState(full.stableDeps.covers(sendTo));
+                                Invariants.checkState(full.partialTxn.covers(sendTo));
                                 persist(node.coordinationAdapter(txnId, InitiateRecovery), node, route, sendTo, txnId, full.partialTxn, full.executeAt, full.stableDeps, full.writes, full.result, null);
                             }
                             propagate = full;

--- a/accord-core/src/main/java/accord/coordinate/Stabilise.java
+++ b/accord-core/src/main/java/accord/coordinate/Stabilise.java
@@ -18,8 +18,8 @@
 
 package accord.coordinate;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.function.BiConsumer;
 
 import accord.coordinate.tracking.QuorumTracker;
@@ -54,7 +54,7 @@ public abstract class Stabilise<R> implements Callback<ReadReply>
     final Timestamp executeAt;
     final Deps stabiliseDeps;
 
-    private final Map<Node.Id, Object> debug = debug() ? new HashMap<>() : null;
+    private final Map<Node.Id, Object> debug = debug() ? new TreeMap<>() : null;
     final QuorumTracker stableTracker;
     final Topologies allTopologies;
     final BiConsumer<? super R, Throwable> callback;

--- a/accord-core/src/main/java/accord/coordinate/tracking/AbstractTracker.java
+++ b/accord-core/src/main/java/accord/coordinate/tracking/AbstractTracker.java
@@ -175,7 +175,7 @@ public abstract class AbstractTracker<ST extends ShardTracker>
         return true;
     }
 
-    public Set<Id> nodes()
+    public Collection<Id> nodes()
     {
         return topologies.nodes();
     }

--- a/accord-core/src/main/java/accord/impl/ErasedSafeCommand.java
+++ b/accord-core/src/main/java/accord/impl/ErasedSafeCommand.java
@@ -28,7 +28,8 @@ import accord.utils.Invariants;
 
 import static accord.local.Listeners.Immutable.EMPTY;
 import static accord.local.SaveStatus.Erased;
-import static accord.local.SaveStatus.ErasedOrInvalidated;
+import static accord.local.SaveStatus.ErasedOrInvalidOrVestigial;
+import static accord.local.Status.Durability.NotDurable;
 import static accord.local.Status.Durability.UniversalOrInvalidated;
 
 public class ErasedSafeCommand extends SafeCommand
@@ -38,8 +39,8 @@ public class ErasedSafeCommand extends SafeCommand
     public ErasedSafeCommand(TxnId txnId, SaveStatus saveStatus)
     {
         super(txnId);
-        Invariants.checkArgument(saveStatus == Erased || saveStatus == ErasedOrInvalidated);
-        this.erased = new Command.Truncated(txnId, saveStatus, UniversalOrInvalidated, null, null, EMPTY, null, null);
+        Invariants.checkArgument(saveStatus == Erased || saveStatus == ErasedOrInvalidOrVestigial);
+        this.erased = new Command.Truncated(txnId, saveStatus, saveStatus == ErasedOrInvalidOrVestigial ? NotDurable : UniversalOrInvalidated, null, null, EMPTY, null, null);
     }
 
     @Override

--- a/accord-core/src/main/java/accord/impl/SimpleProgressLog.java
+++ b/accord-core/src/main/java/accord/impl/SimpleProgressLog.java
@@ -69,6 +69,7 @@ import static accord.local.PreLoadContext.contextFor;
 import static accord.local.PreLoadContext.empty;
 import static accord.local.SaveStatus.LocalExecution.NotReady;
 import static accord.local.SaveStatus.LocalExecution.WaitingToApply;
+import static accord.local.Status.KnownRoute.Full;
 import static accord.local.Status.PreApplied;
 import static accord.utils.Invariants.illegalState;
 
@@ -292,7 +293,7 @@ public class SimpleProgressLog implements ProgressLog.Factory
                 {
                     Invariants.checkState(route != null || participants != null, "Route and participants are both undefined");
                     Invariants.checkState(participants == null || !participants.isEmpty(), "participants is empty");
-                    Invariants.checkState(route == null || route.hasParticipants(), "Route %s does not have participants", route);
+                    Invariants.checkState(route == null || !route.isEmpty(), "Route %s is empty", route);
 
                     this.route = Route.merge(this.route, (Route)route);
                     this.participants = Participants.merge(this.participants, (Participants) participants);
@@ -340,7 +341,7 @@ public class SimpleProgressLog implements ProgressLog.Factory
 
                             setProgress(Expected);
                             // TODO (required): we might not be in the coordinating OR execution epochs if an accept round contacted us but recovery did not (quite hard to achieve)
-                            Invariants.checkState(fail != null || !blockedUntil.isSatisfiedBy(success.propagates()));
+                            Invariants.checkState(fail != null || !blockedUntil.isSatisfiedBy(success.propagates()) || success.route != Full);
                         }).begin(commandStore.agent());
                     };
 

--- a/accord-core/src/main/java/accord/local/Cleanup.java
+++ b/accord-core/src/main/java/accord/local/Cleanup.java
@@ -58,14 +58,6 @@ public enum Cleanup
     }
 
     /**
-     * Durability has been achieved globally across all keys/ranges that make this txnId's metadata safe to purge
-     */
-    public static boolean isSafeToCleanup(DurableBefore durableBefore, TxnId txnId)
-    {
-        return durableBefore.min(txnId) == UniversalOrInvalidated;
-    }
-
-    /**
      * Durability has been achieved for the specific keys associated with this txnId that makes its metadata safe to purge
      */
     public static boolean isSafeToCleanup(DurableBefore durableBefore, TxnId txnId, Unseekables<?> participants)
@@ -128,14 +120,12 @@ public enum Cleanup
                 //      - we can impose additional validations here IF we receive an epoch upper bound
                 //      - we should be more robust to the presence/absence of executeAt
                 //      - be cognisant of future epochs that participated only for PreAccept/Accept, but where txn was not committed to execute in the epoch (this is why we provide null toEpoch here)
-                if (route.isParticipatingHomeKey() || redundantBefore.get(txnId, NO_UPPER_BOUND, route.homeKey()) == NOT_OWNED)
-                    illegalState("Command " + txnId + " that is being loaded is not owned by this shard on route " + route);
+                illegalState("Command " + txnId + " that is being loaded is not owned by this shard on route " + route);
             }
         }
         switch (redundant)
         {
             default: throw new AssertionError();
-            case NOT_OWNED:
             case LIVE:
             case PARTIALLY_PRE_BOOTSTRAP_OR_STALE:
             case PRE_BOOTSTRAP_OR_STALE:

--- a/accord-core/src/main/java/accord/local/CommandStore.java
+++ b/accord-core/src/main/java/accord/local/CommandStore.java
@@ -465,7 +465,7 @@ public abstract class CommandStore implements AgentExecutor
         Timestamp before = Timestamp.minForEpoch(epoch);
         FullRoute<?> route = node.computeRoute(id, ranges);
         // TODO (required): we need to ensure anyone we receive a reply from proposes newer timestamps for anything we don't see
-        CollectDeps.withDeps(node, id, route, ranges, before, (deps, fail) -> {
+        CollectDeps.withDeps(node, id, route, route, ranges, before, (deps, fail) -> {
             if (fail != null)
             {
                 fetchMajorityDeps(coordination, node, epoch, ranges);

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -40,6 +40,7 @@ import accord.api.ProgressLog;
 import accord.api.RoutingKey;
 import accord.local.CommandStore.EpochUpdateHolder;
 import accord.primitives.EpochSupplier;
+import accord.primitives.Participants;
 import accord.primitives.Range;
 import accord.primitives.Ranges;
 import accord.primitives.Routables;
@@ -115,9 +116,9 @@ public abstract class CommandStores
         }
     }
 
-    static class ShardHolder
+    protected static class ShardHolder
     {
-        final CommandStore store;
+        public final CommandStore store;
         RangesForEpoch ranges;
 
         ShardHolder(CommandStore store)
@@ -335,9 +336,9 @@ public abstract class CommandStores
         }
     }
 
-    static class Snapshot
+    protected static class Snapshot
     {
-        final ShardHolder[] shards;
+        public final ShardHolder[] shards;
         final Int2ObjectHashMap<CommandStore> byId;
         final Topology local;
         final Topology global;
@@ -665,6 +666,11 @@ public abstract class CommandStores
         return  select(ranges -> ranges.intersects(route));
     }
 
+    public CommandStore select(Participants<?> participants)
+    {
+        return  select(ranges -> ranges.intersects(participants));
+    }
+
     private CommandStore select(Predicate<Ranges> fn)
     {
         ShardHolder[] shards = current.shards;
@@ -722,5 +728,10 @@ public abstract class CommandStores
                 return shard.store;
         }
         throw new IllegalArgumentException();
+    }
+
+    protected Snapshot current()
+    {
+        return current;
     }
 }

--- a/accord-core/src/main/java/accord/local/DurableBefore.java
+++ b/accord-core/src/main/java/accord/local/DurableBefore.java
@@ -24,8 +24,8 @@ import javax.annotation.Nullable;
 
 import accord.api.RoutingKey;
 import accord.local.Status.Durability;
+import accord.primitives.AbstractRanges;
 import accord.primitives.Participants;
-import accord.primitives.Ranges;
 import accord.primitives.TxnId;
 import accord.primitives.Unseekables;
 import accord.utils.Invariants;
@@ -147,7 +147,7 @@ public class DurableBefore extends ReducingRangeMap<DurableBefore.Entry>
         }
     }
 
-    public static DurableBefore create(Ranges ranges, @Nonnull TxnId majority, @Nonnull TxnId universal)
+    public static DurableBefore create(AbstractRanges ranges, @Nonnull TxnId majority, @Nonnull TxnId universal)
     {
         if (ranges.isEmpty())
             return DurableBefore.EMPTY;

--- a/accord-core/src/main/java/accord/local/MaxConflicts.java
+++ b/accord-core/src/main/java/accord/local/MaxConflicts.java
@@ -21,7 +21,7 @@ package accord.local;
 import javax.annotation.Nonnull;
 
 import accord.api.RoutingKey;
-import accord.primitives.Ranges;
+import accord.primitives.AbstractRanges;
 import accord.primitives.Routables;
 import accord.primitives.Seekables;
 import accord.primitives.Timestamp;
@@ -58,7 +58,7 @@ public class MaxConflicts extends ReducingRangeMap<Timestamp>
         return merge(this, create(keysOrRanges, maxConflict));
     }
 
-    public static MaxConflicts create(Ranges ranges, @Nonnull Timestamp maxConflict)
+    public static MaxConflicts create(AbstractRanges ranges, @Nonnull Timestamp maxConflict)
     {
         if (ranges.isEmpty())
             return MaxConflicts.EMPTY;

--- a/accord-core/src/main/java/accord/local/SafeCommandStore.java
+++ b/accord-core/src/main/java/accord/local/SafeCommandStore.java
@@ -46,7 +46,7 @@ import static accord.local.Cleanup.NO;
 import static accord.local.KeyHistory.COMMANDS;
 import static accord.local.RedundantBefore.PreBootstrapOrStale.FULLY;
 import static accord.local.SaveStatus.Erased;
-import static accord.local.SaveStatus.ErasedOrInvalidated;
+import static accord.local.SaveStatus.ErasedOrInvalidOrVestigial;
 import static accord.primitives.Route.isFullRoute;
 
 /**
@@ -94,7 +94,7 @@ public abstract class SafeCommandStore
         if (command.saveStatus().isUninitialised())
         {
             if (commandStore().durableBefore().isUniversal(txnId, unseekable))
-                return new ErasedSafeCommand(txnId, ErasedOrInvalidated);
+                return new ErasedSafeCommand(txnId, ErasedOrInvalidOrVestigial);
         }
         return maybeTruncate(safeCommand, command, txnId, null);
     }
@@ -126,7 +126,7 @@ public abstract class SafeCommandStore
         if (command.saveStatus().isUninitialised())
         {
             if (Cleanup.isSafeToCleanup(commandStore().durableBefore(), txnId, unseekables))
-                return new ErasedSafeCommand(txnId, isFullRoute(unseekables) ? Erased : ErasedOrInvalidated);
+                return new ErasedSafeCommand(txnId, isFullRoute(unseekables) ? Erased : ErasedOrInvalidOrVestigial);
         }
         return maybeTruncate(safeCommand, command, toEpoch, unseekables);
     }

--- a/accord-core/src/main/java/accord/local/Status.java
+++ b/accord-core/src/main/java/accord/local/Status.java
@@ -78,7 +78,7 @@ public enum Status
      */
     PreCommitted      (Accept,  Maybe, DefinitionUnknown, ExecuteAtKnown,   DepsUnknown,  Unknown),
 
-    Committed         (Commit, Full,   DefinitionKnown,   ExecuteAtKnown,   DepsCommitted, Unknown),
+    Committed         (Commit,  Full,  DefinitionKnown,   ExecuteAtKnown,   DepsCommitted,Unknown),
     Stable            (Execute, Full,  DefinitionKnown,   ExecuteAtKnown,   DepsKnown,    Unknown),
     PreApplied        (Persist, Full,  DefinitionKnown,   ExecuteAtKnown,   DepsKnown,    Outcome.Apply),
     Applied           (Persist, Full,  DefinitionKnown,   ExecuteAtKnown,   DepsKnown,    Outcome.Apply),
@@ -886,6 +886,7 @@ public enum Status
             if (c < 0) { Durability tmp = a; a = b; b = tmp; }
             // if we know we are applied, we can remove the OrInvalidated qualifier
             if (a == UniversalOrInvalidated && (b == Majority || b == ShardUniversal || b == Local)) a = Universal;
+            // TODO (required, minor cleanup): should ShardUniversal+NotDurable=Local? It might be that we are stale.
             if ((a == ShardUniversal) && (b == Local || b == NotDurable)) a = Local;
             if (b == NotDurable && a.compareTo(MajorityOrInvalidated) < 0) a = NotDurable;
             return a;

--- a/accord-core/src/main/java/accord/local/cfk/Pruning.java
+++ b/accord-core/src/main/java/accord/local/cfk/Pruning.java
@@ -35,7 +35,7 @@ import static accord.local.cfk.CommandsForKey.InternalStatus.INVALID_OR_TRUNCATE
 import static accord.local.cfk.CommandsForKey.NO_TXNIDS;
 import static accord.local.cfk.CommandsForKey.managesExecution;
 import static accord.local.cfk.Pruning.LoadingPruned.LOADINGF;
-import static accord.utils.ArrayBuffers.cachedTimestamps;
+import static accord.utils.ArrayBuffers.cachedAny;
 import static accord.utils.ArrayBuffers.cachedTxnIds;
 
 public class Pruning
@@ -203,7 +203,7 @@ public class Pruning
         TxnInfo[] byId = cfk.byId;
         int minUndecidedById = -1;
         int retainCount = 0, removedCommittedCount = 0;
-        Timestamp[] removedExecuteAts = NO_TXNIDS;
+        Object[] removedExecuteAts = NO_TXNIDS;
         int removedExecuteAtCount = 0;
         TxnInfo[] newInfos;
         {
@@ -239,7 +239,7 @@ public class Pruning
                                 if (missing != NO_TXNIDS)
                                 {
                                     if (removedExecuteAtCount == removedExecuteAts.length)
-                                        removedExecuteAts = cachedTimestamps().resize(removedExecuteAts, removedExecuteAtCount, Math.max(8, removedExecuteAtCount + (removedExecuteAtCount >> 1)));
+                                        removedExecuteAts = cachedAny().resize(removedExecuteAts, removedExecuteAtCount, Math.max(8, removedExecuteAtCount + (removedExecuteAtCount >> 1)));
                                     removedExecuteAts[removedExecuteAtCount++] = txn.executeAt;
                                 }
                                 ++removedCommittedCount;
@@ -325,7 +325,7 @@ public class Pruning
             System.arraycopy(committedByExecuteAt, sourcePos, newCommittedByExecuteAt, sourcePos - removedCommittedCount, committedByExecuteAt.length - sourcePos);
         }
 
-        cachedTimestamps().forceDiscard(removedExecuteAts, removedExecuteAtCount);
+        cachedAny().forceDiscard(removedExecuteAts, removedExecuteAtCount);
         int newMaxAppliedWriteByExecuteAt = cfk.maxAppliedWriteByExecuteAt - removedCommittedCount;
         return new CommandsForKey(cfk.key, cfk.redundantBefore, newPrunedBefore, cfk.loadingPruned, newInfos, newCommittedByExecuteAt, minUndecidedById, newMaxAppliedWriteByExecuteAt, cfk.unmanageds);
     }

--- a/accord-core/src/main/java/accord/messages/Accept.java
+++ b/accord-core/src/main/java/accord/messages/Accept.java
@@ -67,8 +67,8 @@ public class Accept extends TxnRequest.WithUnsynced<Accept.AcceptReply>
         super(to, topologies, txnId, route);
         this.ballot = ballot;
         this.executeAt = executeAt;
-        this.keys = keys.slice(scope.covering());
-        this.partialDeps = deps.slice(scope.covering());
+        this.keys = keys.intersecting(scope);
+        this.partialDeps = deps.intersecting(scope);
     }
 
     private Accept(TxnId txnId, PartialRoute<?> scope, long waitForEpoch, long minEpoch, boolean doNotComputeProgressKey, Ballot ballot, Timestamp executeAt, Seekables<?, ?> keys, PartialDeps partialDeps)
@@ -113,7 +113,7 @@ public class Accept extends TxnRequest.WithUnsynced<Accept.AcceptReply>
     private PartialDeps calculatePartialDeps(SafeCommandStore safeStore)
     {
         Ranges ranges = safeStore.ranges().allBetween(minUnsyncedEpoch, executeAt);
-        return PreAccept.calculatePartialDeps(safeStore, txnId, keys, EpochSupplier.constant(minUnsyncedEpoch), executeAt, ranges);
+        return PreAccept.calculatePartialDeps(safeStore, txnId, keys, scope, EpochSupplier.constant(minUnsyncedEpoch), executeAt, ranges);
     }
 
     @Override

--- a/accord-core/src/main/java/accord/messages/Apply.java
+++ b/accord-core/src/main/java/accord/messages/Apply.java
@@ -78,9 +78,9 @@ public class Apply extends TxnRequest<ApplyReply>
         // TODO (desired): it's wasteful to encode the full set of ranges owned by the recipient node;
         //     often it will be cheaper to include the FullRoute for Deps scope (or come up with some other safety-preserving encoding scheme)
         this.kind = kind;
-        this.deps = deps.slice(scope.covering());
-        this.keys = txn.keys().slice(scope.covering());
-        this.txn = kind == Kind.Maximal ? txn.slice(scope.covering(), true) : null;
+        this.deps = deps.intersecting(scope);
+        this.keys = txn.keys().intersecting(scope);
+        this.txn = kind == Kind.Maximal ? txn.intersecting(scope, true) : null;
         this.fullRoute = kind == Kind.Maximal ? route : null;
         this.executeAt = executeAt;
         this.writes = writes;

--- a/accord-core/src/main/java/accord/messages/ApplyThenWaitUntilApplied.java
+++ b/accord-core/src/main/java/accord/messages/ApplyThenWaitUntilApplied.java
@@ -37,6 +37,7 @@ import accord.primitives.PartialDeps;
 import accord.primitives.PartialTxn;
 import accord.primitives.Participants;
 import accord.primitives.Ranges;
+import accord.primitives.Route;
 import accord.primitives.Seekables;
 import accord.primitives.Timestamp;
 import accord.primitives.Txn;
@@ -78,13 +79,13 @@ public class ApplyThenWaitUntilApplied extends WaitUntilApplied
     {
         super(to, topologies, txnId, readScope, executeAt.epoch());
         this.executeAt = executeAt;
-        Ranges slice = computeScope(to, topologies, null, 0, (i,r)->r, Ranges::with);
+        Route<?> scope = computeScope(to, topologies, route);
         this.route = route;
-        this.txn = txn.slice(slice, true);
-        this.deps = deps.slice(slice);
+        this.txn = txn.intersecting(scope, true);
+        this.deps = deps.intersecting(scope);
         this.writes = writes;
         this.result = result;
-        this.notify = notify == null ? null : notify.slice(slice);
+        this.notify = notify == null ? null : notify.intersecting(scope);
     }
 
     protected ApplyThenWaitUntilApplied(TxnId txnId, Participants<?> readScope, Timestamp executeAt, FullRoute<?> route, PartialTxn txn, PartialDeps deps, Writes writes, Result result, Seekables<?, ?> notify)

--- a/accord-core/src/main/java/accord/messages/GetDeps.java
+++ b/accord-core/src/main/java/accord/messages/GetDeps.java
@@ -52,7 +52,7 @@ public class GetDeps extends TxnRequest.WithUnsynced<PartialDeps>
     public GetDeps(Id to, Topologies topologies, FullRoute<?> route, TxnId txnId, Seekables<?, ?> keys, Timestamp executeAt)
     {
         super(to, topologies, txnId, route);
-        this.keys = keys.slice(scope.covering());
+        this.keys = keys.intersecting(scope);
         this.executeAt = executeAt;
     }
 
@@ -73,7 +73,7 @@ public class GetDeps extends TxnRequest.WithUnsynced<PartialDeps>
     public PartialDeps apply(SafeCommandStore instance)
     {
         Ranges ranges = instance.ranges().allBetween(minUnsyncedEpoch, executeAt);
-        return calculatePartialDeps(instance, txnId, keys, constant(minUnsyncedEpoch), executeAt, ranges);
+        return calculatePartialDeps(instance, txnId, keys, scope, constant(minUnsyncedEpoch), executeAt, ranges);
     }
 
     @Override

--- a/accord-core/src/main/java/accord/messages/GetEphemeralReadDeps.java
+++ b/accord-core/src/main/java/accord/messages/GetEphemeralReadDeps.java
@@ -52,7 +52,7 @@ public class GetEphemeralReadDeps extends TxnRequest.WithUnsynced<GetEphemeralRe
     public GetEphemeralReadDeps(Id to, Topologies topologies, FullRoute<?> route, TxnId txnId, Seekables<?, ?> keys, long executionEpoch)
     {
         super(to, topologies, txnId, route);
-        this.keys = keys.slice(scope.covering());
+        this.keys = keys.intersecting(scope);
         this.executionEpoch = executionEpoch;
     }
 
@@ -73,7 +73,7 @@ public class GetEphemeralReadDeps extends TxnRequest.WithUnsynced<GetEphemeralRe
     public GetEphemeralReadDepsOk apply(SafeCommandStore safeStore)
     {
         Ranges ranges = safeStore.ranges().allBetween(minUnsyncedEpoch, executionEpoch);
-        PartialDeps deps = calculatePartialDeps(safeStore, txnId, keys, constant(minUnsyncedEpoch), Timestamp.MAX, ranges);
+        PartialDeps deps = calculatePartialDeps(safeStore, txnId, keys, scope, constant(minUnsyncedEpoch), Timestamp.MAX, ranges);
 
         return new GetEphemeralReadDepsOk(deps, Math.max(safeStore.time().epoch(), node.epoch()));
     }

--- a/accord-core/src/main/java/accord/messages/GetMaxConflict.java
+++ b/accord-core/src/main/java/accord/messages/GetMaxConflict.java
@@ -48,7 +48,7 @@ public class GetMaxConflict extends TxnRequest.WithUnsynced<GetMaxConflict.GetMa
     public GetMaxConflict(Node.Id to, Topologies topologies, FullRoute<?> route, Seekables<?, ?> keys, long executionEpoch)
     {
         super(to, topologies, executionEpoch, route);
-        this.keys = keys.slice(scope.covering());
+        this.keys = keys.intersecting(scope);
         this.executionEpoch = executionEpoch;
     }
 

--- a/accord-core/src/main/java/accord/messages/InformDurable.java
+++ b/accord-core/src/main/java/accord/messages/InformDurable.java
@@ -17,6 +17,8 @@
  */
 package accord.messages;
 
+import javax.annotation.Nullable;
+
 import accord.local.Commands;
 import accord.local.Node.Id;
 import accord.local.PreLoadContext;
@@ -24,8 +26,8 @@ import accord.local.SafeCommand;
 import accord.local.SafeCommandStore;
 import accord.local.Status;
 import accord.local.Status.Durability;
-import accord.primitives.FullRoute;
 import accord.primitives.PartialRoute;
+import accord.primitives.Route;
 import accord.primitives.Timestamp;
 import accord.primitives.TxnId;
 import accord.topology.Topologies;
@@ -44,17 +46,17 @@ public class InformDurable extends TxnRequest<Reply> implements PreLoadContext
         }
     }
 
-    public final Timestamp executeAt;
+    public final @Nullable Timestamp executeAt;
     public final Durability durability;
 
-    public InformDurable(Id to, Topologies topologies, FullRoute<?> route, TxnId txnId, Timestamp executeAt, Durability durability)
+    public InformDurable(Id to, Topologies topologies, Route<?> route, TxnId txnId, @Nullable Timestamp executeAt, Durability durability)
     {
         super(to, topologies, route, txnId);
         this.executeAt = executeAt;
         this.durability = durability;
     }
 
-    private InformDurable(TxnId txnId, PartialRoute<?> scope, long waitForEpoch, Timestamp executeAt, Durability durability)
+    private InformDurable(TxnId txnId, PartialRoute<?> scope, long waitForEpoch, @Nullable Timestamp executeAt, Durability durability)
     {
         super(txnId, scope, waitForEpoch);
         this.executeAt = executeAt;

--- a/accord-core/src/main/java/accord/messages/InformHomeDurable.java
+++ b/accord-core/src/main/java/accord/messages/InformHomeDurable.java
@@ -18,10 +18,6 @@
 
 package accord.messages;
 
-import java.util.Set;
-
-import com.google.common.collect.ImmutableSet;
-
 import accord.local.Commands;
 import accord.local.Node;
 import accord.local.Node.Id;
@@ -42,15 +38,13 @@ public class InformHomeDurable implements Request
     public final Route<?> route;
     public final Timestamp executeAt;
     public final Durability durability;
-    public final Set<Id> persistedOn;
 
-    public InformHomeDurable(TxnId txnId, Route<?> route, Timestamp executeAt, Durability durability, Set<Id> persistedOn)
+    public InformHomeDurable(TxnId txnId, Route<?> route, Timestamp executeAt, Durability durability)
     {
         this.txnId = txnId;
         this.route = route;
         this.executeAt = executeAt;
         this.durability = durability;
-        this.persistedOn = ImmutableSet.copyOf(persistedOn); // Persisted on might be mutated later
     }
 
     @Override

--- a/accord-core/src/main/java/accord/messages/ReadEphemeralTxnData.java
+++ b/accord-core/src/main/java/accord/messages/ReadEphemeralTxnData.java
@@ -32,6 +32,7 @@ import accord.primitives.PartialDeps;
 import accord.primitives.PartialTxn;
 import accord.primitives.Participants;
 import accord.primitives.Ranges;
+import accord.primitives.Route;
 import accord.primitives.Timestamp;
 import accord.primitives.Txn;
 import accord.primitives.TxnId;
@@ -63,15 +64,15 @@ public class ReadEphemeralTxnData extends ReadData
 
     private ReadEphemeralTxnData(Id to, Topologies topologies, TxnId txnId, Participants<?> readScope, long executeAtEpoch, @Nonnull Txn txn, @Nonnull Deps deps, @Nonnull FullRoute<?> route, int latestRelevantIndex)
     {
-        this(txnId, readScope, computeScope(to, topologies, null, latestRelevantIndex, (i, r) -> r, Ranges::with), executeAtEpoch, txn, deps, route);
+        this(txnId, readScope, computeScope(to, topologies, route, latestRelevantIndex), executeAtEpoch, txn, deps, route);
     }
 
-    private ReadEphemeralTxnData(TxnId txnId, Participants<?> readScope, Ranges slice, long executeAtEpoch, @Nonnull Txn txn, @Nonnull Deps deps, @Nonnull FullRoute<?> route)
+    private ReadEphemeralTxnData(TxnId txnId, Participants<?> readScope, Route<?> scope, long executeAtEpoch, @Nonnull Txn txn, @Nonnull Deps deps, @Nonnull FullRoute<?> route)
     {
-        super(txnId, readScope.slice(slice), executeAtEpoch);
+        super(txnId, readScope.intersecting(scope), executeAtEpoch);
         this.route = route;
-        this.partialTxn = txn.slice(slice, false);
-        this.partialDeps = deps.slice(slice);
+        this.partialTxn = txn.intersecting(scope, false);
+        this.partialDeps = deps.intersecting(scope);
     }
 
     public ReadEphemeralTxnData(TxnId txnId, Participants<?> readScope, long executeAtEpoch, @Nonnull PartialTxn partialTxn, @Nonnull PartialDeps partialDeps, @Nonnull FullRoute<?> route)

--- a/accord-core/src/main/java/accord/messages/TxnRequest.java
+++ b/accord-core/src/main/java/accord/messages/TxnRequest.java
@@ -107,6 +107,7 @@ public abstract class TxnRequest<R> implements Request, PreLoadContext, MapReduc
     public final TxnId txnId;
     public final PartialRoute<?> scope;
     public final long waitForEpoch;
+    // set on receive only
     protected transient RoutingKey progressKey;
     protected transient Node node;
     protected transient Id replyTo;

--- a/accord-core/src/main/java/accord/primitives/AbstractUnseekableKeys.java
+++ b/accord-core/src/main/java/accord/primitives/AbstractUnseekableKeys.java
@@ -40,20 +40,32 @@ implements Iterable<RoutingKey>, Unseekables<RoutingKey>, Participants<RoutingKe
     }
 
     @Override
-    public final AbstractUnseekableKeys intersect(Unseekables<?> keysOrRanges)
+    public final boolean intersectsAll(Unseekables<?> keysOrRanges)
     {
-        switch (keysOrRanges.domain())
+        return containsAll(keysOrRanges);
+    }
+
+    @Override
+    public AbstractUnseekableKeys intersecting(Unseekables<?> intersecting, Slice slice)
+    {
+        return intersecting(intersecting);
+    }
+
+    @Override
+    public AbstractUnseekableKeys intersecting(Unseekables<?> intersecting)
+    {
+        switch (intersecting.domain())
         {
-            default: throw new AssertionError("Unhandled domain: " + keysOrRanges.domain());
+            default: throw new AssertionError("Unhandled domain: " + intersecting.domain());
             case Key:
             {
-                AbstractUnseekableKeys that = (AbstractUnseekableKeys) keysOrRanges;
-                return weakWrap(intersect(that, ArrayBuffers.cachedRoutingKeys()), that);
+                AbstractUnseekableKeys that = (AbstractUnseekableKeys) intersecting;
+                return weakWrap(intersecting(that, ArrayBuffers.cachedRoutingKeys()), that);
             }
             case Range:
             {
-                AbstractRanges that = (AbstractRanges) keysOrRanges;
-                return wrap(intersect(that, ArrayBuffers.cachedRoutingKeys()));
+                AbstractRanges that = (AbstractRanges) intersecting;
+                return wrap(intersecting(that, ArrayBuffers.cachedRoutingKeys()));
             }
         }
     }

--- a/accord-core/src/main/java/accord/primitives/Deps.java
+++ b/accord-core/src/main/java/accord/primitives/Deps.java
@@ -212,14 +212,9 @@ public class Deps
         return new Deps(keyDeps.without(remove), rangeDeps.without(remove), directKeyDeps.without(remove));
     }
 
-    public PartialDeps slice(Ranges covering)
+    public PartialDeps intersecting(Participants<?> participants)
     {
-        return slice(covering, covering);
-    }
-
-    public PartialDeps slice(Ranges covering, Ranges slice)
-    {
-        return new PartialDeps(covering, keyDeps.slice(slice), rangeDeps.slice(slice), directKeyDeps.slice(slice));
+        return new PartialDeps(participants, keyDeps.intersecting(participants), rangeDeps.intersecting(participants), directKeyDeps.intersecting(participants));
     }
 
     public boolean isEmpty()

--- a/accord-core/src/main/java/accord/primitives/FullKeyRoute.java
+++ b/accord-core/src/main/java/accord/primitives/FullKeyRoute.java
@@ -25,15 +25,15 @@ public class FullKeyRoute extends KeyRoute implements FullRoute<RoutingKey>
 {
     public static class SerializationSupport
     {
-        public static FullKeyRoute create(RoutingKey homeKey, boolean isParticipatingHomeKey, RoutingKey[] keys)
+        public static FullKeyRoute create(RoutingKey homeKey, RoutingKey[] keys)
         {
-            return new FullKeyRoute(homeKey, isParticipatingHomeKey, keys);
+            return new FullKeyRoute(homeKey, keys);
         }
     }
 
-    public FullKeyRoute(RoutingKey homeKey, boolean isParticipatingHomeKey, RoutingKey[] keys)
+    public FullKeyRoute(RoutingKey homeKey, RoutingKey[] keys)
     {
-        super(homeKey, isParticipatingHomeKey, keys);
+        super(homeKey, keys);
     }
 
     @Override
@@ -43,28 +43,10 @@ public class FullKeyRoute extends KeyRoute implements FullRoute<RoutingKey>
     }
 
     @Override
-    public boolean covers(Ranges ranges)
-    {
-        return true;
-    }
-
-    @Override
     public FullKeyRoute with(RoutingKey withKey)
     {
         Invariants.checkArgument(contains(withKey));
         return this;
-    }
-
-    @Override
-    public PartialKeyRoute slice(Ranges newRanges)
-    {
-        return new PartialKeyRoute(newRanges, homeKey, isParticipatingHomeKey, slice(newRanges, RoutingKey[]::new));
-    }
-
-    @Override
-    public PartialKeyRoute sliceStrict(Ranges ranges)
-    {
-        return slice(ranges);
     }
 
     @Override
@@ -78,5 +60,4 @@ public class FullKeyRoute extends KeyRoute implements FullRoute<RoutingKey>
     {
         return "{homeKey:" + homeKey + ',' + super.toString() + '}';
     }
-
 }

--- a/accord-core/src/main/java/accord/primitives/FullRangeRoute.java
+++ b/accord-core/src/main/java/accord/primitives/FullRangeRoute.java
@@ -24,33 +24,21 @@ public class FullRangeRoute extends RangeRoute implements FullRoute<Range>
 {
     public static class SerializationSupport
     {
-        public static FullRangeRoute create(RoutingKey homeKey, boolean isParticipatingHomeKey, Range[] ranges)
+        public static FullRangeRoute create(RoutingKey homeKey, Range[] ranges)
         {
-            return new FullRangeRoute(homeKey, isParticipatingHomeKey, ranges);
+            return new FullRangeRoute(homeKey, ranges);
         }
     }
 
-    public FullRangeRoute(RoutingKey homeKey, boolean isParticipatingHomeKey, Range[] ranges)
+    public FullRangeRoute(RoutingKey homeKey, Range[] ranges)
     {
-        super(homeKey, isParticipatingHomeKey, ranges);
+        super(homeKey, ranges);
     }
 
     @Override
     public UnseekablesKind kind()
     {
         return UnseekablesKind.FullRangeRoute;
-    }
-
-    @Override
-    public boolean covers(Ranges ranges)
-    {
-        return true;
-    }
-
-    @Override
-    public PartialRangeRoute sliceStrict(Ranges ranges)
-    {
-        return slice(ranges);
     }
 
     @Override

--- a/accord-core/src/main/java/accord/primitives/FullRoute.java
+++ b/accord-core/src/main/java/accord/primitives/FullRoute.java
@@ -21,5 +21,4 @@ package accord.primitives;
 public interface FullRoute<T extends Unseekable> extends Route<T>, Unseekables<T>
 {
     @Override default FullRoute<T> union(Route<T> route) { return this; }
-    @Override default Ranges sliceCovering(Ranges newRanges, Slice slice) { return newRanges; }
 }

--- a/accord-core/src/main/java/accord/primitives/KeyDeps.java
+++ b/accord-core/src/main/java/accord/primitives/KeyDeps.java
@@ -191,9 +191,21 @@ public class KeyDeps implements Iterable<Map.Entry<Key, TxnId>>
         if (isEmpty())
             return new KeyDeps(keys, txnIds, keysToTxnIds);
 
-        // TODO (low priority, efficiency): can slice in parallel with selecting keyToTxnId contents to avoid duplicate merging
-        Keys select = keys.slice(ranges);
+        return select(keys.slice(ranges));
 
+    }
+
+    public KeyDeps intersecting(Unseekables<?> participants)
+    {
+        if (isEmpty())
+            return new KeyDeps(keys, txnIds, keysToTxnIds);
+
+        return select(keys.intersecting(participants));
+    }
+
+    private KeyDeps select(Keys select)
+    {
+        // TODO (low priority, efficiency): can slice in parallel with selecting keyToTxnId contents to avoid duplicate merging
         if (select.isEmpty())
             return new KeyDeps(Keys.EMPTY, NO_TXNIDS, NO_INTS);
 

--- a/accord-core/src/main/java/accord/primitives/KeyRoute.java
+++ b/accord-core/src/main/java/accord/primitives/KeyRoute.java
@@ -18,8 +18,6 @@
 
 package accord.primitives;
 
-import java.util.Arrays;
-
 import accord.utils.Invariants;
 
 import accord.api.RoutingKey;
@@ -32,31 +30,17 @@ import static accord.utils.ArrayBuffers.cachedRoutingKeys;
 public abstract class KeyRoute extends AbstractUnseekableKeys implements Route<RoutingKey>
 {
     public final RoutingKey homeKey;
-    public final boolean isParticipatingHomeKey;
 
-    KeyRoute(@Nonnull RoutingKey homeKey, boolean isParticipatingHomeKey, RoutingKey[] keys)
+    KeyRoute(@Nonnull RoutingKey homeKey, RoutingKey[] keys)
     {
         super(keys);
         this.homeKey = Invariants.nonNull(homeKey);
-        this.isParticipatingHomeKey = isParticipatingHomeKey;
     }
 
     @Override
     public boolean participatesIn(Ranges ranges)
     {
-        if (isParticipatingHomeKey())
-            return intersects(ranges);
-
-        long ij = findNextIntersection(0, ranges, 0);
-        if (ij < 0)
-            return false;
-
-        int i = (int)ij;
-        if (!get(i).equals(homeKey))
-            return true;
-
-        int j = (int)(ij >>> 32);
-        return findNextIntersection(i + 1, ranges, j) >= 0;
+        return intersects(ranges);
     }
 
     @SuppressWarnings("unchecked")
@@ -78,36 +62,14 @@ public abstract class KeyRoute extends AbstractUnseekableKeys implements Route<R
     @Override
     public Participants<RoutingKey> participants()
     {
-        if (isParticipatingHomeKey)
-            return this;
-
-        int removePos = Arrays.binarySearch(keys, homeKey);
-        if (removePos < 0)
-            return this;
-
-        RoutingKey[] result = new RoutingKey[keys.length - 1];
-        System.arraycopy(keys, 0, result, 0, removePos);
-        System.arraycopy(keys, removePos + 1, result, removePos, keys.length - (1 + removePos));
-        // TODO (expected): this should return a PartialKeyRoute, but we need to remove covering()
-        return new RoutingKeys(result);
+        return this;
     }
 
     @Override
     public Participants<RoutingKey> participants(Ranges ranges)
     {
         RoutingKey[] keys = slice(ranges, RoutingKey[]::new);
-        if (isParticipatingHomeKey)
-            return keys == this.keys ? this : new RoutingKeys(keys);
-
-        int removePos = Arrays.binarySearch(keys, homeKey);
-        if (removePos < 0)
-            return new RoutingKeys(keys);
-
-        RoutingKey[] result = new RoutingKey[keys.length - 1];
-        System.arraycopy(keys, 0, result, 0, removePos);
-        System.arraycopy(keys, removePos + 1, result, removePos, keys.length - (1 + removePos));
-        // TODO (expected): this should return a PartialKeyRoute, but we need to remove covering()
-        return new RoutingKeys(result);
+        return keys == this.keys ? this : new RoutingKeys(keys);
     }
 
     @Override
@@ -116,37 +78,40 @@ public abstract class KeyRoute extends AbstractUnseekableKeys implements Route<R
         return participants(ranges);
     }
 
-    public Ranges toRanges()
-    {
-        Invariants.checkState(isParticipatingHomeKey);
-        return super.toRanges();
-    }
-
     @Override
     public RoutingKey homeKey()
     {
         return homeKey;
     }
 
-    @Override
-    public boolean isParticipatingHomeKey()
-    {
-        return isParticipatingHomeKey;
-    }
 
     @Override
-    public RoutingKey someParticipatingKey()
+    public PartialKeyRoute slice(Ranges select)
     {
-        return isParticipatingHomeKey ? homeKey : keys[0];
+        return new PartialKeyRoute(homeKey, slice(select, RoutingKey[]::new));
     }
-
-    @Override
-    public abstract PartialKeyRoute slice(Ranges ranges);
 
     @Override
     public PartialKeyRoute slice(Ranges ranges, Slice slice)
     {
         return slice(ranges);
+    }
+
+    @Override
+    public PartialKeyRoute intersecting(Unseekables<?> intersecting)
+    {
+        switch (intersecting.domain())
+        {
+            default: throw new AssertionError("Unhandled domain: " + intersecting.domain());
+            case Key: return new PartialKeyRoute(homeKey, intersecting((AbstractUnseekableKeys)intersecting, cachedRoutingKeys()));
+            case Range: return new PartialKeyRoute(homeKey, slice((AbstractRanges)intersecting, RoutingKey[]::new));
+        }
+    }
+
+    @Override
+    public PartialKeyRoute intersecting(Unseekables<?> intersecting, Slice slice)
+    {
+        return intersecting(intersecting);
     }
 
     private AbstractUnseekableKeys wrap(RoutingKey[] wrap, AbstractKeys<RoutingKey> that)

--- a/accord-core/src/main/java/accord/primitives/PartialKeyRoute.java
+++ b/accord-core/src/main/java/accord/primitives/PartialKeyRoute.java
@@ -18,6 +18,8 @@
 
 package accord.primitives;
 
+import java.util.Arrays;
+
 import accord.utils.Invariants;
 
 import accord.api.RoutingKey;
@@ -30,34 +32,25 @@ public class PartialKeyRoute extends KeyRoute implements PartialRoute<RoutingKey
 {
     public static class SerializationSupport
     {
-        public static PartialKeyRoute create(Ranges covering, RoutingKey homeKey, boolean isParticipatingHomeKey, RoutingKey[] keys)
+        public static PartialKeyRoute create(RoutingKey homeKey, RoutingKey[] keys)
         {
-            return new PartialKeyRoute(covering, homeKey, isParticipatingHomeKey, keys);
+            return new PartialKeyRoute(homeKey, keys);
         }
     }
 
-    public final Ranges covering;
 
-    public PartialKeyRoute(Ranges covering, RoutingKey homeKey, boolean isParticipatingHomeKey, RoutingKey[] keys)
+    public PartialKeyRoute(RoutingKey homeKey, RoutingKey[] keys)
     {
-        super(homeKey, isParticipatingHomeKey, keys);
-        this.covering = covering;
+        super(homeKey, keys);
     }
 
     @Override
-    public PartialKeyRoute sliceStrict(Ranges newRanges)
+    public PartialKeyRoute slice(Ranges select)
     {
-        if (!covering.containsAll(newRanges))
-            throw new IllegalArgumentException("Not covered");
-
-        return slice(newRanges);
-    }
-
-    @Override
-    public PartialKeyRoute slice(Ranges newRanges)
-    {
-        RoutingKey[] keys = slice(newRanges, RoutingKey[]::new);
-        return new PartialKeyRoute(newRanges, homeKey, isParticipatingHomeKey, keys);
+        RoutingKey[] keys = slice(select, RoutingKey[]::new);
+        if (keys == this.keys)
+            return this;
+        return new PartialKeyRoute(homeKey, keys);
     }
 
     @Override
@@ -74,12 +67,6 @@ public class PartialKeyRoute extends KeyRoute implements PartialRoute<RoutingKey
     }
 
     @Override
-    public boolean covers(Ranges ranges)
-    {
-        return covering.containsAll(ranges);
-    }
-
-    @Override
     public AbstractUnseekableKeys with(RoutingKey withKey)
     {
         if (withKey.equals(homeKey))
@@ -88,31 +75,33 @@ public class PartialKeyRoute extends KeyRoute implements PartialRoute<RoutingKey
         if (contains(withKey))
             return this;
 
-        return new RoutingKeys(toRoutingKeysArray(withKey));
+        return new RoutingKeys(toRoutingKeysArray(withKey, true));
     }
 
     @Override
     public PartialKeyRoute withHomeKey()
     {
-        if (contains(homeKey))
+        int insertPos = Arrays.binarySearch(keys, homeKey);
+        if (insertPos >= 0)
             return this;
-        return new PartialKeyRoute(covering.with(Ranges.of(homeKey.asRange())), homeKey, isParticipatingHomeKey, toRoutingKeysArray(homeKey));
+
+        insertPos = -1 - insertPos;
+        RoutingKey[] keys = new RoutingKey[1 + this.keys.length];
+        System.arraycopy(this.keys, 0, keys, 0, insertPos);
+        keys[insertPos] = homeKey;
+        System.arraycopy(this.keys, insertPos, keys, insertPos + 1, this.keys.length - insertPos);
+
+        return new PartialKeyRoute(homeKey, keys);
     }
 
     @Override
-    public PartialKeyRoute slice(Ranges newRanges, Slice slice)
+    public PartialKeyRoute slice(Ranges select, Slice slice)
     {
-        if (newRanges.containsAll(covering))
+        RoutingKey[] keys = slice(select, RoutingKey[]::new);
+        if (keys == this.keys)
             return this;
 
-        RoutingKey[] keys = slice(newRanges, RoutingKey[]::new);
-        return new PartialKeyRoute(newRanges, homeKey, isParticipatingHomeKey, keys);
-    }
-
-    @Override
-    public Ranges covering()
-    {
-        return covering;
+        return new PartialKeyRoute(homeKey, keys);
     }
 
     @Override
@@ -123,13 +112,13 @@ public class PartialKeyRoute extends KeyRoute implements PartialRoute<RoutingKey
 
         PartialKeyRoute that = (PartialKeyRoute) with;
         Invariants.checkState(homeKey.equals(that.homeKey));
-        Invariants.checkState(isParticipatingHomeKey == that.isParticipatingHomeKey);
         RoutingKey[] keys = SortedArrays.linearUnion(this.keys, that.keys, RoutingKey[]::new);
-        Ranges covering = this.covering.with(that.covering);
-        if (covering == this.covering && keys == this.keys)
+        if (keys == this.keys || keys == that.keys)
+        {
+            if (keys != that.keys) return this;
+            if (keys != this.keys) return that;
             return this;
-        if (covering == that.covering && keys == that.keys)
-            return that;
-        return new PartialKeyRoute(covering, homeKey, isParticipatingHomeKey, keys);
+        }
+        return new PartialKeyRoute(homeKey, keys);
     }
 }

--- a/accord-core/src/main/java/accord/primitives/PartialRangeRoute.java
+++ b/accord-core/src/main/java/accord/primitives/PartialRangeRoute.java
@@ -18,8 +18,6 @@
 
 package accord.primitives;
 
-import javax.annotation.Nonnull;
-
 import accord.api.RoutingKey;
 import accord.utils.Invariants;
 
@@ -32,18 +30,21 @@ public class PartialRangeRoute extends RangeRoute implements PartialRoute<Range>
 {
     public static class SerializationSupport
     {
-        public static PartialRangeRoute create(Ranges covering, RoutingKey homeKey, boolean isParticipatingHomeKey, Range[] ranges)
+        public static PartialRangeRoute create(RoutingKey homeKey, Range[] ranges)
         {
-            return new PartialRangeRoute(covering, homeKey, isParticipatingHomeKey, ranges);
+            return new PartialRangeRoute(homeKey, ranges);
         }
     }
 
-    public final Ranges covering;
-
-    public PartialRangeRoute(Ranges covering, RoutingKey homeKey, boolean isParticipatingHomeKey, Range[] ranges)
+    public PartialRangeRoute(RoutingKey homeKey, Range[] ranges)
     {
-        super(homeKey, isParticipatingHomeKey, ranges);
-        this.covering = covering;
+        super(homeKey, ranges);
+    }
+
+    //
+    private PartialRangeRoute(Object ignore, RoutingKey homeKey, Range[] ranges)
+    {
+        super(homeKey, ranges);
     }
 
     @Override
@@ -53,34 +54,13 @@ public class PartialRangeRoute extends RangeRoute implements PartialRoute<Range>
     }
 
     @Override
-    public Ranges covering()
-    {
-        return covering;
-    }
-
-    @Override
-    public boolean covers(Ranges ranges)
-    {
-        return covering.containsAll(ranges);
-    }
-
-    @Override
-    public PartialRangeRoute sliceStrict(Ranges newRanges)
-    {
-        if (!covering.containsAll(newRanges))
-            throw new IllegalArgumentException("Not covered");
-
-        return slice(newRanges);
-    }
-
-    @Override
     public PartialRangeRoute withHomeKey()
     {
         if (contains(homeKey))
             return this;
 
         Ranges with = Ranges.of(homeKey.asRange());
-        return new PartialRangeRoute(covering.with(with), homeKey, isParticipatingHomeKey, union(MERGE_OVERLAPPING, this, with, null, null, (i1, i2, rs) -> rs));
+        return new PartialRangeRoute(homeKey, union(MERGE_OVERLAPPING, this, with, null, null, (i1, i2, rs) -> rs));
     }
 
     @Override
@@ -98,28 +78,7 @@ public class PartialRangeRoute extends RangeRoute implements PartialRoute<Range>
 
         PartialRangeRoute that = (PartialRangeRoute) with;
         Invariants.checkState(homeKey.equals(that.homeKey));
-        Ranges covering = this.covering.with(that.covering);
-        if (covering == this.covering) return this;
-        else if (covering == that.covering) return that;
 
-        return union(MERGE_OVERLAPPING, this, that, covering, homeKey,
-                     isParticipatingHomeKey ? PartialRangeRoute::withParticipatingHomeKey
-                                            : PartialRangeRoute::withNonParticipatingHomeKey);
-    }
-
-    @Override
-    public boolean equals(Object that)
-    {
-        return super.equals(that) && covering.equals(((PartialRangeRoute)that).covering);
-    }
-
-    static PartialRangeRoute withParticipatingHomeKey(Ranges covering, @Nonnull RoutingKey homeKey, Range[] ranges)
-    {
-        return new PartialRangeRoute(covering, homeKey, true, ranges);
-    }
-
-    static PartialRangeRoute withNonParticipatingHomeKey(Ranges covering, @Nonnull RoutingKey homeKey, Range[] ranges)
-    {
-        return new PartialRangeRoute(covering, homeKey, false, ranges);
+        return union(MERGE_OVERLAPPING, this, that, null, homeKey, (ignore, homeKey, ranges) -> new PartialRangeRoute(homeKey, ranges));
     }
 }

--- a/accord-core/src/main/java/accord/primitives/PartialRoute.java
+++ b/accord-core/src/main/java/accord/primitives/PartialRoute.java
@@ -22,16 +22,9 @@ public interface PartialRoute<T extends Unseekable> extends Route<T>
 {
     @Override
     boolean isEmpty();
-    Ranges covering();
 
     /**
      * Expected to be compatible PartialRoute type, i.e. both split from the same FullRoute
      */
     PartialRoute<T> union(PartialRoute<T> route);
-
-    @Override
-    default Ranges sliceCovering(Ranges newRanges, Slice slice)
-    {
-        return covering().slice(newRanges, slice);
-    }
 }

--- a/accord-core/src/main/java/accord/primitives/Participants.java
+++ b/accord-core/src/main/java/accord/primitives/Participants.java
@@ -24,12 +24,15 @@ package accord.primitives;
  * that these classes will only be used via interfaces such as Route that do not extend this interface,
  * so that the implementation may return itself when suitable, and a converted copy otherwise.
  */
+// TODO (desired): so we need this abstraction anymore, now that we have removed the concept of non-participating home keys?
 public interface Participants<K extends Unseekable> extends Unseekables<K>
 {
     Participants<K> with(Participants<K> with);
 
     @Override
-    Participants<K> intersect(Unseekables<?> with);
+    Participants<K> intersecting(Unseekables<?> intersecting);
+    @Override
+    Participants<K> intersecting(Unseekables<?> intersecting, Slice slice);
     @Override
     Participants<K> slice(Ranges ranges);
     @Override
@@ -39,39 +42,6 @@ public interface Participants<K extends Unseekable> extends Unseekables<K>
     Participants<K> subtract(Unseekables<?> without);
 
     Ranges toRanges();
-
-    static boolean isParticipants(Unseekables<?> unseekables)
-    {
-        switch (unseekables.kind())
-        {
-            default: throw new AssertionError("Unhandled Unseekables.Kind: " + unseekables.kind());
-            case FullKeyRoute:
-            case FullRangeRoute:
-            case PartialKeyRoute:
-            case PartialRangeRoute:
-                return Route.castToRoute(unseekables).isParticipatingHomeKey();
-            case RoutingRanges:
-            case RoutingKeys:
-                return true;
-        }
-    }
-
-    static Participants<?> participants(Unseekables<?> unseekables)
-    {
-        switch (unseekables.kind())
-        {
-            default: throw new AssertionError("Unhandled Unseekables.Kind: " + unseekables.kind());
-            case FullKeyRoute:
-            case FullRangeRoute:
-            case PartialKeyRoute:
-            case PartialRangeRoute:
-                return Route.castToRoute(unseekables).participants();
-            case RoutingRanges:
-                return (Ranges) unseekables;
-            case RoutingKeys:
-                return (RoutingKeys) unseekables;
-        }
-    }
 
     /**
      * If both left and right are a Route, invoke {@link Route#union} on them. Otherwise invoke {@link #with}.

--- a/accord-core/src/main/java/accord/primitives/Routables.java
+++ b/accord-core/src/main/java/accord/primitives/Routables.java
@@ -34,6 +34,10 @@ import static accord.utils.SortedArrays.Search.FLOOR;
  */
 public interface Routables<K extends Routable> extends Iterable<K>
 {
+    /**
+     * How to slice an input range that partially overlaps a slice range.
+     * This modifier applies only when both input collections (to either {@link #slice} or {@link #intersecting} contain Ranges)
+     */
     enum Slice
     {
         /** (Default) Overlapping ranges are returned unmodified */
@@ -66,9 +70,12 @@ public interface Routables<K extends Routable> extends Iterable<K>
 
     boolean contains(RoutableKey key);
     boolean containsAll(Routables<?> keysOrRanges);
+    boolean intersectsAll(Unseekables<?> keysOrRanges);
 
     Routables<?> slice(Ranges ranges);
     Routables<K> slice(Ranges ranges, Slice slice);
+    Routables<?> intersecting(Unseekables<?> intersecting);
+    Routables<K> intersecting(Unseekables<?> intersecting, Slice slice);
 
     /**
      * Search forwards from {code thisIndex} and {@code withIndex} to find the first entries in each collection

--- a/accord-core/src/main/java/accord/primitives/RoutingKeys.java
+++ b/accord-core/src/main/java/accord/primitives/RoutingKeys.java
@@ -90,7 +90,7 @@ public class RoutingKeys extends AbstractUnseekableKeys implements Unseekables<R
         if (contains(with))
             return this;
 
-        return wrap(toRoutingKeysArray(with));
+        return wrap(toRoutingKeysArray(with, true));
     }
 
     @Override

--- a/accord-core/src/main/java/accord/primitives/Seekables.java
+++ b/accord-core/src/main/java/accord/primitives/Seekables.java
@@ -32,7 +32,12 @@ public interface Seekables<K extends Seekable, U extends Seekables<K, ?>> extend
     default U slice(Ranges ranges) { return slice(ranges, Overlapping); }
 
     @Override
+    default U intersecting(Unseekables<?> intersecting) { return intersecting(intersecting, Overlapping); }
+
+    @Override
     U slice(Ranges ranges, Slice slice);
+    U intersecting(Unseekables<?> intersecting, Slice slice);
+
     Seekables<K, U> subtract(Ranges ranges);
     Seekables<K, U> subtract(U without);
     Seekables<K, U> with(U with);

--- a/accord-core/src/main/java/accord/primitives/Txn.java
+++ b/accord-core/src/main/java/accord/primitives/Txn.java
@@ -306,9 +306,20 @@ public interface Txn
         public PartialTxn slice(Ranges ranges, boolean includeQuery)
         {
             return new PartialTxn.InMemory(
-                    ranges, kind(), keys().slice(ranges),
-                    read().slice(ranges), includeQuery ? query() : null,
-                    update() == null ? null : update().slice(ranges)
+                kind(), keys().slice(ranges),
+                read().slice(ranges), includeQuery ? query() : null,
+                update() == null ? null : update().slice(ranges)
+            );
+        }
+
+        @Nonnull
+        @Override
+        public PartialTxn intersecting(Participants<?> participants, boolean includeQuery)
+        {
+            return new PartialTxn.InMemory(
+                kind(), keys().intersecting(participants),
+                read().intersecting(participants), includeQuery ? query() : null,
+                update() == null ? null : update().intersecting(participants)
             );
         }
 
@@ -374,6 +385,7 @@ public interface Txn
     @Nullable Update update();
 
     @Nonnull PartialTxn slice(Ranges ranges, boolean includeQuery);
+    @Nonnull PartialTxn intersecting(Participants<?> participants, boolean includeQuery);
 
     default boolean isWrite()
     {

--- a/accord-core/src/main/java/accord/primitives/TxnId.java
+++ b/accord-core/src/main/java/accord/primitives/TxnId.java
@@ -166,7 +166,7 @@ public class TxnId extends Timestamp
         return new TxnId(epochMsb(epoch), 0, Id.NONE);
     }
 
-    private static final Pattern PARSE = Pattern.compile("\\[(?<epoch>[0-9]+),(?<hlc>[0-9]+),(?<flags>[0-9]+)\\([KREWNSXL]\\),(?<node>[0-9]+)]");
+    private static final Pattern PARSE = Pattern.compile("\\[(?<epoch>[0-9]+),(?<hlc>[0-9]+),(?<flags>[0-9]+)\\([KR][REWSXL]\\),(?<node>[0-9]+)]");
     public static TxnId parse(String txnIdString)
     {
         Matcher m = PARSE.matcher(txnIdString);

--- a/accord-core/src/main/java/accord/primitives/Unseekable.java
+++ b/accord-core/src/main/java/accord/primitives/Unseekable.java
@@ -23,4 +23,5 @@ package accord.primitives;
  */
 public interface Unseekable extends Routable
 {
+    Range asRange();
 }

--- a/accord-core/src/main/java/accord/primitives/Unseekables.java
+++ b/accord-core/src/main/java/accord/primitives/Unseekables.java
@@ -41,14 +41,17 @@ public interface Unseekables<K extends Unseekable> extends Iterable<K>, Routable
     }
 
     @Override
-    Unseekables<K> slice(Ranges ranges);
+    Unseekables<K> intersecting(Unseekables<?> intersecting);
+    @Override
+    Unseekables<K> intersecting(Unseekables<?> intersecting, Slice slice);
 
+    @Override
+    Unseekables<K> slice(Ranges ranges);
     @Override
     Unseekables<K> slice(Ranges ranges, Slice slice);
 
     Unseekables<K> subtract(Ranges ranges);
     Unseekables<K> subtract(Unseekables<?> subtract);
-    Unseekables<K> intersect(Unseekables<?> intersect);
 
     /**
      * Return an object containing any {@code K} present in either of the original collections.

--- a/accord-core/src/main/java/accord/topology/Shard.java
+++ b/accord-core/src/main/java/accord/topology/Shard.java
@@ -26,9 +26,9 @@ import accord.local.Node.Id;
 import accord.primitives.Range;
 import accord.primitives.RoutableKey;
 import accord.utils.SortedArrays.ExtendedSortedArrayList;
+import accord.utils.SortedArrays.SortedArrayList;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 
@@ -38,7 +38,7 @@ import static accord.utils.Invariants.checkArgument;
 public class Shard
 {
     public final Range range;
-    public final List<Id> nodes;
+    public final SortedArrayList<Id> nodes;
     public final ExtendedSortedArrayList<Id> sortedNodes;
     public final Set<Id> fastPathElectorate;
     public final Set<Id> joining;
@@ -47,10 +47,10 @@ public class Shard
     public final int fastPathQuorumSize;
     public final int slowPathQuorumSize;
 
-    public Shard(Range range, List<Id> nodes, Set<Id> fastPathElectorate, Set<Id> joining)
+    public Shard(Range range, SortedArrayList<Id> nodes, Set<Id> fastPathElectorate, Set<Id> joining)
     {
         this.range = range;
-        this.nodes = ImmutableList.copyOf(nodes);
+        this.nodes = nodes;
         this.sortedNodes = ExtendedSortedArrayList.sortedCopyOf(nodes, Id[]::new);
         this.maxFailures = maxToleratedFailures(nodes.size());
         this.fastPathElectorate = ImmutableSet.copyOf(fastPathElectorate);
@@ -62,7 +62,7 @@ public class Shard
         this.fastPathQuorumSize = fastPathQuorumSize(nodes.size(), e, maxFailures);
     }
 
-    public Shard(Range range, List<Id> nodes, Set<Id> fastPathElectorate)
+    public Shard(Range range, SortedArrayList<Id> nodes, Set<Id> fastPathElectorate)
     {
         this(range, nodes, fastPathElectorate, Collections.emptySet());
     }

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -115,7 +115,7 @@ public class TopologyManager
 
         public boolean hasReachedQuorum()
         {
-            return syncTracker == null ? true : syncTracker.hasReachedQuorum();
+            return syncTracker == null || syncTracker.hasReachedQuorum();
         }
 
         public boolean recordSyncComplete(Id node)

--- a/accord-core/src/main/java/accord/utils/CheckpointIntervalArray.java
+++ b/accord-core/src/main/java/accord/utils/CheckpointIntervalArray.java
@@ -24,6 +24,7 @@ import accord.utils.CheckpointIntervalArrayBuilder.Accessor;
 import net.nicoulaj.compilecommand.annotations.Inline;
 
 import static accord.utils.SortedArrays.Search.CEIL;
+import static accord.utils.SortedArrays.Search.FLOOR;
 
 public class CheckpointIntervalArray<Ranges, Range, Key>
 {
@@ -92,12 +93,12 @@ public class CheckpointIntervalArray<Ranges, Range, Key>
     }
 
     @Inline
-    public <P1, P2, P3, P4> int forEach(Range range, IndexedQuadConsumer<P1, P2, P3, P4> forEachScanOrCheckpoint, IndexedRangeQuadConsumer<P1, P2, P3, P4> forEachRange, P1 p1, P2 p2, P3 p3, P4 p4, int minIndex)
+    public <P1, P2, P3, P4> int forEachRange(Range range, IndexedQuadConsumer<P1, P2, P3, P4> forEachScanOrCheckpoint, IndexedRangeQuadConsumer<P1, P2, P3, P4> forEachRange, P1 p1, P2 p2, P3 p3, P4 p4, int minIndex)
     {
-        return forEach(accessor.start(range), accessor.end(range), forEachScanOrCheckpoint, forEachRange, p1, p2, p3, p4, minIndex);
+        return forEachRange(accessor.start(range), accessor.end(range), forEachScanOrCheckpoint, forEachRange, p1, p2, p3, p4, minIndex);
     }
 
-    public <P1, P2, P3, P4> int forEach(Key startKey, Key endKey, IndexedQuadConsumer<P1, P2, P3, P4> forEachScanOrCheckpoint, IndexedRangeQuadConsumer<P1, P2, P3, P4> forEachRange, P1 p1, P2 p2, P3 p3, P4 p4, int minIndex)
+    public <P1, P2, P3, P4> int forEachRange(Key startKey, Key endKey, IndexedQuadConsumer<P1, P2, P3, P4> forEachScanOrCheckpoint, IndexedRangeQuadConsumer<P1, P2, P3, P4> forEachRange, P1 p1, P2 p2, P3 p3, P4 p4, int minIndex)
     {
         if (accessor.size(ranges) == 0 || minIndex == accessor.size(ranges))
             return minIndex;
@@ -125,6 +126,36 @@ public class CheckpointIntervalArray<Ranges, Range, Key>
 
         // Since endInclusive() != startInclusive(), so no need to adjust start/end comparisons
         return forEach(start, end, floor, startKey, 0, forEachScanOrCheckpoint, forEachRange, p1, p2, p3, p4, minIndex);
+    }
+
+    public <P1, P2, P3, P4> int forEachKey(Key key, IndexedQuadConsumer<P1, P2, P3, P4> forEachScanOrCheckpoint, IndexedRangeQuadConsumer<P1, P2, P3, P4> forEachRange, P1 p1, P2 p2, P3 p3, P4 p4, int minIndex)
+    {
+        if (accessor.size(ranges) == 0 || minIndex == accessor.size(ranges))
+            return minIndex;
+
+        var c = accessor.keyComparator();
+        int end = accessor.binarySearch(ranges, minIndex, accessor.size(ranges), key, (a, b) -> c.compare(a, accessor.start(b)), FLOOR);
+        if (end < 0) end = -1 - end;
+        else ++end;
+        if (end <= minIndex) return minIndex;
+
+        int floor = accessor.binarySearch(ranges, minIndex, accessor.size(ranges), key, (a, b) -> c.compare(a, accessor.start(b)), CEIL);
+        int start = floor;
+        if (floor < 0)
+        {
+            // if there's no precise match on start, step backwards;
+            // if this range does not overlap us, step forwards again for start
+            // but retain the floor index for performing scan and checkpoint searches from
+            // as this contains all ranges that might overlap us (whereas those that end
+            // after us but before the next range's start would be missed by the next range index)
+            start = floor = -2 - floor;
+            if (start < 0)
+                start = floor = 0;
+            else if (c.compare(accessor.end(ranges, start), key) <= 0)
+                ++start;
+        }
+
+        return forEach(start, end, floor, key, 0, forEachScanOrCheckpoint, forEachRange, p1, p2, p3, p4, minIndex);
     }
 
     @Inline

--- a/accord-core/src/main/java/accord/utils/Functions.java
+++ b/accord-core/src/main/java/accord/utils/Functions.java
@@ -57,6 +57,22 @@ public class Functions
         return result;
     }
 
+    public static <I, O> O mapReduceNonNull(Function<I, O> map, BiFunction<O, O, O> reduce, I[] input)
+    {
+        O result = null;
+        for (I i : input)
+        {
+            if (i == null) continue;
+
+            O o = map.apply(i);
+            if (o == null) continue;
+
+            if (result == null) result = o;
+            else result = reduce.apply(result, o);
+        }
+        return result;
+    }
+
     public static <I, O> O foldl(List<I> list, BiFunction<I, O, O> foldl, O zero)
     {
         O result = zero;

--- a/accord-core/src/main/java/accord/utils/ImmutableBitSet.java
+++ b/accord-core/src/main/java/accord/utils/ImmutableBitSet.java
@@ -50,6 +50,11 @@ public class ImmutableBitSet extends SimpleBitSet
         super(copy);
     }
 
+    public ImmutableBitSet(SimpleBitSet copy, boolean share)
+    {
+        super(copy, share);
+    }
+
     ImmutableBitSet(long[] bits)
     {
         super(bits);

--- a/accord-core/src/main/java/accord/utils/ReducingIntervalMap.java
+++ b/accord-core/src/main/java/accord/utils/ReducingIntervalMap.java
@@ -435,6 +435,11 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
             this.values = new ArrayList<>(capacity + 1);
         }
 
+        public boolean isEmpty()
+        {
+            return values.isEmpty();
+        }
+
         /**
          * null is a valid value to represent no knowledge, and is the *expected* final value, representing
          * the bound of our knowledge (any higher key will find no associated information)
@@ -443,8 +448,8 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
         {
             int tailIdx = starts.size() - 1;
 
-            assert starts.size() == values.size();
-            assert tailIdx < 0 || start.compareTo(starts.get(tailIdx)) >= 0;
+            Invariants.checkState(starts.size() == values.size());
+            Invariants.checkState( tailIdx < 0 || start.compareTo(starts.get(tailIdx)) >= 0);
 
             boolean sameAsTailKey, sameAsTailValue;
             V tailValue;

--- a/accord-core/src/main/java/accord/utils/ReducingRangeMap.java
+++ b/accord-core/src/main/java/accord/utils/ReducingRangeMap.java
@@ -77,6 +77,11 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         return foldl(routables, (a, b, f, p) -> f.apply(a, b, p), accumulator, fold, p1, terminate);
     }
 
+    public <V2, P1> V2 foldlWithKey(Routables<?> routables, IndexedTriFunction<V, V2, P1, V2> fold, V2 accumulator, P1 p1, Predicate<V2> terminate)
+    {
+        return foldl(routables, (v, v2, f, p, i, j, k) -> f.apply(v, v2, p, i), accumulator, fold, p1, terminate);
+    }
+
     public <V2, P1, P2> V2 foldl(Routables<?> routables, QuadFunction<V, V2, P1, P2, V2> fold, V2 accumulator, P1 p1, P2 p2, Predicate<V2> terminate)
     {
         return foldl(routables, (v, v2, param1, param2, i, j, k) -> fold.apply(v, v2, param1, param2), accumulator, p1, p2, terminate);
@@ -107,7 +112,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         return foldlWithDefault(routables, (v, v2, param1, param2, i, j) -> fold.apply(v, v2, param1, param2), defaultValue, accumulator, p1, p2, terminate);
     }
 
-    private <V2, P1, P2> V2 foldl(Routables<?> routables, ReduceFunction<V, V2, P1, P2> fold, V2 accumulator, P1 p1, P2 p2, Predicate<V2> terminate)
+    public <V2, P1, P2> V2 foldl(Routables<?> routables, ReduceFunction<V, V2, P1, P2> fold, V2 accumulator, P1 p1, P2 p2, Predicate<V2> terminate)
     {
         switch (routables.domain())
         {
@@ -117,7 +122,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         }
     }
 
-    private <V2, P1, P2> V2 foldl(AbstractKeys<?> keys, ReduceFunction<V, V2, P1, P2> fold, V2 accumulator, P1 p1, P2 p2, Predicate<V2> terminate)
+    public <V2, P1, P2> V2 foldl(AbstractKeys<?> keys, ReduceFunction<V, V2, P1, P2> fold, V2 accumulator, P1 p1, P2 p2, Predicate<V2> terminate)
     {
         if (values.length == 0)
             return accumulator;
@@ -151,7 +156,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         return accumulator;
     }
 
-    private <V2, P1, P2> V2 foldl(AbstractRanges ranges, ReduceFunction<V, V2, P1, P2> fold, V2 accumulator, P1 p1, P2 p2, Predicate<V2> terminate)
+    public <V2, P1, P2> V2 foldl(AbstractRanges ranges, ReduceFunction<V, V2, P1, P2> fold, V2 accumulator, P1 p1, P2 p2, Predicate<V2> terminate)
     {
         if (values.length == 0)
             return accumulator;
@@ -314,7 +319,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         return values[idx];
     }
 
-    public static <V> ReducingRangeMap<V> create(Ranges ranges, V value)
+    public static <V> ReducingRangeMap<V> create(AbstractRanges ranges, V value)
     {
         if (value == null)
             throw new IllegalArgumentException("value is null");
@@ -330,7 +335,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         switch (keysOrRanges.domain())
         {
             default: throw new AssertionError("Unhandled domain: " + keysOrRanges.domain());
-            case Range: return create((Ranges) keysOrRanges, value, builder);
+            case Range: return create((AbstractRanges) keysOrRanges, value, builder);
             case Key: return create((AbstractUnseekableKeys) keysOrRanges, value, builder);
         }
     }
@@ -340,12 +345,12 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         switch (keysOrRanges.domain())
         {
             default: throw new AssertionError("Unhandled domain: " + keysOrRanges.domain());
-            case Range: return create((Ranges) keysOrRanges, value, builder);
+            case Range: return create((AbstractRanges) keysOrRanges, value, builder);
             case Key: return create((Keys) keysOrRanges, value, builder);
         }
     }
 
-    public static <V, M extends ReducingRangeMap<V>> M create(Ranges ranges, V value, BuilderFactory<RoutingKey, V, M> factory)
+    public static <V, M extends ReducingRangeMap<V>> M create(AbstractRanges ranges, V value, BuilderFactory<RoutingKey, V, M> factory)
     {
         if (value == null)
             throw new IllegalArgumentException("value is null");

--- a/accord-core/src/main/java/accord/utils/SimpleBitSet.java
+++ b/accord-core/src/main/java/accord/utils/SimpleBitSet.java
@@ -61,6 +61,11 @@ public class SimpleBitSet
 
     public SimpleBitSet(SimpleBitSet copy)
     {
+        this(copy, false);
+    }
+
+    public SimpleBitSet(SimpleBitSet copy, boolean share)
+    {
         bits = copy.bits.clone();
         count = copy.count;
     }

--- a/accord-core/src/main/java/accord/utils/SortedArrays.java
+++ b/accord-core/src/main/java/accord/utils/SortedArrays.java
@@ -52,6 +52,19 @@ public class SortedArrays
             this.array = checkArgument(array, SortedArrays::isSortedUnique);
         }
 
+        public static <T extends Comparable<? super T>> SortedArrayList<T> copySorted(Collection<T> copy, IntFunction<T[]> allocator)
+        {
+            T[] array = copy.toArray(allocator);
+            return new SortedArrayList<>(array);
+        }
+
+        public static <T extends Comparable<? super T>> SortedArrayList<T> copyUnsorted(Collection<T> copy, IntFunction<T[]> allocator)
+        {
+            T[] array = copy.toArray(allocator);
+            Arrays.sort(array);
+            return new SortedArrayList<>(array);
+        }
+
         @Override
         public T get(int index)
         {
@@ -78,7 +91,12 @@ public class SortedArrays
 
         public boolean containsAll(SortedArrayList<T> test)
         {
-            return test.array.length == SortedArrays.foldlIntersection(Comparable::compareTo, array, 0, array.length, test.array, 0, test.array.length, (t, p, v, li, ri) -> v + 1, 0, 0, test.array.length);
+            return isSubset(Comparable::compareTo, test.array, 0, test.array.length, array, 0, array.length);
+        }
+
+        public T[] backingArrayUnsafe()
+        {
+            return array;
         }
 
         public static class Builder<T extends Comparable<? super T>>
@@ -1338,22 +1356,18 @@ public class SortedArrays
     }
 
     @Inline
-    public static <T> boolean isSubset(AsymmetricComparator<? super T, ? super T> comparator, T[] test, int testFrom, int testTo, T[] superset, int supersetFrom, int supersetTo)
+    public static <T1, T2> boolean isSubset(AsymmetricComparator<? super T1, ? super T2> comparator, T1[] test, int testFrom, int testTo, T2[] superset, int supersetFrom, int supersetTo)
     {
-        while (true)
+        while (testFrom < testTo)
         {
-            long abi = findNextIntersection(test, testFrom, testTo, superset, supersetFrom, supersetTo, comparator);
-            if (abi < 0)
-                return true;
-
-            int nextai = (int)(abi);
-            if (testFrom != nextai)
+            supersetFrom = SortedArrays.exponentialSearch(superset, supersetFrom, supersetTo, test[testFrom], comparator, FAST);
+            if (supersetFrom < 0)
                 return false;
 
-            supersetFrom = (int)(abi >>> 32);
             ++testFrom;
             ++supersetFrom;
         }
+        return true;
     }
 
     public static <T extends Comparable<T>> void assertSorted(T[] array)

--- a/accord-core/src/main/java/accord/utils/SortedList.java
+++ b/accord-core/src/main/java/accord/utils/SortedList.java
@@ -18,10 +18,49 @@
 
 package accord.utils;
 
+import java.util.AbstractList;
 import java.util.List;
+import java.util.RandomAccess;
+import java.util.Set;
+import java.util.Spliterator;
 
-public interface SortedList<T extends Comparable<? super T>> extends List<T>
+public interface SortedList<T extends Comparable<? super T>> extends List<T>, Set<T>, RandomAccess
 {
     int findNext(int i, Comparable<? super T> find);
     int find(Comparable<? super T> find);
+
+    @Override
+    default boolean contains(Object o)
+    {
+        return o != null && find((Comparable<? super T>) o) >= 0;
+    }
+
+    @Override
+    default int indexOf(Object o)
+    {
+        return o == null ? -1 : Math.max(-1, find((Comparable<? super T>) o));
+    }
+
+    @Override
+    default Spliterator<T> spliterator()
+    {
+        return List.super.spliterator();
+    }
+
+    @Override
+    default int lastIndexOf(Object o)
+    {
+        return indexOf(o);
+    }
+
+    default <V> List<V> select(V[] selectFrom, List<T> select)
+    {
+        return new AbstractList<>()
+        {
+            @Override
+            public V get(int index) { return selectFrom[find(select.get(index))]; }
+            @Override
+            public int size() { return select.size(); }
+        };
+    }
 }

--- a/accord-core/src/main/java/accord/utils/Utils.java
+++ b/accord-core/src/main/java/accord/utils/Utils.java
@@ -118,7 +118,7 @@ public class Utils
     public static ImmutableBitSet ensureImmutable(SimpleBitSet set)
     {
         if (set == null) return null;
-        return set instanceof ImmutableBitSet ? (ImmutableBitSet) set : new ImmutableBitSet(set);
+        return set instanceof ImmutableBitSet ? (ImmutableBitSet) set : new ImmutableBitSet(set, true);
     }
 
     public static <T> T[] addAll(T[] first, T[] second)

--- a/accord-core/src/test/java/accord/coordinate/CoordinateTransactionTest.java
+++ b/accord-core/src/test/java/accord/coordinate/CoordinateTransactionTest.java
@@ -306,7 +306,7 @@ public class CoordinateTransactionTest
             // Apply the blockingTxn to unblock the rest
             for (Node n : cluster)
                 assertEquals(ApplyOutcome.Success, getUninterruptibly(n.unsafeForKey(key).submit(blockingTxnContext, store -> {
-                    return Commands.apply(store, store.get(blockingTxnId, homeKey), blockingTxnId, route, null, blockingTxnId, PartialDeps.builder(store.ranges().allAt(blockingTxnId.epoch())).build(), blockingTxn.slice(store.ranges().allAt(blockingTxnId.epoch()), true), blockingTxn.execute(blockingTxnId, blockingTxnId, null), blockingTxn.query().compute(blockingTxnId, blockingTxnId, keys, null, null, null));
+                    return Commands.apply(store, store.get(blockingTxnId, homeKey), blockingTxnId, route, null, blockingTxnId, PartialDeps.builder(route).build(), blockingTxn.slice(store.ranges().allAt(blockingTxnId.epoch()), true), blockingTxn.execute(blockingTxnId, blockingTxnId, null), blockingTxn.query().compute(blockingTxnId, blockingTxnId, keys, null, null, null));
                 })));
             // Global sync should be unblocked
             syncPoint = getUninterruptibly(syncInclusiveSyncFuture);

--- a/accord-core/src/test/java/accord/impl/AbstractConfigurationServiceTest.java
+++ b/accord-core/src/test/java/accord/impl/AbstractConfigurationServiceTest.java
@@ -21,7 +21,6 @@ package accord.impl;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -29,9 +28,10 @@ import java.util.stream.Collectors;
 
 import accord.api.ConfigurationService.EpochReady;
 import accord.primitives.Ranges;
+import accord.utils.SortedArrays.SortedArrayList;
 import accord.utils.async.AsyncResult;
 import accord.utils.async.AsyncResults;
-import com.google.common.collect.ImmutableList;
+
 import com.google.common.collect.ImmutableSet;
 
 import accord.api.ConfigurationService;
@@ -175,15 +175,15 @@ public class AbstractConfigurationServiceTest
     private static final Id ID1 = new Id(1);
     private static final Id ID2 = new Id(2);
     private static final Id ID3 = new Id(3);
-    private static final List<Id> NODES = ImmutableList.of(ID1, ID2, ID3);
+    private static final SortedArrayList<Id> NODES = new SortedArrayList<>(new Id[] { ID1, ID2, ID3 });
     private static final Range RANGE = IntKey.range(0, 100);
 
-    private static Shard shard(Range range, List<Id> nodes, Set<Id> fastPath)
+    private static Shard shard(Range range, SortedArrayList<Id> nodes, Set<Id> fastPath)
     {
         return new Shard(range, nodes, fastPath);
     }
 
-    private static Topology topology(long epoch, Range range, List<Id> nodes, Set<Id> fastPath)
+    private static Topology topology(long epoch, Range range, SortedArrayList<Id> nodes, Set<Id> fastPath)
     {
         return new Topology(epoch, shard(range, nodes, fastPath));
     }

--- a/accord-core/src/test/java/accord/impl/basic/DelayedCommandStores.java
+++ b/accord-core/src/test/java/accord/impl/basic/DelayedCommandStores.java
@@ -18,6 +18,7 @@
 
 package accord.impl.basic;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -295,5 +296,13 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
                 commandStore.validateRead(safe.current());
             });
         }
+    }
+
+    public List<DelayedCommandStore> unsafeStores()
+    {
+        List<DelayedCommandStore> stores = new ArrayList<>();
+        for (ShardHolder holder : current().shards)
+            stores.add((DelayedCommandStore) holder.store);
+        return stores;
     }
 }

--- a/accord-core/src/test/java/accord/impl/basic/Journal.java
+++ b/accord-core/src/test/java/accord/impl/basic/Journal.java
@@ -298,8 +298,8 @@ public class Journal implements LocalRequest.Handler, Runnable
             case TruncatedApplyWithDeps:
             case TruncatedApply:
                 return Command.Truncated.truncatedApply(attrs, status, executeAt, writes, result, executesAtLeast);
-            case ErasedOrInvalidated:
-                return Command.Truncated.erasedOrInvalidated(attrs.txnId(), attrs.durability(), attrs.route());
+            case ErasedOrInvalidOrVestigial:
+                return Command.Truncated.erasedOrInvalidOrVestigial(attrs.txnId(), attrs.durability(), attrs.route());
             case Erased:
                 return Command.Truncated.erased(attrs.txnId(), attrs.durability(), attrs.route());
             case Invalidated:

--- a/accord-core/src/test/java/accord/impl/list/ListFetchCoordinator.java
+++ b/accord-core/src/test/java/accord/impl/list/ListFetchCoordinator.java
@@ -53,7 +53,7 @@ public class ListFetchCoordinator extends AbstractFetchCoordinator
     @Override
     protected PartialTxn rangeReadTxn(Ranges ranges)
     {
-        return new PartialTxn.InMemory(ranges, Txn.Kind.Read, ranges, new ListRead(Function.identity(), false, ranges, ranges), new ListQuery(Node.Id.NONE, Long.MIN_VALUE, false), null);
+        return new PartialTxn.InMemory(Txn.Kind.Read, ranges, new ListRead(Function.identity(), false, ranges, ranges), new ListQuery(Node.Id.NONE, Long.MIN_VALUE, false), null);
     }
 
     @Override

--- a/accord-core/src/test/java/accord/impl/list/ListRead.java
+++ b/accord-core/src/test/java/accord/impl/list/ListRead.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.function.Function;
 
 import accord.local.SafeCommandStore;
+import accord.primitives.Participants;
 import accord.primitives.Ranges;
 import accord.primitives.Timestamp;
 import accord.utils.async.AsyncChain;
@@ -96,6 +97,12 @@ public class ListRead implements Read
     public Read slice(Ranges ranges)
     {
         return new ListRead(executor, isEphemeralRead, userReadKeys.slice(ranges), keys.slice(ranges));
+    }
+
+    @Override
+    public Read intersecting(Participants<?> participants)
+    {
+        return new ListRead(executor, isEphemeralRead, userReadKeys.intersecting(participants), keys.intersecting(participants));
     }
 
     @Override

--- a/accord-core/src/test/java/accord/impl/list/ListRequest.java
+++ b/accord-core/src/test/java/accord/impl/list/ListRequest.java
@@ -108,7 +108,8 @@ public class ListRequest implements Request
         @Override
         protected void onDone(CheckShards.Success done, Throwable failure)
         {
-            if (failure != null) callback.accept(null, failure);
+            if (failure instanceof Exhausted) callback.accept(Outcome.Lost, null);
+            else if (failure != null) callback.accept(null, failure);
             else if (merged.maxKnowledgeSaveStatus.is(Status.Invalidated)) callback.accept(Outcome.Invalidated, null);
             else if (merged.maxKnowledgeSaveStatus.is(Status.Truncated)) callback.accept(Outcome.Truncated, null);
             else if (merged.maxKnowledgeSaveStatus.hasBeen(Applied)) callback.accept(new Outcome(Outcome.Kind.Applied, (ListResult) ((CheckStatus.CheckStatusOkFull) merged).result), null);
@@ -189,7 +190,7 @@ public class ListRequest implements Request
 
         private void checkOnResult(@Nullable RoutingKey homeKey, TxnId txnId, int attempt, Throwable t) {
             if (homeKey == null)
-                homeKey = node.computeRoute(txnId, txn.keys()).someParticipatingKey();
+                homeKey = node.computeRoute(txnId, txn.keys()).homeKey();
             RoutingKey finalHomeKey = homeKey;
             node.commandStores().select(homeKey).execute(() -> CheckOnResult.checkOnResult(node, txnId, finalHomeKey, (s, f) -> {
                 if (f != null)

--- a/accord-core/src/test/java/accord/impl/list/ListUpdate.java
+++ b/accord-core/src/test/java/accord/impl/list/ListUpdate.java
@@ -29,6 +29,7 @@ import accord.api.Key;
 import accord.api.Update;
 import accord.local.CommandStore;
 import accord.primitives.Keys;
+import accord.primitives.Participants;
 import accord.primitives.Ranges;
 import accord.primitives.Seekables;
 import accord.primitives.Timestamp;
@@ -72,6 +73,18 @@ public class ListUpdate extends TreeMap<Key, Integer> implements Update
         for (Map.Entry<Key, Integer> e : entrySet())
         {
             if (ranges.contains(e.getKey()))
+                result.put(e.getKey(), e.getValue());
+        }
+        return result;
+    }
+
+    @Override
+    public Update intersecting(Participants<?> participants)
+    {
+        ListUpdate result = new ListUpdate(executor);
+        for (Map.Entry<Key, Integer> e : entrySet())
+        {
+            if (participants.contains(e.getKey()))
                 result.put(e.getKey(), e.getValue());
         }
         return result;

--- a/accord-core/src/test/java/accord/impl/mock/MockStore.java
+++ b/accord-core/src/test/java/accord/impl/mock/MockStore.java
@@ -27,6 +27,7 @@ import accord.api.Update;
 import accord.api.Write;
 import accord.local.Node;
 import accord.local.SafeCommandStore;
+import accord.primitives.Participants;
 import accord.primitives.Ranges;
 import accord.primitives.Seekable;
 import accord.primitives.Seekables;
@@ -74,6 +75,12 @@ public class MockStore implements DataStore
             }
 
             @Override
+            public Read intersecting(Participants<?> participants)
+            {
+                return MockStore.read(keys.intersecting(participants));
+            }
+
+            @Override
             public Read merge(Read other)
             {
                 return MockStore.read(((Seekables)keys).with(other.keys()));
@@ -107,6 +114,12 @@ public class MockStore implements DataStore
             public Update slice(Ranges ranges)
             {
                 return MockStore.update(keys.slice(ranges));
+            }
+
+            @Override
+            public Update intersecting(Participants<?> participants)
+            {
+                return MockStore.update(keys.intersecting(participants));
             }
 
             @Override

--- a/accord-core/src/test/java/accord/local/BootstrapLocalTxnTest.java
+++ b/accord-core/src/test/java/accord/local/BootstrapLocalTxnTest.java
@@ -86,7 +86,7 @@ class BootstrapLocalTxnTest
                     SyncPoint<Ranges> syncPoint = new SyncPoint<>(globalSyncId, Deps.NONE, ranges, route);
                     Ranges valid = AccordGens.rangesInsideRanges(ranges, (rs2, r) -> rs2.nextInt(1, 4)).next(rs);
                     Invariants.checkArgument(syncPoint.keysOrRanges.containsAll(valid));
-                    store.execute(contextFor(localSyncId, syncPoint.waitFor.keyDeps.keys(), KeyHistory.COMMANDS), safe -> Commands.createBootstrapCompleteMarkerTransaction(safe, localSyncId, syncPoint, valid))
+                    store.execute(contextFor(localSyncId, syncPoint.waitFor.keyDeps.keys(), KeyHistory.COMMANDS), safe -> Commands.createBootstrapCompleteMarkerTransaction(safe, localSyncId, valid))
                          .flatMap(ignore -> store.execute(contextFor(localSyncId), safe -> validate.accept(safe.get(localSyncId, route.homeKey()).current())))
                          .flatMap(ignore -> store.execute(contextFor(localSyncId), safe -> Commands.markBootstrapComplete(safe, localSyncId, ranges)))
                          .flatMap(ignore -> store.execute(contextFor(localSyncId), safe -> validate.accept(safe.get(localSyncId, route.homeKey()).current())))

--- a/accord-core/src/test/java/accord/messages/ReadDataTest.java
+++ b/accord-core/src/test/java/accord/messages/ReadDataTest.java
@@ -263,7 +263,7 @@ class ReadDataTest
             this.partialRoute = route.slice(RANGES);
             this.progressKey = key.toUnseekable();
             this.executeAt = txnId;
-            this.deps = PartialDeps.builder(RANGES).build();
+            this.deps = PartialDeps.builder(partialRoute).build();
             this.readResult = readResult;
         }
 

--- a/accord-core/src/test/java/accord/primitives/AbstractRangesTest.java
+++ b/accord-core/src/test/java/accord/primitives/AbstractRangesTest.java
@@ -105,6 +105,18 @@ class AbstractRangesTest
         {
             throw new UnsupportedOperationException();
         }
+
+        @Override
+        public Routables<?> intersecting(Unseekables<?> intersecting)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Routables<Range> intersecting(Unseekables<?> intersecting, Slice slice)
+        {
+            throw new UnsupportedOperationException();
+        }
     }
 
     private static class PrefixKey extends IntKey.Routing

--- a/accord-core/src/test/java/accord/topology/ShardTest.java
+++ b/accord-core/src/test/java/accord/topology/ShardTest.java
@@ -19,11 +19,12 @@
 package accord.topology;
 
 import accord.local.Node;
+import accord.utils.SortedArrays.SortedArrayList;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static accord.Utils.ids;
@@ -151,7 +152,7 @@ public class ShardTest
     @Test
     void pendingNodeValidation()
     {
-        List<Node.Id> nodes = ids(0, 3);
+        SortedArrayList<Node.Id> nodes = ids(0, 3);
         Set<Node.Id> fpNodes = new HashSet<>(ids(0, 2));
         // pending nodes are part of electorate
         new Shard(range(0, 100), nodes, fpNodes, new HashSet<>(ids(3, 3)));

--- a/accord-core/src/test/java/accord/topology/TopologyManagerTest.java
+++ b/accord-core/src/test/java/accord/topology/TopologyManagerTest.java
@@ -30,6 +30,8 @@ import accord.utils.Gens;
 import accord.utils.RandomSource;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
+
+import accord.utils.SortedArrays.SortedArrayList;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -366,9 +368,9 @@ public class TopologyManagerTest
     void aba()
     {
         TopologyManager service = new TopologyManager(SUPPLIER, ID);
-        List<Node.Id> dc1Nodes = idList(1, 2, 3);
+        SortedArrayList<Node.Id> dc1Nodes = idList(1, 2, 3);
         Set<Node.Id> dc1Fp = idSet(1, 2);
-        List<Node.Id> dc2Nodes = idList(4, 5, 6);
+        SortedArrayList<Node.Id> dc2Nodes = idList(4, 5, 6);
         Set<Node.Id> dc2Fp = idSet(4, 5);
         addAndMarkSynced(service, topology(1,
                 shard(PrefixedIntHashKey.range(0, 0, 100), dc2Nodes, dc2Fp),

--- a/accord-core/src/test/java/accord/topology/TopologyUtils.java
+++ b/accord-core/src/test/java/accord/topology/TopologyUtils.java
@@ -29,6 +29,7 @@ import accord.primitives.Unseekables;
 import accord.primitives.Unseekables.UnseekablesKind;
 import accord.utils.Gens;
 import accord.utils.RandomSource;
+import accord.utils.SortedArrays.SortedArrayList;
 import accord.utils.Utils;
 import accord.utils.WrapAroundList;
 import accord.utils.WrapAroundSet;
@@ -56,7 +57,7 @@ public class TopologyUtils
 
     public static Topology withEpoch(Topology topology, long epoch)
     {
-        return new Topology(topology.global == null ? null : withEpoch(topology.global, epoch), epoch, topology.shards, topology.ranges, topology.nodeLookup, topology.subsetOfRanges, topology.supersetIndexes);
+        return new Topology(topology.global == null ? null : withEpoch(topology.global, epoch), epoch, topology.shards, topology.ranges, topology.nodeIds, topology.nodeLookup, topology.subsetOfRanges, topology.supersetIndexes);
     }
 
     public static Topology topology(long epoch, List<Node.Id> cluster, Ranges ranges, int rf)
@@ -85,7 +86,8 @@ public class TopologyUtils
         Set<Node.Id> noShard = new HashSet<>(Arrays.asList(cluster));
         for (int i = 0; i < ranges.size() ; ++i)
         {
-            shards.add(new Shard(ranges.get(i), electorates.get(i % electorates.size()), fastPathElectorates.get(i % fastPathElectorates.size())));
+            SortedArrayList<Node.Id> sortedNodes = SortedArrayList.copyUnsorted(electorates.get(i % electorates.size()), Node.Id[]::new);
+            shards.add(new Shard(ranges.get(i), sortedNodes, fastPathElectorates.get(i % fastPathElectorates.size())));
             noShard.removeAll(electorates.get(i % electorates.size()));
         }
         if (!noShard.isEmpty())

--- a/accord-core/src/test/java/accord/utils/AccordGens.java
+++ b/accord-core/src/test/java/accord/utils/AccordGens.java
@@ -51,6 +51,7 @@ import accord.primitives.Txn;
 import accord.primitives.TxnId;
 import accord.topology.Shard;
 import accord.topology.Topology;
+import accord.utils.SortedArrays.SortedArrayList;
 import org.agrona.collections.IntHashSet;
 
 import static accord.utils.Utils.toArray;
@@ -298,11 +299,11 @@ public class AccordGens
         };
     }
 
-    public static Gen<Shard> shards(Gen<Range> rangeGen, Gen<List<Node.Id>> nodesGen)
+    public static Gen<Shard> shards(Gen<Range> rangeGen, Gen<SortedArrayList<Node.Id>> nodesGen)
     {
         return rs -> {
             Range range = rangeGen.next(rs);
-            List<Node.Id> nodes = nodesGen.next(rs);
+            SortedArrayList<Node.Id> nodes = nodesGen.next(rs);
             int maxFailures = (nodes.size() - 1) / 2;
             Set<Node.Id> fastPath = new HashSet<>();
             if (maxFailures == 0)
@@ -367,8 +368,9 @@ public class AccordGens
             for (int i = 0; i < ranges.size() ; ++i)
             {
                 WrapAroundList<Node.Id> replicas = electorates.get(i % electorates.size());
+                SortedArrayList<Node.Id> sortedIds = SortedArrayList.copyUnsorted(replicas, Node.Id[]::new);
                 Range range = ranges.get(i);
-                shards.add(shards(ignore -> range, ignore -> replicas).next(rs));
+                shards.add(shards(ignore -> range, ignore -> sortedIds).next(rs));
                 replicas.forEach(noShard::remove);
             }
             if (!noShard.isEmpty())

--- a/accord-core/src/test/java/accord/utils/SearchableRangeListTest.java
+++ b/accord-core/src/test/java/accord/utils/SearchableRangeListTest.java
@@ -45,7 +45,7 @@ class SearchableRangeListTest
         class Counter { int value;}
         BiConsumer<Integer, Integer> test = (rangeStart, rangeEnd) -> {
             Counter counter = new Counter();
-            list.forEach(IntKey.range(rangeStart, rangeEnd), (a, b, c, d, e) -> {
+            list.forEachRange(IntKey.range(rangeStart, rangeEnd), (a, b, c, d, e) -> {
                 counter.value++;
             }, (a, b, c, d, start, end) -> {
                 counter.value += (end - start + 1);
@@ -102,7 +102,7 @@ class SearchableRangeListTest
                         expected.add(r);
                 }
                 List<Range> actual = new ArrayList<>(expected.size());
-                list.forEach(range, (a, b, c, d, idx) -> {
+                list.forEachRange(range, (a, b, c, d, idx) -> {
                     actual.add(list.ranges[idx]);
                 }, (a, b, c, d, start, end) -> {
                     for (int j = start; j < end; j++)

--- a/accord-maelstrom/src/main/java/accord/maelstrom/MaelstromRead.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/MaelstromRead.java
@@ -24,6 +24,7 @@ import accord.api.Key;
 import accord.api.Read;
 import accord.local.SafeCommandStore;
 import accord.primitives.Keys;
+import accord.primitives.Participants;
 import accord.primitives.Ranges;
 import accord.primitives.Seekable;
 import accord.primitives.Timestamp;
@@ -60,6 +61,12 @@ public class MaelstromRead implements Read
     public Read slice(Ranges ranges)
     {
         return new MaelstromRead(readKeys.slice(ranges), keys.slice(ranges));
+    }
+
+    @Override
+    public Read intersecting(Participants<?> participants)
+    {
+        return new MaelstromRead(readKeys.intersecting(participants), keys.intersecting(participants));
     }
 
     @Override

--- a/accord-maelstrom/src/main/java/accord/maelstrom/MaelstromUpdate.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/MaelstromUpdate.java
@@ -24,8 +24,10 @@ import java.util.TreeMap;
 import accord.api.Key;
 import accord.api.Data;
 import accord.api.Update;
+import accord.primitives.Participants;
 import accord.primitives.Ranges;
 import accord.primitives.Keys;
+import accord.primitives.Routables;
 import accord.primitives.Timestamp;
 
 public class MaelstromUpdate extends TreeMap<Key, Value> implements Update
@@ -49,10 +51,21 @@ public class MaelstromUpdate extends TreeMap<Key, Value> implements Update
     @Override
     public Update slice(Ranges ranges)
     {
+        return intersecting((Routables<?>) ranges);
+    }
+
+    @Override
+    public Update intersecting(Participants<?> participants)
+    {
+        return intersecting((Routables<?>) participants);
+    }
+
+    public Update intersecting(Routables<?> routables)
+    {
         MaelstromUpdate result = new MaelstromUpdate();
         for (Map.Entry<Key, Value> e : entrySet())
         {
-            if (ranges.contains(e.getKey()))
+            if (routables.contains(e.getKey()))
                 result.put(e.getKey(), e.getValue());
         }
         return result;

--- a/accord-maelstrom/src/main/java/accord/maelstrom/TopologyFactory.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/TopologyFactory.java
@@ -32,6 +32,7 @@ import accord.topology.Topology;
 import accord.utils.WrapAroundList;
 import accord.utils.WrapAroundSet;
 
+import static accord.utils.SortedArrays.SortedArrayList.copyUnsorted;
 import static accord.utils.Utils.toArray;
 
 public class TopologyFactory
@@ -82,7 +83,7 @@ public class TopologyFactory
         for (int j = 0 ; j < kinds.length ; ++j)
         {
             for (int i = 0 ; i < this.shards ; ++i)
-                shards.add(new Shard(ranges[j][i], electorates.get(i % electorates.size()), fastPathElectorates.get(i % fastPathElectorates.size())));
+                shards.add(new Shard(ranges[j][i], copyUnsorted(electorates.get(i % electorates.size()), Id[]::new), fastPathElectorates.get(i % fastPathElectorates.size())));
         }
         return new Topology(1, toArray(shards, Shard[]::new));
     }


### PR DESCRIPTION
This patch fixes various bugs as well as deficiencies in some of the abstractions

- Remove concept of non-participating home keys; home keys are required to be a participant in the transaction
- Remove covering/covers concept
- Fix various invalidation/truncation/erase behaviours