### PR TITLE
Fix 351354342367750L, acceptedOrCommitted state restore

### DIFF
--- a/accord-core/src/main/java/accord/local/Command.java
+++ b/accord-core/src/main/java/accord/local/Command.java
@@ -183,6 +183,7 @@ public abstract class Command implements ICommand
                && saveStatus() == command.saveStatus()
                && durability() == command.durability()
                && Objects.equals(participants(), command.participants())
+               && Objects.equals(acceptedOrCommitted(), command.acceptedOrCommitted())
                && Objects.equals(promised(), command.promised());
     }
 


### PR DESCRIPTION
```
Caused by: java.lang.IllegalStateException: [6,9208,0,8] != [0,0,0,0]
	at accord.utils.Invariants.createIllegalState(Invariants.java:76)
	at accord.utils.Invariants.illegalState(Invariants.java:81)
	at accord.utils.Invariants.require(Invariants.java:271)
	at accord.impl.basic.Cluster.verifyConsistentRestore(Cluster.java:938)
	at accord.impl.basic.Cluster.lambda$run$24(Cluster.java:781)
	at accord.impl.basic.RecurringPendingRunnable.run(RecurringPendingRunnable.java:57)
	at accord.impl.basic.Cluster.processNext(Cluster.java:380)
	at accord.impl.basic.Cluster.processPending(Cluster.java:332)
	at accord.impl.basic.Cluster.run(Cluster.java:806)
	at accord.burn.BurnTestBase.burn(BurnTestBase.java:521)
```