### PR TITLE
Sorted arrays tests sometimes falls into infinite re-generate loop

### DIFF
--- a/accord-core/src/test/java/accord/utils/Gens.java
+++ b/accord-core/src/test/java/accord/utils/Gens.java
@@ -1050,8 +1050,14 @@ public class Gens {
             if (!bestEffort)
             {
                 T value;
-                while (!seen.add((value = fn.next(random)))) {}
-                return value;
+                // 10k attempts
+                for (int i = 0; i < 10_000; i++)
+                {
+                    if (seen.add((value = fn.next(random))))
+                        return value;
+                }
+
+                throw new IllegalArgumentException("Could not generate a unique value after 10k attempts");
             }
             else
             {

--- a/accord-core/src/test/java/accord/utils/SortedArraysTest.java
+++ b/accord-core/src/test/java/accord/utils/SortedArraysTest.java
@@ -237,17 +237,18 @@ class SortedArraysTest
     @Test
     public void testLinearSubtract()
     {
-        int[][] quants = {{0, 1000, 0, 1000},
-                          {0, 100, 0, 1000},
-                          {0, 100, 0, 10},
-                          {0, 10, 0, 10},
-                          {0, 5, 0, 5},
-                          {0, 5, 0, 5}};
+        int[][] quants = {{1000, 1000},
+                          {100, 1000},
+                          {100, 10},
+                          {10, 10},
+                          {5, 5},
+                          {5, 5}};
 
         for (int[] quant : quants)
         {
-            Gen<Integer[]> gen1 = sortedUniqueIntegerArray(quant[1], quant[0]);
-            Gen<Integer[]> gen2 = sortedUniqueIntegerArray(quant[3], quant[2]);
+            System.out.println(Arrays.toString(quant));
+            Gen<Integer[]> gen1 = sortedUniqueIntegerArray(quant[0] * 2, 0, quant[0]);
+            Gen<Integer[]> gen2 = sortedUniqueIntegerArray(quant[1] * 2, 0, quant[1]);
             qt().forAll(gen1, gen2).withExamples(1000).check((a, b) -> {
                 Set<Integer> left = new HashSet<>(Arrays.asList(a));
                 Set<Integer> right = new HashSet<>(Arrays.asList(b));
@@ -366,18 +367,25 @@ class SortedArraysTest
     }
 
     private static Gen<Integer[]> sortedUniqueIntegerArray(int range, int minSize) {
+        return sortedUniqueIntegerArray(range, minSize, 100);
+    }
+
+    private static Gen<Integer[]> sortedUniqueIntegerArray(int range, int minSize, int maxSize) {
         return Gens.arrays(Integer.class, Gens.ints().between(0, range))
-                .unique()
-                .ofSizeBetween(minSize, 100)
-                .map(a -> {
-                    Arrays.sort(a);
-                    return a;
-                });
+                   .unique()
+                   .ofSizeBetween(minSize, maxSize)
+                   .map(a -> {
+                       Arrays.sort(a);
+                       return a;
+                   });
     }
 
     private static Gen<Integer[]> sortedIntegerArray(int range, int minSize) {
+        return sortedUniqueIntegerArray(range, minSize, 100);
+    }
+    private static Gen<Integer[]> sortedIntegerArray(int range, int minSize, int maxSize) {
         return Gens.arrays(Integer.class, Gens.ints().between(0, range))
-                .ofSizeBetween(minSize, 100)
+                .ofSizeBetween(minSize, maxSize)
                 .map(a -> {
                     Arrays.sort(a);
                     return a;


### PR DESCRIPTION
This only does the simplest possible thing: limits the number of cycles to 10K. We can improve this in the future by introducing a variable-entropy zero-cycle Integer generators. I have made a sketch, but I'm not comfortable releasing it yet, needs a bit more thought.