### PR TITLE
Fixes

### DIFF
--- a/accord-core/src/main/java/accord/api/ProtocolModifiers.java
+++ b/accord-core/src/main/java/accord/api/ProtocolModifiers.java
@@ -205,6 +205,7 @@ public class ProtocolModifiers
         public static void setRequiresUniqueHlcs(boolean newRequiresUniqueHlcs) { requiresUniqueHlcs = newRequiresUniqueHlcs; }
 
         private static int markStaleIfCannotExecute = TinyEnumSet.encode(Txn.Kind.Write);
+        public static boolean markStaleIfCannotExecute(TxnId txnId) { return TinyEnumSet.contains(markStaleIfCannotExecute, txnId.kindOrdinal()); }
         public static boolean markStaleIfCannotExecute(Txn.Kind kind) { return TinyEnumSet.contains(markStaleIfCannotExecute, kind); }
         public static void setMarkStaleIfCannotExecute(Txn.Kind ... kinds)
         {
@@ -213,10 +214,24 @@ public class ProtocolModifiers
             markStaleIfCannotExecute = newMarkStaleIfCannotExecute;
         }
 
+        private static int transitiveDependenciesAreVisible = TinyEnumSet.encode(Txn.Kind.ExclusiveSyncPoint);
+        public static boolean isTransitiveDependencyVisible(TxnId txnId) { return TinyEnumSet.contains(transitiveDependenciesAreVisible, txnId.kindOrdinal()); }
+        public static boolean isTransitiveDependencyVisible(Txn.Kind kind) { return TinyEnumSet.contains(transitiveDependenciesAreVisible, kind); }
+        public static void setTransitiveDependenciesAreVisible(Txn.Kind ... kinds)
+        {
+            int newTransitiveDependenciesAreVisible = TinyEnumSet.encode(kinds);
+            Invariants.require(TinyEnumSet.contains(newTransitiveDependenciesAreVisible, Txn.Kind.ExclusiveSyncPoint));
+            transitiveDependenciesAreVisible = newTransitiveDependenciesAreVisible;
+        }
+
         public enum DependencyElision { OFF, ON, IF_DURABLE }
         private static DependencyElision dependencyElision = IF_DURABLE;
         public static DependencyElision dependencyElision() { return dependencyElision; }
         public static void setDependencyElision(DependencyElision newDependencyElision) { dependencyElision = newDependencyElision; }
+
+        private static boolean visitMaybePruned = true;
+        public static boolean shouldVisitMaybePruned() { return visitMaybePruned; }
+        public static void setVisitMaybePruned(boolean newVisitMaybePruned) { visitMaybePruned = newVisitMaybePruned; }
 
         public enum InformOfDurability { HOME, ALL }
         private static InformOfDurability informOfDurability = ALL;

--- a/accord-core/src/main/java/accord/coordinate/Recover.java
+++ b/accord-core/src/main/java/accord/coordinate/Recover.java
@@ -372,8 +372,10 @@ public class Recover implements Callback<RecoverReply>, BiConsumer<Result, Throw
             }
             case Accept:
             {
-                propose(SLOW, txnId, recoverOkList);
-                return;
+                // we still have to wait for earlier transactions to decide themselves so we don't accidentally include
+                // a non-fastpath transaction in our dependencies and permit it to conclude it is safe to execute.
+                // So, we fall-through to Unknown condition - though we don't in principle need to wait for any future transactions
+                
             }
             case Unknown:
             {

--- a/accord-core/src/main/java/accord/local/Commands.java
+++ b/accord-core/src/main/java/accord/local/Commands.java
@@ -722,7 +722,7 @@ public class Commands
                     Invariants.require(dependency.executeAt().compareTo(waitingExecuteAt) < 0
                                        || waitingId.awaitsOnlyDeps()
                                        || waiting.participants().stillExecutes().isEmpty()
-                                       || !markStaleIfCannotExecute(dependencyId.kind())
+                                       || !markStaleIfCannotExecute(dependencyId)
                                        || safeStore.redundantBefore().status(dependencyId, null,
                                                  waiting.partialDeps().participants(dependencyId)).all(LOCALLY_DEFUNCT)
                     );

--- a/accord-core/src/main/java/accord/local/Node.java
+++ b/accord-core/src/main/java/accord/local/Node.java
@@ -704,8 +704,13 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
      */
     public TxnId nextTxnId(Txn.Kind rw, Domain domain, Cardinality cardinality, int flags)
     {
+        return nextTxnId(uniqueNow(), rw, domain, cardinality, flags);
+    }
+
+    private static TxnId nextTxnId(Timestamp now, Txn.Kind rw, Domain domain, Cardinality cardinality, int flags)
+    {
         Invariants.require(domain == Key || rw != Txn.Kind.Write, "Range writes not supported without forwarding uniqueHlc information to WaitingOn for direct dependencies");
-        TxnId txnId = new TxnId(uniqueNow(), flags, rw, domain, cardinality);
+        TxnId txnId = new TxnId(now, flags, rw, domain, cardinality);
         Invariants.require((txnId.lsb & (0xffff & ~TxnId.IDENTITY_FLAGS)) == 0);
         return txnId;
     }
@@ -747,7 +752,7 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
             fastPath = Unoptimised;
 
         Cardinality cardinality = cardinality(domain, keys);
-        return nextTxnId(kind, domain, cardinality, fastPath.bits | mediumPath.bit());
+        return nextTxnId(now, kind, domain, cardinality, fastPath.bits | mediumPath.bit());
     }
 
     public AsyncResult<Result> coordinate(Txn txn)

--- a/accord-core/src/main/java/accord/local/cfk/Updating.java
+++ b/accord-core/src/main/java/accord/local/cfk/Updating.java
@@ -495,7 +495,7 @@ class Updating
             else if (c > 0)
             {
                 TxnId txnId = additions[j++];
-                newById[count] = TxnInfo.create(txnId, TRANSITIVE_VISIBLE, mayExecute(boundsInfo, txnId), txnId, Ballot.ZERO);
+                newById[count] = TxnInfo.createTransitive(txnId, boundsInfo, plainTxnId);
                 ++missingCount;
             }
             else
@@ -512,7 +512,7 @@ class Updating
                 while (count < targetInsertPos)
                 {
                     TxnId txnId = additions[j++];
-                    newById[count++] = TxnInfo.create(txnId, TRANSITIVE_VISIBLE, mayExecute(boundsInfo, txnId), txnId, Ballot.ZERO);
+                    newById[count++] = TxnInfo.createTransitive(txnId, boundsInfo, plainTxnId);
                 }
                 newById[targetInsertPos] = newInfo;
                 count = targetInsertPos + 1;
@@ -520,7 +520,7 @@ class Updating
             while (j < additionCount)
             {
                 TxnId txnId = additions[j++];
-                newById[count++] = TxnInfo.create(txnId, TRANSITIVE_VISIBLE, mayExecute(boundsInfo, txnId), txnId, Ballot.ZERO);
+                newById[count++] = TxnInfo.createTransitive(txnId, boundsInfo, plainTxnId);
             }
         }
         else if (count == targetInsertPos)
@@ -532,7 +532,7 @@ class Updating
     /**
      * Similar to insertOrUpdateWithAdditions, but when we only need to insert some additions (i.e. when calling registerUnmanaged)
      */
-    static TxnInfo[] insertAdditionsOnly(TxnInfo[] byId, TxnInfo[] committedByExecuteAt, TxnInfo[] newInfos, TxnId[] additions, int additionCount, RedundantBefore.Entry boundsInfo)
+    static TxnInfo[] insertAdditionsOnly(TxnInfo[] byId, TxnInfo[] committedByExecuteAt, TxnInfo[] newInfos, TxnId[] additions, int additionCount, RedundantBefore.Entry boundsInfo, TxnId witnessedBy)
     {
         // the most recently constructed pure insert missing array, so that it may be reused if possible
         int minByExecuteAtSearchIndex = 0;
@@ -585,7 +585,7 @@ class Updating
             else if (c > 0)
             {
                 TxnId txnId = additions[j];
-                newInfos[count] = TxnInfo.create(txnId, TRANSITIVE_VISIBLE, mayExecute(boundsInfo, txnId), txnId, Ballot.ZERO);
+                newInfos[count] = TxnInfo.createTransitive(txnId, boundsInfo, witnessedBy);
                 ++j;
                 ++missingCount;
             }
@@ -970,7 +970,7 @@ class Updating
                         TxnId minUndecidedMissing = minUndecidedMissingIndex == missingCount ? null : missing[minUndecidedMissingIndex];
                         TxnId minUndecided = TxnId.nonNullOrMin(minUndecidedMissing, cfk.minUndecided());
                         newById = new TxnInfo[byId.length + missingCount];
-                        newCommittedByExecuteAt = insertAdditionsOnly(byId, cfk.committedByExecuteAt, newById, missing, missingCount, cfk.boundsInfo);
+                        newCommittedByExecuteAt = insertAdditionsOnly(byId, cfk.committedByExecuteAt, newById, missing, missingCount, cfk.boundsInfo, waitingTxnId);
                         // we can safely use missing[prunedIndex] here because we only fill missing with transactions for which we manage execution
                         if (minUndecided != null)
                             newMinUndecidedById = Arrays.binarySearch(newById, minUndecided);

--- a/accord-core/src/main/java/accord/messages/BeginRecovery.java
+++ b/accord-core/src/main/java/accord/messages/BeginRecovery.java
@@ -284,10 +284,7 @@ public class BeginRecovery extends TxnRequest.WithUnsynced<BeginRecovery.Recover
                         case COMMITTED:
                         case ACCEPTED:
                             if (testExecuteAt.is(HLC_BOUND))
-                            {
-                                supersedingRejects = true;
-                                return false;
-                            }
+                                return markSupersedingRejects();
                             if (status != ACCEPTED)
                                 break;
                         case PREACCEPTED:
@@ -312,8 +309,7 @@ public class BeginRecovery extends TxnRequest.WithUnsynced<BeginRecovery.Recover
                          * witnessed us we are safe to propose the pre-accept timestamp regardless, whereas if any transaction
                          * has not witnessed us we can safely invalidate.
                          */
-                        supersedingRejects = true;
-                        return false;
+                        return markSupersedingRejects();
 
                     case NOT_ELIGIBLE:
                         switch (status)
@@ -351,8 +347,7 @@ public class BeginRecovery extends TxnRequest.WithUnsynced<BeginRecovery.Recover
                          * witnessed us we are safe to propose the pre-accept timestamp regardless, whereas if any transaction
                          * has not witnessed us we can safely invalidate (us).
                          */
-                        supersedingRejects = true;
-                        return false;
+                        return markSupersedingRejects();
 
                     case NOT_ELIGIBLE:
                         // the command doesn't have any coordinator deps; or we are its coordinator and cannot commit on the privileged fast path
@@ -370,6 +365,12 @@ public class BeginRecovery extends TxnRequest.WithUnsynced<BeginRecovery.Recover
             }
 
             return true;
+        }
+
+        private boolean markSupersedingRejects()
+        {
+            this.supersedingRejects = true;
+            return false;
         }
 
         private Deps.Builder ensureEarlierNoWait()

--- a/accord-core/src/main/java/accord/messages/Propagate.java
+++ b/accord-core/src/main/java/accord/messages/Propagate.java
@@ -390,7 +390,7 @@ public class Propagate implements PreLoadContext, MapReduceConsume<SafeCommandSt
             return null;
 
         // TODO (expected): if the above last ditch doesn't work, see if only the stale ranges can't apply and so some shenanigans to apply partially and move on
-        if (ProtocolModifiers.Toggles.markStaleIfCannotExecute(txnId.kind()))
+        if (ProtocolModifiers.Toggles.markStaleIfCannotExecute(txnId))
         {
             safeStore.commandStore().markShardStale(safeStore, executeAtIfKnown == null ? txnId : executeAtIfKnown, stale.toRanges(), true);
             if (!stale.containsAll(stillTouches) || !stale.containsAll(stillOwnsOrMayExecute))

--- a/accord-core/src/main/java/accord/utils/BTreeReducingRangeMap.java
+++ b/accord-core/src/main/java/accord/utils/BTreeReducingRangeMap.java
@@ -350,7 +350,7 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
                         if (isRangeOpen)
                             acc.remove(entry.start());
                         else
-                            acc.add(entry.start(), value);
+                            acc.add(entry.start(), supersedes);
                     }
                     isRangeOpen = supersedes != null;
                 }


### PR DESCRIPTION
 - Even if we can decide autonomously that we took the fast path, we must still wait for earlier transactions to decide themselves
 - We must update a command that is in CFK.loadingPruned whether or not it is outOfRange
 - We must visit pruned commands that are transitive dependencies of RX to ensure dependencies are propagated
 - flagsWithoutDomainAndKind() -> flagsWithoutDomainOrKindOrCardinality() [to fix integration regression]
 - Don't invoke uniqueNow() twice when allocate nextTxnId
 - BTreeReducingRangeMap edge case that corrupts map when merge function does not return one of its inputs