### PR TITLE
Fixes:

### DIFF
--- a/accord-core/src/main/java/accord/coordinate/CheckShards.java
+++ b/accord-core/src/main/java/accord/coordinate/CheckShards.java
@@ -18,6 +18,8 @@
 
 package accord.coordinate;
 
+import javax.annotation.Nullable;
+
 import accord.local.Node;
 import accord.local.Node.Id;
 import accord.messages.CheckStatus;
@@ -45,24 +47,26 @@ public abstract class CheckShards<U extends Participants<?>> extends ReadCoordin
      */
     final long sourceEpoch;
     final IncludeInfo includeInfo;
+    final @Nullable Ballot bumpBallot;
     final Infer.InvalidIf previouslyKnownToBeInvalidIf;
 
     protected CheckStatusOk merged;
     protected boolean truncated;
 
     // srcEpoch is either txnId.epoch() or executeAt.epoch()
-    protected CheckShards(Node node, TxnId txnId, U route, IncludeInfo includeInfo, Infer.InvalidIf previouslyKnownToBeInvalidIf)
+    protected CheckShards(Node node, TxnId txnId, U route, IncludeInfo includeInfo, @Nullable Ballot bumpBallot, Infer.InvalidIf previouslyKnownToBeInvalidIf)
     {
-        this(node, txnId, route, txnId.epoch(), includeInfo, previouslyKnownToBeInvalidIf);
+        this(node, txnId, route, txnId.epoch(), includeInfo, bumpBallot, previouslyKnownToBeInvalidIf);
         Invariants.require(txnId.isVisible());
     }
 
-    protected CheckShards(Node node, TxnId txnId, U route, long srcEpoch, IncludeInfo includeInfo, Infer.InvalidIf previouslyKnownToBeInvalidIf)
+    protected CheckShards(Node node, TxnId txnId, U route, long srcEpoch, IncludeInfo includeInfo, @Nullable Ballot bumpBallot, Infer.InvalidIf previouslyKnownToBeInvalidIf)
     {
         super(node, topologyFor(node, txnId, route, srcEpoch), txnId);
         this.sourceEpoch = srcEpoch;
         this.route = route;
         this.includeInfo = includeInfo;
+        this.bumpBallot = bumpBallot;
         this.previouslyKnownToBeInvalidIf = previouslyKnownToBeInvalidIf;
     }
 
@@ -76,7 +80,7 @@ public abstract class CheckShards<U extends Participants<?>> extends ReadCoordin
     protected void contact(Id id)
     {
         Participants<?> unseekables = route.slice(topologies().computeRangesForNode(id));
-        node.send(id, new CheckStatus(txnId, unseekables, sourceEpoch, includeInfo), this);
+        node.send(id, new CheckStatus(txnId, unseekables, sourceEpoch, includeInfo, bumpBallot), this);
     }
 
     protected boolean isSufficient(Id from, CheckStatusOk ok) { return isSufficient(ok); }

--- a/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
@@ -156,7 +156,7 @@ public class CoordinateSyncPoint<R> extends CoordinatePreAccept<R>
                 withFlags = txnId.addFlag(HLC_BOUND);
             Deps deps = Deps.merge(oks.valuesAsNullableList(), oks.domainSize(), List::get, ok -> ok.deps);
             if (tracker.hasFastPathAccepted())
-                adapter.execute(node, topologies, route, FAST, ExecuteFlags.none(), txnId, txn, withFlags, deps, deps, this);
+                adapter.execute(node, topologies, route, Ballot.ZERO, FAST, ExecuteFlags.none(), txnId, txn, withFlags, deps, deps, this);
             else if (tracker.hasMediumPathAccepted())
                 adapter.propose(node, topologies, route, Accept.Kind.MEDIUM, Ballot.ZERO, txnId, txn, withFlags, deps, this);
             else
@@ -173,10 +173,10 @@ public class CoordinateSyncPoint<R> extends CoordinatePreAccept<R>
 
     public static void sendApply(Node node, Node.Id to, SyncPoint<?> syncPoint, Topologies participates)
     {
-        sendApply(node, to, syncPoint, participates, null);
+        sendApply(node, to, syncPoint, participates, Ballot.ZERO, null);
     }
 
-    public static void sendApply(Node node, Node.Id to, SyncPoint<?> syncPoint, Topologies participates, @Nullable Callback<Apply.ApplyReply> callback)
+    public static void sendApply(Node node, Node.Id to, SyncPoint<?> syncPoint, Topologies participates, Ballot ballot, @Nullable Callback<Apply.ApplyReply> callback)
     {
         TxnId txnId = syncPoint.syncId;
         Timestamp executeAt = syncPoint.executeAt;
@@ -184,7 +184,7 @@ public class CoordinateSyncPoint<R> extends CoordinatePreAccept<R>
         Deps deps = syncPoint.waitFor;
         FullRoute<?> route = syncPoint.route;
         Result result = txn.result(txnId, executeAt, null);
-        Apply apply = Apply.FACTORY.create(Maximal, to, participates, txnId, route, txn, executeAt, deps, null, result, route);
+        Apply apply = Apply.FACTORY.create(Maximal, to, participates, txnId, ballot, route, txn, executeAt, deps, null, result, route);
         if (callback == null) node.send(to, apply);
         else node.send(to, apply, callback);
     }

--- a/accord-core/src/main/java/accord/coordinate/CoordinateTransaction.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinateTransaction.java
@@ -111,7 +111,7 @@ public class CoordinateTransaction extends CoordinatePreAccept<Result>
                 // note: we merge all Deps regardless of witnessedAt. While we only need fast path votes,
                 // we must include Deps from fast path votes from earlier epochs that may have witnessed later transactions
                 // TODO (desired): we might mask some bugs by merging more responses than we strictly need, so optimise this to optionally merge minimal deps
-                executeAdapter().execute(node, topologies, route, FAST, executeFlags, txnId, txn, txnId, deps, deps, settingCallback());
+                executeAdapter().execute(node, topologies, route, Ballot.ZERO, FAST, executeFlags, txnId, txn, txnId, deps, deps, settingCallback());
                 node.agent().eventListener().onFastPathTaken(txnId, deps);
                 return;
             }

--- a/accord-core/src/main/java/accord/coordinate/CoordinationAdapter.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinationAdapter.java
@@ -73,11 +73,11 @@ public interface CoordinationAdapter<R>
     void proposeOnly(Node node, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Accept.Kind kind, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, BiConsumer<? super Deps, Throwable> callback);
     void stabilise(Node node, @Nullable Topologies any, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, BiConsumer<? super R, Throwable> callback);
     void stabiliseOnly(Node node, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, BiConsumer<? super Deps, Throwable> callback);
-    void execute(Node node, @Nullable Topologies any, FullRoute<?> route, ExecutePath path, ExecuteFlags executeFlags, TxnId txnId, Txn txn, Timestamp executeAt, Deps stableDeps, Deps sendDeps, BiConsumer<? super R, Throwable> callback);
-    void persist(Node node, @Nullable Topologies any, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super R, Throwable> callback);
-    default void persist(Node node, @Nullable Topologies any, FullRoute<?> route, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super R, Throwable> callback)
+    void execute(Node node, @Nullable Topologies any, FullRoute<?> route, Ballot ballot, ExecutePath path, ExecuteFlags executeFlags, TxnId txnId, Txn txn, Timestamp executeAt, Deps stableDeps, Deps sendDeps, BiConsumer<? super R, Throwable> callback);
+    void persist(Node node, @Nullable Topologies any, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super R, Throwable> callback);
+    default void persist(Node node, @Nullable Topologies any, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super R, Throwable> callback)
     {
-        persist(node, any, route, route, SHARE, route, txnId, txn, executeAt, deps, writes, result, callback);
+        persist(node, any, route, route, SHARE, route, ballot, txnId, txn, executeAt, deps, writes, result, callback);
     }
 
     class DefaultFactory implements Factory
@@ -167,7 +167,7 @@ public interface CoordinationAdapter<R>
                                                           route, txnId, executeAt, SHARE, QuorumEpochIntersections.commit);
                 Topologies coordinates = all.size() == 1 ? all : accept.forEpoch(txnId.epoch());
 
-                if (ProtocolModifiers.Faults.txnInstability) execute(node, all, route, SLOW, ExecuteFlags.none(), txnId, txn, executeAt, deps, deps, callback);
+                if (ProtocolModifiers.Faults.txnInstability) execute(node, all, route, ballot, SLOW, ExecuteFlags.none(), txnId, txn, executeAt, deps, deps, callback);
                 else new StabiliseTxn(node, coordinates, all, route, ballot, txnId, txn, executeAt, deps, callback).start();
             }
 
@@ -191,7 +191,7 @@ public interface CoordinationAdapter<R>
             }
 
             @Override
-            public void execute(Node node, Topologies any, FullRoute<?> route, ExecutePath path, ExecuteFlags executeFlags, TxnId txnId, Txn txn, Timestamp executeAt, Deps stableDeps, Deps sendDeps, BiConsumer<? super Result, Throwable> callback)
+            public void execute(Node node, Topologies any, FullRoute<?> route, Ballot ballot, ExecutePath path, ExecuteFlags executeFlags, TxnId txnId, Txn txn, Timestamp executeAt, Deps stableDeps, Deps sendDeps, BiConsumer<? super Result, Throwable> callback)
             {
                 Topologies all = execution(node, any, route, SHARE, route, txnId, executeAt);
 
@@ -199,21 +199,21 @@ public interface CoordinationAdapter<R>
                 {
                     Writes writes = txnId.is(Txn.Kind.Write) ? txn.execute(txnId, executeAt, null) : null;
                     Result result = txn.result(txnId, executeAt, null);
-                    persist(node, all, route, txnId, txn, executeAt, stableDeps, writes, result, callback);
+                    persist(node, all, route, ballot, txnId, txn, executeAt, stableDeps, writes, result, callback);
                 }
                 else
                 {
-                    new ExecuteTxn(node, all, route, path, txnId, txn, executeAt, stableDeps, sendDeps, callback).start();
+                    new ExecuteTxn(node, all, route, ballot, path, txnId, txn, executeAt, stableDeps, sendDeps, callback).start();
                 }
             }
 
             @Override
-            public void persist(Node node, Topologies any, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super Result, Throwable> callback)
+            public void persist(Node node, Topologies any, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super Result, Throwable> callback)
             {
                 Topologies all = execution(node, any, sendTo, selectNodeOwnership, route, txnId, executeAt);
 
                 if (callback != null) callback.accept(result, null);
-                new PersistTxn(node, all, txnId, require, txn, executeAt, deps, writes, result, route, Apply.FACTORY)
+                new PersistTxn(node, all, txnId, ballot, require, txn, executeAt, deps, writes, result, route, Apply.FACTORY)
                 .start(applyKind, all, writes, result);
             }
 
@@ -269,18 +269,18 @@ public interface CoordinationAdapter<R>
             }
 
             @Override
-            public void execute(Node node, Topologies any, FullRoute<?> route, ExecutePath path, ExecuteFlags executeFlags, TxnId txnId, Txn txn, Timestamp executeAt, Deps stableDeps, Deps sendDeps, BiConsumer<? super R, Throwable> callback)
+            public void execute(Node node, Topologies any, FullRoute<?> route, Ballot ballot, ExecutePath path, ExecuteFlags executeFlags, TxnId txnId, Txn txn, Timestamp executeAt, Deps stableDeps, Deps sendDeps, BiConsumer<? super R, Throwable> callback)
             {
-                persist(node, null, route, txnId, txn, executeAt, stableDeps, null, txn.result(txnId, executeAt, null), callback);
+                persist(node, null, route, ballot, txnId, txn, executeAt, stableDeps, null, txn.result(txnId, executeAt, null), callback);
             }
 
             @Override
-            public void persist(Node node, Topologies ignore, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super R, Throwable> callback)
+            public void persist(Node node, Topologies ignore, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super R, Throwable> callback)
             {
                 Topologies all = forExecution(node, sendTo, selectNodeOwnership, txnId, executeAt, deps);
 
                 invokeSuccess(node, route, txnId, executeAt, txn, deps, callback);
-                new PersistSyncPoint(node, all, txnId, sendTo, txn, executeAt, deps, writes, result, route)
+                new PersistSyncPoint(node, all, txnId, ballot, sendTo, txn, executeAt, deps, writes, result, route)
                 .start(Maximal, all, writes, result);
             }
         }
@@ -305,12 +305,12 @@ public interface CoordinationAdapter<R>
             }
 
             @Override
-            public void execute(Node node, Topologies any, FullRoute<?> route, ExecutePath path, ExecuteFlags executeFlags, TxnId txnId, Txn txn, Timestamp executeAt, Deps stableDeps, Deps sendDeps, BiConsumer<? super R, Throwable> callback)
+            public void execute(Node node, Topologies any, FullRoute<?> route, Ballot ballot, ExecutePath path, ExecuteFlags executeFlags, TxnId txnId, Txn txn, Timestamp executeAt, Deps stableDeps, Deps sendDeps, BiConsumer<? super R, Throwable> callback)
             {
                 // We cannot use the fast path for sync points as their visibility is asymmetric wrt other transactions,
                 // so we could recover to include different transactions than those we fast path committed with.
                 Invariants.require(path != FAST);
-                super.execute(node, any, route, path, executeFlags, txnId, txn, executeAt, stableDeps, sendDeps, callback);
+                super.execute(node, any, route, ballot, path, executeFlags, txnId, txn, executeAt, stableDeps, sendDeps, callback);
             }
         }
 

--- a/accord-core/src/main/java/accord/coordinate/ExecuteTxn.java
+++ b/accord-core/src/main/java/accord/coordinate/ExecuteTxn.java
@@ -80,6 +80,7 @@ public class ExecuteTxn extends ReadCoordinator<ReadReply> implements Timeouts.T
     final ExecutePath path;
     final Txn txn;
     final FullRoute<?> route;
+    final Ballot ballot;
     final Timestamp executeAt;
     final Deps stableDeps;
     final Deps sendDeps;
@@ -91,12 +92,13 @@ public class ExecuteTxn extends ReadCoordinator<ReadReply> implements Timeouts.T
     private Data data;
     private long uniqueHlc;
 
-    ExecuteTxn(Node node, Topologies topologies, FullRoute<?> route, ExecutePath path, TxnId txnId, Txn txn, Timestamp executeAt, Deps stableDeps, Deps sendDeps, BiConsumer<? super Result, Throwable> callback)
+    ExecuteTxn(Node node, Topologies topologies, FullRoute<?> route, Ballot ballot, ExecutePath path, TxnId txnId, Txn txn, Timestamp executeAt, Deps stableDeps, Deps sendDeps, BiConsumer<? super Result, Throwable> callback)
     {
         super(node, topologies.forEpoch(executeAt.epoch()), txnId);
         this.path = path;
         this.txn = txn;
         this.route = route;
+        this.ballot = ballot;
         this.allTopologies = topologies;
         this.executeAt = executeAt;
         this.stableDeps = stableDeps;
@@ -238,7 +240,7 @@ public class ExecuteTxn extends ReadCoordinator<ReadReply> implements Timeouts.T
 
             Writes writes = txnId.is(Txn.Kind.Write) ? txn.execute(txnId, executeAt, data) : null;
             Result result = txn.result(txnId, executeAt, data);
-            adapter().persist(node, allTopologies, route, txnId, txn, executeAt, stableDeps, writes, result, callback);
+            adapter().persist(node, allTopologies, route, ballot, txnId, txn, executeAt, stableDeps, writes, result, callback);
         }
         else
         {

--- a/accord-core/src/main/java/accord/coordinate/FetchData.java
+++ b/accord-core/src/main/java/accord/coordinate/FetchData.java
@@ -290,7 +290,7 @@ public class FetchData extends CheckShards<Route<?>>
     private FetchData(Node node, Known target, TxnId txnId, InvalidIf invalidIf, Route<?> route, Route<?> routeWithHomeKey, Route<?> maxRoute, Unseekables<?> propagateTo, long sourceEpoch, long lowEpoch, long highEpoch, BiConsumer<? super FetchResult, Throwable> callback)
     {
         // TODO (desired, efficiency): restore behaviour of only collecting info if e.g. Committed or Executed
-        super(node, txnId, routeWithHomeKey, sourceEpoch, CheckStatus.IncludeInfo.All, invalidIf);
+        super(node, txnId, routeWithHomeKey, sourceEpoch, CheckStatus.IncludeInfo.All, null, invalidIf);
         this.propagateTo = propagateTo;
         this.lowEpoch = lowEpoch;
         this.maxRoute = maxRoute;

--- a/accord-core/src/main/java/accord/coordinate/FindRoute.java
+++ b/accord-core/src/main/java/accord/coordinate/FindRoute.java
@@ -54,7 +54,7 @@ public class FindRoute extends CheckShards<Route<?>>
     final BiConsumer<Result, Throwable> callback;
     FindRoute(Node node, TxnId txnId, InvalidIf invalidIf, Route<?> someRoute, BiConsumer<Result, Throwable> callback)
     {
-        super(node, txnId, someRoute, IncludeInfo.Route, invalidIf);
+        super(node, txnId, someRoute, IncludeInfo.Route, null, invalidIf);
         this.callback = callback;
     }
 

--- a/accord-core/src/main/java/accord/coordinate/FindSomeRoute.java
+++ b/accord-core/src/main/java/accord/coordinate/FindSomeRoute.java
@@ -53,7 +53,7 @@ public class FindSomeRoute extends CheckShards<Participants<?>>
     final BiConsumer<Result, Throwable> callback;
     FindSomeRoute(Node node, TxnId txnId, Infer.InvalidIf invalidIf, Participants<?> unseekables, BiConsumer<Result, Throwable> callback)
     {
-        super(node, txnId, unseekables, IncludeInfo.Route, invalidIf);
+        super(node, txnId, unseekables, IncludeInfo.Route, null, invalidIf);
         this.callback = callback;
     }
 

--- a/accord-core/src/main/java/accord/coordinate/Invalidate.java
+++ b/accord-core/src/main/java/accord/coordinate/Invalidate.java
@@ -216,7 +216,7 @@ public class Invalidate implements Callback<InvalidateReply>
                         if (!invalidateWith.containsAll(fullRoute))
                             witnessedByInvalidation = null;
                     }
-                    RecoverWithRoute.recover(node, ballot, txnId, NotKnownToBeInvalid, fullRoute, witnessedByInvalidation, reportLowEpoch, reportHighEpoch, callback);
+                    RecoverWithRoute.recover(node, txnId, NotKnownToBeInvalid, fullRoute, witnessedByInvalidation, reportLowEpoch, reportHighEpoch, callback);
                     return;
 
                 case Invalidated:

--- a/accord-core/src/main/java/accord/coordinate/MaybeRecover.java
+++ b/accord-core/src/main/java/accord/coordinate/MaybeRecover.java
@@ -45,7 +45,7 @@ public class MaybeRecover extends CheckShards<Route<?>>
     MaybeRecover(Node node, TxnId txnId, Infer.InvalidIf invalidIf, Route<?> someRoute, ProgressToken prevProgress, long reportLowEpoch, long reportHighEpoch, BiConsumer<Outcome, Throwable> callback)
     {
         // we only want to enquire with the home shard, but we prefer maximal route information for running Invalidation against, if necessary
-        super(node, txnId, someRoute.withHomeKey(), IncludeInfo.Route, invalidIf);
+        super(node, txnId, someRoute.withHomeKey(), IncludeInfo.Route, null, invalidIf);
         this.prevProgress = prevProgress;
         this.callback = callback;
         this.reportLowEpoch = reportLowEpoch;
@@ -113,7 +113,7 @@ public class MaybeRecover extends CheckShards<Route<?>>
 
                 case Apply:
                     // we have included the home key, and one that witnessed the definition has responded, so it should also know the full route
-                    if (hasMadeProgress(full))
+                    if (hasMadeProgress(full) || !Route.isFullRoute(someRoute))
                     {
                         if (full.durability.isDurable())
                             InformDurable.informDefault(node, topologies, txnId, route, full.executeAtIfKnown(), full.durability);
@@ -121,7 +121,6 @@ public class MaybeRecover extends CheckShards<Route<?>>
                     }
                     else
                     {
-                        Invariants.require(Route.isFullRoute(someRoute), "Require a full route but given %s", full.route);
                         node.recover(txnId, full.invalidIf, Route.castToFullRoute(someRoute), reportLowEpoch, reportHighEpoch).invoke(callback);
                     }
                     break;

--- a/accord-core/src/main/java/accord/coordinate/Persist.java
+++ b/accord-core/src/main/java/accord/coordinate/Persist.java
@@ -27,6 +27,7 @@ import accord.messages.Apply;
 import accord.messages.Apply.ApplyReply;
 import accord.messages.Callback;
 import accord.messages.InformDurable;
+import accord.primitives.Ballot;
 import accord.primitives.Deps;
 import accord.primitives.FullRoute;
 import accord.primitives.Route;
@@ -45,6 +46,7 @@ public abstract class Persist implements Callback<ApplyReply>
 {
     protected final Node node;
     protected final TxnId txnId;
+    protected final Ballot ballot;
     protected final Route<?> sendTo;
     protected final Txn txn;
     protected final Timestamp executeAt;
@@ -58,10 +60,11 @@ public abstract class Persist implements Callback<ApplyReply>
     protected final Apply.Factory factory;
     boolean isDone;
 
-    protected Persist(Node node, Topologies all, TxnId txnId, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps stableDeps, Writes writes, Result result, FullRoute<?> route, Apply.Factory factory)
+    protected Persist(Node node, Topologies all, TxnId txnId, Ballot ballot, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps stableDeps, Writes writes, Result result, FullRoute<?> route, Apply.Factory factory)
     {
         this.node = node;
         this.txnId = txnId;
+        this.ballot = ballot;
         this.sendTo = sendTo;
         this.txn = txn;
         this.executeAt = executeAt;
@@ -91,9 +94,14 @@ public abstract class Persist implements Callback<ApplyReply>
                         InformDurable.informDefault(node, topologies, txnId, route, executeAt, Majority);
                     }
                 }
+            case RaceWithRecovery:
+                // don't count this towards durability; otherwise it is possible (though very unlikely)
+                // for InformDurable to reach a replica, the CommandsForKey to prune this transaction as durably applied
+                // and some superseding transaction to be coordinated and not witness it before the in-progress recovery
+                // reached another response in its quorum; in this case it may incorrectly determine the transaction should be invalidated
                 break;
             case Insufficient:
-                node.send(from, factory.create(Apply.Kind.Maximal, from, topologies, txnId, sendTo, txn, executeAt, stableDeps, writes, result, route));
+                node.send(from, factory.create(Apply.Kind.Maximal, from, topologies, txnId, ballot, sendTo, txn, executeAt, stableDeps, writes, result, route));
         }
     }
 
@@ -123,7 +131,7 @@ public abstract class Persist implements Callback<ApplyReply>
         else
         {
             CommandStore commandStore = CommandStore.currentOrElseSelect(node, route);
-            node.send(contact, to -> factory.create(kind, to, all, txnId, sendTo, txn, executeAt, stableDeps, writes, result, route), commandStore, this);
+            node.send(contact, to -> factory.create(kind, to, all, txnId, ballot, sendTo, txn, executeAt, stableDeps, writes, result, route), commandStore, this);
         }
     }
 }

--- a/accord-core/src/main/java/accord/coordinate/PersistSyncPoint.java
+++ b/accord-core/src/main/java/accord/coordinate/PersistSyncPoint.java
@@ -21,6 +21,7 @@ package accord.coordinate;
 import accord.api.Result;
 import accord.local.Node;
 import accord.messages.Apply;
+import accord.primitives.Ballot;
 import accord.primitives.Deps;
 import accord.primitives.FullRoute;
 import accord.primitives.Route;
@@ -33,9 +34,9 @@ import accord.utils.SortedArrays;
 
 public class PersistSyncPoint extends Persist
 {
-    public PersistSyncPoint(Node node, Topologies topologies, TxnId txnId, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, FullRoute<?> route)
+    public PersistSyncPoint(Node node, Topologies topologies, TxnId txnId, Ballot ballot, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, FullRoute<?> route)
     {
-        super(node, topologies, txnId, sendTo, txn, executeAt, deps, writes, result, route, Apply.FACTORY);
+        super(node, topologies, txnId, ballot, sendTo, txn, executeAt, deps, writes, result, route, Apply.FACTORY);
     }
 
     @Override
@@ -50,7 +51,7 @@ public class PersistSyncPoint extends Persist
         {
             for (Node.Id to : contact)
             {
-                Apply apply = factory.create(kind, to, all, txnId, sendTo, txn, executeAt, stableDeps, writes, result, route);
+                Apply apply = factory.create(kind, to, all, txnId, ballot, sendTo, txn, executeAt, stableDeps, writes, result, route);
                 if (apply == null)
                     tracker.recordSuccess(to);
                 else

--- a/accord-core/src/main/java/accord/coordinate/PersistTxn.java
+++ b/accord-core/src/main/java/accord/coordinate/PersistTxn.java
@@ -21,6 +21,7 @@ package accord.coordinate;
 import accord.api.Result;
 import accord.local.Node;
 import accord.messages.Apply;
+import accord.primitives.Ballot;
 import accord.primitives.Deps;
 import accord.primitives.FullRoute;
 import accord.primitives.Route;
@@ -32,8 +33,9 @@ import accord.topology.Topologies;
 
 public class PersistTxn extends Persist
 {
-    public PersistTxn(Node node, Topologies topologies, TxnId txnId, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, FullRoute<?> route, Apply.Factory factory)
+    // TODO (desired): standardise parameter order with CoordinationAdapter (and others)
+    public PersistTxn(Node node, Topologies topologies, TxnId txnId, Ballot ballot, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, FullRoute<?> route, Apply.Factory factory)
     {
-        super(node, topologies, txnId, sendTo, txn, executeAt, deps, writes, result, route, factory);
+        super(node, topologies, txnId, ballot, sendTo, txn, executeAt, deps, writes, result, route, factory);
     }
 }

--- a/accord-core/src/main/java/accord/coordinate/Propose.java
+++ b/accord-core/src/main/java/accord/coordinate/Propose.java
@@ -196,7 +196,7 @@ abstract class Propose<R> implements Callback<AcceptReply>
         //  Or we must pick it up as an Unstable dependency here.
         Deps newDeps = mergeNewDeps();
         Deps stableDeps = mergeDeps(newDeps);
-        if (kind == Kind.MEDIUM) adapter().execute(node, acceptTracker.topologies(), route, MEDIUM, ExecuteFlags.none(), txnId, txn, executeAt, stableDeps, newDeps, callback);
+        if (kind == Kind.MEDIUM) adapter().execute(node, acceptTracker.topologies(), route, ballot, MEDIUM, ExecuteFlags.none(), txnId, txn, executeAt, stableDeps, newDeps, callback);
         else adapter().stabilise(node, acceptTracker.topologies(), route, ballot, txnId, txn, executeAt, stableDeps, callback);
         if (!Invariants.debug()) acceptOks.clear();
     }

--- a/accord-core/src/main/java/accord/coordinate/Recover.java
+++ b/accord-core/src/main/java/accord/coordinate/Recover.java
@@ -297,7 +297,7 @@ public class Recover implements Callback<RecoverReply>, BiConsumer<Result, Throw
                     case PreApplied:
                     {
                         withStableDeps(merge, executeAt, (i, t) -> node.agent().acceptAndWrap(i, t), stableDeps -> {
-                            adapter.persist(node, tracker.topologies(), route, txnId, txn, executeAt, stableDeps, acceptOrCommitNotTruncated.writes, acceptOrCommitNotTruncated.result, (i, t) -> node.agent().acceptAndWrap(i, t));
+                            adapter.persist(node, tracker.topologies(), route, ballot, txnId, txn, executeAt, stableDeps, acceptOrCommitNotTruncated.writes, acceptOrCommitNotTruncated.result, (i, t) -> node.agent().acceptAndWrap(i, t));
                         });
                         accept(acceptOrCommitNotTruncated.result, null);
                         return;
@@ -306,7 +306,7 @@ public class Recover implements Callback<RecoverReply>, BiConsumer<Result, Throw
                     case Stable:
                     {
                         withStableDeps(merge, executeAt, this, stableDeps -> {
-                            adapter.execute(node, tracker.topologies(), route, RECOVER, ExecuteFlags.none(), txnId, txn, executeAt, stableDeps, stableDeps, this);
+                            adapter.execute(node, tracker.topologies(), route, ballot, RECOVER, ExecuteFlags.none(), txnId, txn, executeAt, stableDeps, stableDeps, this);
                         });
                         return;
                     }

--- a/accord-core/src/main/java/accord/coordinate/RecoverWithRoute.java
+++ b/accord-core/src/main/java/accord/coordinate/RecoverWithRoute.java
@@ -52,7 +52,6 @@ import static accord.primitives.Known.Outcome.Apply;
 import static accord.primitives.ProgressToken.APPLIED;
 import static accord.primitives.ProgressToken.INVALIDATED;
 import static accord.primitives.ProgressToken.TRUNCATED_DURABLE_OR_INVALIDATED;
-import static accord.primitives.Route.castToFullRoute;
 import static accord.primitives.Status.Durability.Majority;
 import static accord.topology.Topologies.SelectNodeOwnership.SLICE;
 import static accord.topology.Topologies.SelectNodeOwnership.SHARE;
@@ -60,22 +59,20 @@ import static accord.utils.Invariants.illegalState;
 
 public class RecoverWithRoute extends CheckShards<FullRoute<?>>
 {
-    final @Nullable Ballot promisedBallot; // if non-null, has already been promised by some shard
     final BiConsumer<Outcome, Throwable> callback;
     final Status witnessedByInvalidation;
     // TODO (required): we don't use this on all paths, and should at least make sure we don't trigger any Invariant failures e.g. "Fetch was successful for all keys, but the WaitingState has not been cleared"
     final long reportLowEpoch, reportHighEpoch;
 
-    private RecoverWithRoute(Node node, Topologies topologies, @Nullable Ballot promisedBallot, TxnId txnId, Infer.InvalidIf invalidIf, FullRoute<?> route, Status witnessedByInvalidation, long reportLowEpoch, long reportHighEpoch, BiConsumer<Outcome, Throwable> callback)
+    private RecoverWithRoute(Node node, Topologies topologies, TxnId txnId, Infer.InvalidIf invalidIf, FullRoute<?> route, Status witnessedByInvalidation, long reportLowEpoch, long reportHighEpoch, BiConsumer<Outcome, Throwable> callback)
     {
-        super(node, txnId, route, IncludeInfo.All, invalidIf);
+        super(node, txnId, route, IncludeInfo.All, node.uniqueTimestamp(Ballot::fromValues), invalidIf);
         this.reportLowEpoch = reportLowEpoch;
         this.reportHighEpoch = reportHighEpoch;
         // if witnessedByInvalidation == AcceptedInvalidate then we cannot assume its definition was known, and our comparison with the status is invalid
         Invariants.require(witnessedByInvalidation != Status.AcceptedInvalidate);
         // if witnessedByInvalidation == Invalidated we should anyway not be recovering
         Invariants.require(witnessedByInvalidation != Status.Invalidated);
-        this.promisedBallot = promisedBallot;
         this.callback = callback;
         this.witnessedByInvalidation = witnessedByInvalidation;
         assert topologies.oldestEpoch() == topologies.currentEpoch() && topologies.currentEpoch() == txnId.epoch();
@@ -88,30 +85,15 @@ public class RecoverWithRoute extends CheckShards<FullRoute<?>>
 
     private static RecoverWithRoute recover(Node node, Topologies topologies, TxnId txnId, Infer.InvalidIf invalidIf, FullRoute<?> route, @Nullable Status witnessedByInvalidation, long reportLowEpoch, long reportHighEpoch, BiConsumer<Outcome, Throwable> callback)
     {
-        return recover(node, topologies, null, txnId, invalidIf, route, witnessedByInvalidation, reportLowEpoch, reportHighEpoch, callback);
-    }
-
-    public static RecoverWithRoute recover(Node node, @Nullable Ballot promisedBallot, TxnId txnId, Infer.InvalidIf invalidIf, FullRoute<?> route, @Nullable Status witnessedByInvalidation, long reportLowEpoch, long reportHighEpoch, BiConsumer<Outcome, Throwable> callback)
-    {
-        return recover(node, node.topology().forEpoch(route, txnId.epoch(), SHARE), promisedBallot, txnId, invalidIf, route, witnessedByInvalidation, reportLowEpoch, reportHighEpoch, callback);
-    }
-
-    private static RecoverWithRoute recover(Node node, Topologies topologies, Ballot ballot, TxnId txnId, Infer.InvalidIf invalidIf, FullRoute<?> route, @Nullable Status witnessedByInvalidation, long reportLowEpoch, long reportHighEpoch, BiConsumer<Outcome, Throwable> callback)
-    {
-        RecoverWithRoute recover = new RecoverWithRoute(node, topologies, ballot, txnId, invalidIf, route, witnessedByInvalidation, reportLowEpoch, reportHighEpoch, callback);
+        RecoverWithRoute recover = new RecoverWithRoute(node, topologies, txnId, invalidIf, route, witnessedByInvalidation, reportLowEpoch, reportHighEpoch, callback);
         recover.start();
         return recover;
-    }
-
-    private FullRoute<?> route()
-    {
-        return castToFullRoute(this.route);
     }
 
     @Override
     public void contact(Id to)
     {
-        node.send(to, new CheckStatus(to, topologies(), txnId, route, sourceEpoch, IncludeInfo.All), this);
+        node.send(to, new CheckStatus(to, topologies(), txnId, route, sourceEpoch, IncludeInfo.All, bumpBallot), this);
     }
 
     @Override
@@ -215,14 +197,14 @@ public class RecoverWithRoute extends CheckShards<FullRoute<?>>
 
                                         LatestDeps.withStable(node.coordinationAdapter(txnId, Recovery), node, txnId, full.executeAt, full.partialTxn, stable, haveUnstable, trySendTo, SLICE, route, callback, deps -> {
                                             Deps stableDeps = deps.intersecting(trySendTo);
-                                            node.coordinationAdapter(txnId, Recovery).persist(node, null, trySendTo, trySendTo, SLICE, route, txnId, full.partialTxn, full.executeAt, stableDeps, full.writes, full.result, null);
+                                            node.coordinationAdapter(txnId, Recovery).persist(node, null, trySendTo, trySendTo, SLICE, route, bumpBallot, txnId, full.partialTxn, full.executeAt, stableDeps, full.writes, full.result, null);
                                         });
                                     }
                                     else
                                     {
                                         Invariants.require(full.stableDeps.covers(trySendTo));
                                         Invariants.require(txnId.isSystemTxn() || full.partialTxn.covers(trySendTo));
-                                        node.coordinationAdapter(txnId, Recovery).persist(node, null, trySendTo, trySendTo, SLICE, route, txnId, full.partialTxn, full.executeAt, full.stableDeps, full.writes, full.result, null);
+                                        node.coordinationAdapter(txnId, Recovery).persist(node, null, trySendTo, trySendTo, SLICE, route, bumpBallot, txnId, full.partialTxn, full.executeAt, full.stableDeps, full.writes, full.result, null);
                                     }
                                 }
                             }
@@ -270,7 +252,7 @@ public class RecoverWithRoute extends CheckShards<FullRoute<?>>
                     }
                     LatestDeps.withStable(node.coordinationAdapter(txnId, Recovery), node, txnId, full.executeAt, full.partialTxn, deps, missingDeps, route, SHARE, route, callback, mergedDeps -> {
                         node.withEpoch(full.executeAt.epoch(), node.agent(), t -> WrappableException.wrap(t), () -> {
-                            node.coordinationAdapter(txnId, Recovery).persist(node, topologies, route, txnId, txn, full.executeAt, mergedDeps, full.writes, full.result, (s, f) -> {
+                            node.coordinationAdapter(txnId, Recovery).persist(node, topologies, route, bumpBallot, txnId, txn, full.executeAt, mergedDeps, full.writes, full.result, (s, f) -> {
                                 callback.accept(f == null ? APPLIED : null, f);
                             });
                         });

--- a/accord-core/src/main/java/accord/coordinate/Stabilise.java
+++ b/accord-core/src/main/java/accord/coordinate/Stabilise.java
@@ -158,7 +158,7 @@ public abstract class Stabilise<R> implements Callback<ReadReply>
 
     protected void onStabilised()
     {
-        adapter().execute(node, allTopologies, route, ballot == Ballot.ZERO ? SLOW : RECOVER, ExecuteFlags.none(), txnId, txn, executeAt, stabiliseDeps, stabiliseDeps, callback);
+        adapter().execute(node, allTopologies, route, ballot, ballot == Ballot.ZERO ? SLOW : RECOVER, ExecuteFlags.none(), txnId, txn, executeAt, stabiliseDeps, stabiliseDeps, callback);
     }
 
     protected abstract CoordinationAdapter<R> adapter();

--- a/accord-core/src/main/java/accord/impl/InMemoryCommandStore.java
+++ b/accord-core/src/main/java/accord/impl/InMemoryCommandStore.java
@@ -809,7 +809,7 @@ public abstract class InMemoryCommandStore extends CommandStore
                     {
                         SafeCommandsForKey safeCfk = commandsForKey.get(key);
                         CommandsForKey cfk = safeCfk.current();
-                        int i = cfk.indexOf(cfk.bootstrappedAt());
+                        int i = cfk.indexOf(cfk.bounds().bootstrappedAt);
                         if (i < 0) i = -1 - i;
                         while (--i >= 0)
                         {

--- a/accord-core/src/main/java/accord/impl/progresslog/WaitingState.java
+++ b/accord-core/src/main/java/accord/impl/progresslog/WaitingState.java
@@ -64,7 +64,6 @@ import static accord.impl.progresslog.WaitingState.CallbackKind.AwaitHome;
 import static accord.impl.progresslog.WaitingState.CallbackKind.AwaitSlice;
 import static accord.impl.progresslog.WaitingState.CallbackKind.Fetch;
 import static accord.impl.progresslog.WaitingState.CallbackKind.FetchRoute;
-import static accord.primitives.Txn.Kind.ExclusiveSyncPoint;
 import static accord.topology.Topologies.SelectNodeOwnership.SHARE;
 
 /**
@@ -250,24 +249,7 @@ abstract class WaitingState extends BaseTxnState
 
     static long computeLowEpoch(SafeCommandStore safeStore, TxnId txnId, Command command)
     {
-        StoreParticipants participants = command.participants();
-        long txnIdEpoch = txnId.epoch();
-        if (txnId.is(ExclusiveSyncPoint))
-        {
-            long newEpoch = safeStore.ranges().latestEarlierEpochThatFullyCovers(txnIdEpoch, participants.hasTouched());
-            return Math.min(newEpoch, txnIdEpoch);
-        }
-
-        if (command.known().deps().hasPreAcceptedOrProposedOrDecidedDeps() && participants.touchesOnlyOwned())
-            return txnIdEpoch;
-
-        // note: we use hasTouched rather than route here, to account for cases route is null and we have already "touched" some key in an earlier epoch
-        Participants<?> unsynced = safeStore.node().topology().unsyncedOnly(participants.hasTouched(), txnIdEpoch);
-        if (unsynced == null || unsynced.isEmpty())
-            return txnIdEpoch;
-
-        long lowEpoch = safeStore.ranges().latestEarlierEpochThatFullyCovers(txnIdEpoch, unsynced);
-        return Math.min(lowEpoch, txnIdEpoch);
+        return StoreParticipants.computeFetchLowEpoch(safeStore, txnId, command);
     }
 
     long readLowEpoch(SafeCommandStore safeStore, TxnId txnId, Route<?> route)

--- a/accord-core/src/main/java/accord/local/Cleanup.java
+++ b/accord-core/src/main/java/accord/local/Cleanup.java
@@ -265,6 +265,7 @@ public enum Cleanup
         if (redundantStatus.any(LOCALLY_APPLIED))
             return invalidate(txnId);
 
+        // TODO (desired): safe to use MAJORITY_APPLIED, LOCALLY_REDUNDANT?
         if (redundantStatus.all(SHARD_APPLIED, LOCALLY_REDUNDANT))
             return vestigial(txnId);
 

--- a/accord-core/src/main/java/accord/local/Command.java
+++ b/accord-core/src/main/java/accord/local/Command.java
@@ -1505,9 +1505,9 @@ public abstract class Command implements ICommand
         return committed(command, SaveStatus.ReadyToExecute);
     }
 
-    static Command.Executed preapplied(Command command, @Nonnull StoreParticipants participants, Timestamp executeAt, PartialTxn partialTxn, PartialDeps partialDeps, Command.WaitingOn waitingOn, Writes writes, Result result)
+    static Command.Executed preapplied(Command command, @Nonnull StoreParticipants participants, Ballot promised, Timestamp executeAt, PartialTxn partialTxn, PartialDeps partialDeps, Command.WaitingOn waitingOn, Writes writes, Result result)
     {
-        return executed(command.txnId(), SaveStatus.get(Status.PreApplied, command.known()), command.durability(), participants, command.promised(), executeAt, partialTxn, partialDeps, command.acceptedOrCommitted(), waitingOn, writes, result);
+        return executed(command.txnId(), SaveStatus.get(Status.PreApplied, command.known()), command.durability(), participants, promised, executeAt, partialTxn, partialDeps, command.acceptedOrCommitted(), waitingOn, writes, result);
     }
 
     static Command.Executed applying(Command.Executed command)

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -172,6 +172,7 @@ public abstract class CommandStores
     {
         final long[] epochs;
         final Ranges[] ranges;
+        public static final RangesForEpoch EMPTY = new RangesForEpoch(new long[0], new Ranges[0]);
 
         public RangesForEpoch(long epoch, Ranges ranges)
         {

--- a/accord-core/src/main/java/accord/local/Commands.java
+++ b/accord-core/src/main/java/accord/local/Commands.java
@@ -63,7 +63,6 @@ import static accord.api.ProgressLog.BlockedUntil.HasDecidedExecuteAt;
 import static accord.api.ProtocolModifiers.Toggles.DependencyElision.IF_DURABLE;
 import static accord.api.ProtocolModifiers.Toggles.dependencyElision;
 import static accord.api.ProtocolModifiers.Toggles.markStaleIfCannotExecute;
-import static accord.local.Cleanup.EXPUNGE;
 import static accord.local.Cleanup.Input.FULL;
 import static accord.local.Cleanup.NO;
 import static accord.local.Cleanup.shouldCleanup;
@@ -465,9 +464,23 @@ public class Commands
         safeStore.notifyListeners(safeCommand, command);
     }
 
-    public enum ApplyOutcome { Success, Redundant, Insufficient }
+    public enum ApplyOutcome
+    {
+        Success,
 
-    public static ApplyOutcome apply(SafeCommandStore safeStore, SafeCommand safeCommand, StoreParticipants participants, TxnId txnId, Route<?> route, Timestamp executeAt, @Nullable Deps deps, @Nullable Txn txn, Writes writes, Result result)
+        Redundant,
+        Insufficient,
+
+        /**
+         * The apply was successful, but a recovery coordinator with a newer ballot had begun beforehand, so we cannot
+         * safely count this towards durability for pruning transitive CommandsForKey, else this in-flight recovery
+         * may reach an incorrect recovery decision by witnessing a superseding transaction without this transaction
+         * as a dependency
+         */
+        RaceWithRecovery,
+    }
+
+    public static ApplyOutcome apply(SafeCommandStore safeStore, SafeCommand safeCommand, StoreParticipants participants, Ballot ballot, TxnId txnId, Route<?> route, Timestamp executeAt, @Nullable Deps deps, @Nullable Txn txn, Writes writes, Result result)
     {
         Command command = safeCommand.current();
         if (command.hasBeen(PreApplied))
@@ -509,7 +522,10 @@ public class Commands
         WaitingOn waitingOn = !command.hasBeen(Stable) ? initialiseWaitingOn(safeStore, txnId,  executeAt, participants, partialDeps)
                                                        : command.asCommitted().waitingOn();
 
-        safeCommand.preapplied(safeStore, participants, executeAt, partialTxn, partialDeps, waitingOn, writes, result);
+        Ballot promised = command.promised();
+        if (promised.compareTo(ballot) <= 0)
+            promised = ballot;
+        safeCommand.preapplied(safeStore, participants, promised, executeAt, partialTxn, partialDeps, waitingOn, writes, result);
         if (logger.isTraceEnabled())
             logger.trace("{}: apply, status set to Executed with executeAt: {}, deps: {}", txnId, executeAt, partialDeps);
 
@@ -517,7 +533,7 @@ public class Commands
         maybeExecute(safeStore, safeCommand, true, true);
         safeStore.agent().eventListener().onExecuted(command);
 
-        return ApplyOutcome.Success;
+        return promised == ballot ? ApplyOutcome.Success : ApplyOutcome.RaceWithRecovery;
     }
 
     public static void listenerUpdate(SafeCommandStore safeStore, SafeCommand safeListener, SafeCommand safeUpdated)

--- a/accord-core/src/main/java/accord/local/Node.java
+++ b/accord-core/src/main/java/accord/local/Node.java
@@ -90,6 +90,7 @@ import accord.utils.SortedList;
 import accord.utils.SortedListMap;
 import accord.utils.WrappableException;
 import accord.utils.async.AsyncChain;
+import accord.utils.async.AsyncChains;
 import accord.utils.async.AsyncExecutor;
 import accord.utils.async.AsyncResult;
 import accord.utils.async.AsyncResults;
@@ -398,10 +399,8 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
         if (epoch < topology.minEpoch())
         {
             callback.accept(null, new TopologyManager.TopologyRetiredException(epoch, topology.minEpoch()));
-            return;
         }
-
-        if (topology.hasAtLeastEpoch(epoch))
+        else if (topology.hasAtLeastEpoch(epoch))
         {
             callback.accept(null, null);
         }
@@ -415,8 +414,10 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
     public void withEpoch(long epoch, BiConsumer<?, ? super Throwable> ifFailure, Runnable ifSuccess)
     {
         if (epoch < topology.minEpoch())
-            throw new TopologyManager.TopologyRetiredException(epoch, topology.minEpoch());
-        if (topology.hasAtLeastEpoch(epoch))
+        {
+            ifFailure.accept(null, new TopologyManager.TopologyRetiredException(epoch, topology.minEpoch()));
+        }
+        else if (topology.hasAtLeastEpoch(epoch))
         {
             ifSuccess.run();
         }
@@ -433,8 +434,10 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
     public void withEpoch(long epoch, BiConsumer<?, Throwable> ifFailure, Function<Throwable, Throwable> onFailure, Runnable ifSuccess)
     {
         if (epoch < topology.minEpoch())
-            throw new TopologyManager.TopologyRetiredException(epoch, topology.minEpoch());
-        if (topology.hasEpoch(epoch))
+        {
+            ifFailure.accept(null, onFailure.apply(new TopologyManager.TopologyRetiredException(epoch, topology.minEpoch())));
+        }
+        else if (topology.hasEpoch(epoch))
         {
             ifSuccess.run();
         }
@@ -452,8 +455,10 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
     public <T> AsyncChain<T> withEpoch(long epoch, Supplier<? extends AsyncChain<T>> supplier)
     {
         if (epoch < topology.minEpoch())
-            throw new TopologyManager.TopologyRetiredException(epoch, topology.minEpoch());
-        if (topology.hasEpoch(epoch))
+        {
+            return AsyncChains.failure(new TopologyManager.TopologyRetiredException(epoch, topology.minEpoch()));
+        }
+        else if (topology.hasEpoch(epoch))
         {
             return supplier.get();
         }

--- a/accord-core/src/main/java/accord/local/RedundantBefore.java
+++ b/accord-core/src/main/java/accord/local/RedundantBefore.java
@@ -28,7 +28,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -77,6 +76,7 @@ import static accord.local.RedundantStatus.any;
 import static accord.local.RedundantStatus.mask;
 import static accord.local.RedundantStatus.matchesMask;
 import static accord.local.RedundantStatus.toAll;
+import static accord.primitives.Routables.Slice.Minimal;
 import static accord.primitives.Timestamp.Flag.SHARD_BOUND;
 import static accord.primitives.Txn.Kind.ExclusiveSyncPoint;
 import static accord.utils.ArrayBuffers.cachedAny;
@@ -504,24 +504,14 @@ public class RedundantBefore extends ReducingRangeMap<RedundantBefore.Bounds>
             return TxnId.nonNullOrMax(max, get.apply(bounds));
         }
 
-        static Participants<?> participantsWithoutStaleOrPreBootstrap(Bounds bounds, @Nonnull Participants<?> execute, TxnId txnId, @Nullable EpochSupplier executeAt)
-        {
-            return withoutStaleOrPreBootstrap(bounds, execute, txnId, executeAt, Participants::without);
-        }
-
-        static Ranges rangesWithoutStaleOrPreBootstrap(Bounds bounds, @Nonnull Ranges execute, TxnId txnId, @Nullable EpochSupplier executeAt)
-        {
-            return withoutStaleOrPreBootstrap(bounds, execute, txnId, executeAt, Ranges::without);
-        }
-
-        static <P extends Participants<?>> P withoutStaleOrPreBootstrap(Bounds bounds, @Nonnull P execute, TxnId txnId, @Nullable EpochSupplier executeAt, BiFunction<P, Ranges, P> without)
+        static Participants<?> withoutStaleOrPreBootstrap(Bounds bounds, @Nonnull Participants<?> execute, TxnId txnId, @Nullable EpochSupplier executeAt)
         {
             if (bounds == null)
                 return execute;
 
             Invariants.require(txnId.isSyncPoint() || (executeAt == null ? !bounds.outOfBounds(txnId) : !bounds.outOfBounds(txnId, executeAt)));
             if (bounds.is(txnId, PRE_BOOTSTRAP_OR_STALE))
-                return without.apply(execute, Ranges.of(bounds.range));
+                return execute.without(Ranges.of(bounds.range));
 
             return execute;
         }
@@ -590,15 +580,15 @@ public class RedundantBefore extends ReducingRangeMap<RedundantBefore.Bounds>
             return notShardApplied;
         }
 
-        static Participants<?> withoutShardAppliedLocallySynced(Bounds bounds, @Nonnull Participants<?> notShardAppliedLocallyDefunct, TxnId txnId)
+        static Participants<?> withoutShardAppliedLocallySynced(Bounds bounds, @Nonnull Participants<?> notShardAppliedLocallySynced, TxnId txnId)
         {
             if (bounds == null)
-                return notShardAppliedLocallyDefunct;
+                return notShardAppliedLocallySynced;
 
-            if (bounds.is(txnId, SHARD_APPLIED, LOCALLY_SYNCED))
-                return notShardAppliedLocallyDefunct.without(Ranges.of(bounds.range));
+            if (bounds.isRetired() || bounds.is(txnId, SHARD_APPLIED, LOCALLY_SYNCED))
+                return notShardAppliedLocallySynced.without(Ranges.of(bounds.range));
 
-            return notShardAppliedLocallyDefunct;
+            return notShardAppliedLocallySynced;
         }
 
         static Ranges withoutBeforeGc(Bounds entry, @Nonnull Ranges notGarbage, TxnId txnId, @Nullable Timestamp executeAt)
@@ -1049,13 +1039,13 @@ public class RedundantBefore extends ReducingRangeMap<RedundantBefore.Bounds>
         if (!mayFilterStaleOrPreBootstrap(txnId, participants))
             return participants;
 
-        return foldl(participants, Bounds::participantsWithoutStaleOrPreBootstrap, participants, txnId, executeAt);
+        return foldl(participants, Bounds::withoutStaleOrPreBootstrap, participants, txnId, executeAt);
     }
 
     /**
-     * Subtract anything we won't execute locally, i.e. are pre-bootstrap or stale (or for RX are on ranges that are already retired)
+     * Subtract anything we won't execute locally, i.e. are pre-bootstrap or stale or retired
      */
-    public Participants<?> expectToWaitOn(TxnId txnId, @Nullable Timestamp executeAt, Participants<?> participants)
+    public Participants<?> expectExclusiveSyncPointToWaitOn(TxnId txnId, @Nullable Timestamp executeAt, Participants<?> participants)
     {
         Invariants.require(txnId.is(ExclusiveSyncPoint));
         if (!mayFilterStaleOrPreBootstrapOrRetiredOrNotOwned(txnId, executeAt, participants))
@@ -1178,9 +1168,15 @@ public class RedundantBefore extends ReducingRangeMap<RedundantBefore.Bounds>
          */
         class RangeState
         {
+            final Unseekables<?> participants;
             Range range;
             int bootstrapIdx, appliedIdx;
             Map<Integer, Ranges> partiallyBootstrapping;
+
+            RangeState(Unseekables<?> participants)
+            {
+                this.participants = participants;
+            }
 
             /**
              * Are the participating ranges for the txn fully covered by bootstrapping ranges for this command store
@@ -1195,10 +1191,11 @@ public class RedundantBefore extends ReducingRangeMap<RedundantBefore.Bounds>
                     partiallyBootstrapping = new HashMap<>();
                 Ranges prev = partiallyBootstrapping.get(rangeTxnIdx);
                 Ranges remaining = prev;
-                if (remaining == null) remaining = builder.directRangeDeps.ranges(rangeTxnIdx);
+                if (remaining == null) remaining = builder.directRangeDeps.ranges(rangeTxnIdx).intersecting(participants, Minimal);
                 else Invariants.require(!remaining.isEmpty());
                 remaining = remaining.without(Ranges.of(range));
-                if (prev == null) Invariants.require(!remaining.isEmpty());
+                if (prev == null && remaining.isEmpty())
+                    return true;
                 partiallyBootstrapping.put(rangeTxnIdx, remaining);
                 return remaining.isEmpty();
             }
@@ -1245,7 +1242,7 @@ public class RedundantBefore extends ReducingRangeMap<RedundantBefore.Bounds>
                 });
             }
             return s;
-        }, new RangeState(), rangeDeps, builder);
+        }, new RangeState(participants), rangeDeps, builder);
     }
 
     public final boolean hasLocallyRedundantDependencies(TxnId minimumDependencyId, Timestamp executeAt, Participants<?> participantsOfWaitingTxn)

--- a/accord-core/src/main/java/accord/local/SafeCommand.java
+++ b/accord-core/src/main/java/accord/local/SafeCommand.java
@@ -153,9 +153,9 @@ public abstract class SafeCommand
         return update(safeStore, Command.readyToExecute(current().asCommitted()));
     }
 
-    public Command.Executed preapplied(SafeCommandStore safeStore, @Nonnull StoreParticipants participants, Timestamp executeAt, PartialTxn partialTxn, PartialDeps partialDeps, Command.WaitingOn waitingOn, Writes writes, Result result)
+    public Command.Executed preapplied(SafeCommandStore safeStore, @Nonnull StoreParticipants participants, Ballot promised, Timestamp executeAt, PartialTxn partialTxn, PartialDeps partialDeps, Command.WaitingOn waitingOn, Writes writes, Result result)
     {
-        return update(safeStore, Command.preapplied(current(), participants, executeAt, partialTxn, partialDeps, waitingOn, writes, result));
+        return update(safeStore, Command.preapplied(current(), participants, promised, executeAt, partialTxn, partialDeps, waitingOn, writes, result));
     }
 
     public Command.Executed applying(SafeCommandStore safeStore)

--- a/accord-core/src/main/java/accord/local/StoreParticipants.java
+++ b/accord-core/src/main/java/accord/local/StoreParticipants.java
@@ -73,29 +73,40 @@ public class StoreParticipants
             }
         }
 
-        @Nullable public final Participants<?> executes()
+        @Override
+        public final @Nullable Participants<?> executes()
         {
             return executes;
         }
 
-        @Nullable public final Participants<?> waitsOn()
+        @Override
+        public final @Nullable Participants<?> waitsOn()
         {
             return waitsOn;
         }
 
+        @Override
         public final Participants<?> touches()
         {
             return touches;
         }
 
+        @Override
         public final Participants<?> hasTouched()
         {
             return hasTouched;
         }
 
+        @Override
         public final boolean touchesOnlyOwned()
         {
             return touches.equals(owns());
+        }
+
+        @Override
+        public final boolean hasTouchedOnlyOwned()
+        {
+            return hasTouched.equals(owns());
         }
     }
 
@@ -136,22 +147,24 @@ public class StoreParticipants
         }
 
         @Override
-        public Participants<?> stillExecutes()
+        public @Nullable Participants<?> stillExecutes()
         {
             return stillExecutes;
         }
 
         @Override
-        public Participants<?> stillWaitsOn()
+        public @Nullable Participants<?> stillWaitsOn()
         {
             return stillWaitsOn;
         }
 
+        @Override
         StoreParticipants update(Route<?> route, Participants<?> hasTouched)
         {
             return new FilteredStoreParticipants(route, owns(), executes(), waitsOn(), touches(), hasTouched, stillOwns, stillExecutes, stillWaitsOn, stillTouches);
         }
 
+        @Override
         StoreParticipants update(Route<?> route, Participants<?> owns, Participants<?> executes, Participants<?> waitsOn, Participants<?> touches, Participants<?> hasTouched)
         {
             return new FilteredStoreParticipants(route, owns, executes, waitsOn, touches, hasTouched, stillOwns, stillExecutes, stillWaitsOn, stillTouches);
@@ -244,6 +257,11 @@ public class StoreParticipants
         return true;
     }
 
+    public boolean hasTouchedOnlyOwned()
+    {
+        return true;
+    }
+
     /**
      * touches, but excluding any stale, pre-bootstrap or retired ranges that are also shard redundant,
      * as we do not need to do anything with these keys locally.
@@ -263,7 +281,6 @@ public class StoreParticipants
 
     /**
      * If set, the keys we are known to execute
-     * @return
      */
     public @Nullable Participants<?> executes()
     {
@@ -278,7 +295,6 @@ public class StoreParticipants
 
     /**
      * If set, the keys we are known to still execute (i.e. excluding any that are pre-bootstrap or stale)
-     * @return
      */
     public @Nullable Participants<?> stillExecutes()
     {
@@ -286,8 +302,12 @@ public class StoreParticipants
     }
 
     /**
-     * If set, the keys we are known to locally waitOn for execution
-     * @return
+     * If set, the keys we are known to locally waitOn for execution.
+     * The distinction is only pertinent for ExclusiveSyncPoints, where we want to distinguish the ranges
+     * we own and execute for bootstrap purposes from those we execute after the completion of.
+     * That is, an ExclusiveSyncPoint waits for all prior epochs for execution, so that we can impose a
+     * global cluster happens-before relationship across all nodes and epochs; however, we can only safely
+     * provide the data for the normal execution ranges if using the sync point to fetch ranges.
      */
     public @Nullable Participants<?> waitsOn()
     {
@@ -296,16 +316,10 @@ public class StoreParticipants
 
     /**
      * If set, the keys we are known to still locally waitOn (i.e. excluding any that are pre-bootstrap or stale)
-     * @return
      */
     public @Nullable Participants<?> stillWaitsOn()
     {
         return waitsOn();
-    }
-
-    public Participants<?> stillOwnsOrWaitsOn(TxnId txnId)
-    {
-        return txnId.is(ExclusiveSyncPoint) ? stillTouches() : stillOwns();
     }
 
     /**
@@ -340,7 +354,7 @@ public class StoreParticipants
             if (txnId.is(ExclusiveSyncPoint))
             {
                 curStillWaitsOn = stillWaitsOn();
-                stillWaitsOn = redundantBefore.expectToWaitOn(txnId, executeAtIfKnown, curStillWaitsOn);
+                stillWaitsOn = redundantBefore.expectExclusiveSyncPointToWaitOn(txnId, executeAtIfKnown, curStillWaitsOn);
             }
             else
             {
@@ -497,7 +511,7 @@ public class StoreParticipants
     }
 
     // TODO (required): synchronise with latest standard logic
-    public static Route<?> touches(SafeCommandStore safeStore, long fromEpoch, TxnId txnId,long toEpoch, Route<?> route)
+    public static Route<?> touches(SafeCommandStore safeStore, long fromEpoch, TxnId txnId, long toEpoch, Route<?> route)
     {
         // TODO (required): remove pre-bootstrap?
         if (txnId.is(ExclusiveSyncPoint))
@@ -639,4 +653,42 @@ public class StoreParticipants
         return new StoreParticipants(route, route, false);
     }
 
+    public static long computeFetchLowEpoch(SafeCommandStore safeStore, TxnId txnId, Command command)
+    {
+        StoreParticipants participants = command.participants();
+        // note: we use hasTouched rather than route here, to account for cases route is null and we have already "touched" some key in an earlier epoch
+        return computeFetchLowEpoch(safeStore, txnId, participants.hasTouched(), participants.owns());
+    }
+
+    private static long computeFetchLowEpoch(SafeCommandStore safeStore, TxnId txnId, Participants<?> touches, Participants<?> owns)
+    {
+        long txnIdEpoch = txnId.epoch();
+        if (txnId.is(ExclusiveSyncPoint))
+            return computeCoveringEpoch(safeStore, txnIdEpoch, touches);
+
+        if (touches.equals(owns))
+            return txnIdEpoch;
+
+        return computeUnsyncedEpoch(safeStore, txnIdEpoch, touches);
+    }
+
+    public static long computePropagateLowEpoch(SafeCommandStore safeStore, TxnId txnId, Route<?> newRoute)
+    {
+        return computeUnsyncedEpoch(safeStore, txnId.epoch(), newRoute);
+    }
+
+    private static long computeUnsyncedEpoch(SafeCommandStore safeStore, long txnIdEpoch, Participants<?> participants)
+    {
+        Participants<?> unsynced = safeStore.node().topology().unsyncedOnly(participants, txnIdEpoch);
+        if (unsynced == null || unsynced.isEmpty())
+            return txnIdEpoch;
+
+        return computeCoveringEpoch(safeStore, txnIdEpoch, unsynced);
+    }
+
+    private static long computeCoveringEpoch(SafeCommandStore safeStore, long txnIdEpoch, Participants<?> participants)
+    {
+        long lowEpoch = safeStore.ranges().latestEarlierEpochThatFullyCovers(txnIdEpoch, participants);
+        return Math.min(lowEpoch, txnIdEpoch);
+    }
 }

--- a/accord-core/src/main/java/accord/local/cfk/CommandsForKey.java
+++ b/accord-core/src/main/java/accord/local/cfk/CommandsForKey.java
@@ -1465,27 +1465,26 @@ public class CommandsForKey extends CommandsForKeyUpdate
             visitor.visit(p1, p2, txn.summaryStatus(), key, txn.plainTxnId());
         }
 
-        if (startedBefore.compareTo(prunedBefore) <= 0)
+        if (end <= prunedBeforeById)
         {
             // In the event we have pruned transactions that may execute before us, we take the earliest future dependency we can in their place.
             // This may occur for any transaction that isn't witnessed by a Write (so, sync points and exclusive sync points).
             // In the former case, this can only happen on recovery, as the original coordinator would propose a later executeAt than any dependency it may witness.
-            int i = SortedArrays.binarySearch(committedByExecuteAt, 0, maxAppliedWriteByExecuteAt, startedBefore, (f, v) -> f.compareTo(v.executeAt), FAST);
-            if (i < 0) i = -1 - i;
-            while (i < committedByExecuteAt.length)
-            {
-                TxnInfo txn = committedByExecuteAt[i];
-                if (txn.epoch() > startedBefore.epoch())
-                    break;
 
-                if (txn.is(Write))
-                {
-                    visitor.visit(p1, p2, txn.summaryStatus(), key, committedByExecuteAt[i].plainTxnId());
-                    if (txn.compareTo(startedBefore) > 0)
-                        break;
-                }
-                ++i;
+            // Note: we do not use committedByExecuteAt because it might exclude transactions that are locally pre-bootstrap, which might lead to an invalid future transaction being included
+            TxnInfo best = byId[prunedBeforeById];
+            for (int i = end; i < prunedBeforeById ; ++i)
+            {
+                TxnInfo txn = byId[i];
+                if (!txn.is(Write) || !txn.isCommittedToExecute()) continue;
+                if (txn.executeAt.compareTo(best.executeAt) < 0)
+                    best = txn;
+
+                if (txn.executeAt == txn || txn.epoch() > startedBefore.epoch())
+                    break;
             }
+            if (best.executeAt.epoch() <= startedBefore.epoch() && !best.equals(startedBefore))
+                visitor.visit(p1, p2, best.summaryStatus(), key, best.plainTxnId());
         }
     }
 

--- a/accord-core/src/main/java/accord/messages/Apply.java
+++ b/accord-core/src/main/java/accord/messages/Apply.java
@@ -29,6 +29,7 @@ import accord.local.SafeCommand;
 import accord.local.SafeCommandStore;
 import accord.local.StoreParticipants;
 import accord.messages.Apply.ApplyReply;
+import accord.primitives.Ballot;
 import accord.primitives.Deps;
 import accord.primitives.FullRoute;
 import accord.primitives.PartialDeps;
@@ -52,18 +53,19 @@ public class Apply extends TxnRequest<ApplyReply>
     public static final Factory FACTORY = Apply::new;
     public static class SerializationSupport
     {
-        public static Apply create(TxnId txnId, Route<?> scope, long minEpoch, long waitForEpoch, long maxEpoch, Kind kind, Timestamp executeAt, PartialDeps deps, PartialTxn txn, @Nullable FullRoute<?> fullRoute, Writes writes, Result result)
+        public static Apply create(TxnId txnId, Ballot ballot, Route<?> scope, long minEpoch, long waitForEpoch, long maxEpoch, Kind kind, Timestamp executeAt, PartialDeps deps, PartialTxn txn, @Nullable FullRoute<?> fullRoute, Writes writes, Result result)
         {
-            return new Apply(kind, txnId, scope, minEpoch, waitForEpoch, maxEpoch, executeAt, deps, txn, fullRoute, writes, result);
+            return new Apply(kind, txnId, ballot, scope, minEpoch, waitForEpoch, maxEpoch, executeAt, deps, txn, fullRoute, writes, result);
         }
     }
 
     public interface Factory
     {
-        Apply create(Kind kind, Id to, Topologies participates, TxnId txnId, Route<?> scope, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, FullRoute<?> fullRoute);
+        Apply create(Kind kind, Id to, Topologies participates, TxnId txnId, Ballot ballot, Route<?> scope, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, FullRoute<?> fullRoute);
     }
 
     public final Kind kind;
+    public final Ballot ballot;
     public final Timestamp executeAt;
     public final PartialDeps deps; // TODO (expected): this should be nullable, and only included if we did not send Commit (or if sending Maximal apply)
     public final @Nullable PartialTxn txn;
@@ -75,10 +77,11 @@ public class Apply extends TxnRequest<ApplyReply>
 
     public enum Kind { Minimal, Maximal }
 
-    protected Apply(Kind kind, Id to, Topologies participates, TxnId txnId, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, FullRoute<?> fullRoute)
+    protected Apply(Kind kind, Id to, Topologies participates, TxnId txnId, Ballot ballot, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, FullRoute<?> fullRoute)
     {
         super(to, participates, sendTo, txnId);
         Invariants.require(txnId.kind() != Txn.Kind.Write || writes != null);
+        this.ballot = ballot;
         this.kind = kind;
         this.deps = deps.intersecting(scope);
         this.txn = kind == Kind.Maximal ? txn.intersecting(scope, true) : null;
@@ -100,10 +103,11 @@ public class Apply extends TxnRequest<ApplyReply>
         return node.topology().preciseEpochs(route, txnId.epoch(), executeAt.epoch(), SHARE);
     }
 
-    protected Apply(Kind kind, TxnId txnId, Route<?> route, long minEpoch, long waitForEpoch, long maxEpoch, Timestamp executeAt, PartialDeps deps, @Nullable PartialTxn txn, @Nullable FullRoute<?> fullRoute, Writes writes, Result result)
+    protected Apply(Kind kind, TxnId txnId, Ballot ballot, Route<?> route, long minEpoch, long waitForEpoch, long maxEpoch, Timestamp executeAt, PartialDeps deps, @Nullable PartialTxn txn, @Nullable FullRoute<?> fullRoute, Writes writes, Result result)
     {
         super(txnId, route, waitForEpoch);
         this.kind = kind;
+        this.ballot = ballot;
         this.executeAt = executeAt;
         this.deps = deps;
         this.txn = txn;
@@ -130,26 +134,24 @@ public class Apply extends TxnRequest<ApplyReply>
 
     public ApplyReply apply(SafeCommandStore safeStore, StoreParticipants participants)
     {
-        return apply(safeStore, participants, txn, txnId, executeAt, deps, participants.route(), writes, result);
+        return apply(safeStore, participants, ballot, txn, txnId, executeAt, deps, participants.route(), writes, result);
     }
 
-    public static ApplyReply apply(SafeCommandStore safeStore, StoreParticipants participants, PartialTxn txn, TxnId txnId, Timestamp executeAt, PartialDeps deps, Route<?> route, Writes writes, Result result)
+    public static ApplyReply apply(SafeCommandStore safeStore, StoreParticipants participants, Ballot ballot, PartialTxn txn, TxnId txnId, Timestamp executeAt, PartialDeps deps, Route<?> route, Writes writes, Result result)
     {
         SafeCommand safeCommand = safeStore.get(txnId, participants);
-        return apply(safeStore, safeCommand, participants, txn, txnId, executeAt, deps, route, writes, result);
+        return apply(safeStore, safeCommand, participants, ballot, txn, txnId, executeAt, deps, route, writes, result);
     }
 
-    public static ApplyReply apply(SafeCommandStore safeStore, SafeCommand safeCommand, StoreParticipants participants, PartialTxn txn, TxnId txnId, Timestamp executeAt, PartialDeps deps, Route<?> route, Writes writes, Result result)
+    public static ApplyReply apply(SafeCommandStore safeStore, SafeCommand safeCommand, StoreParticipants participants, Ballot ballot, PartialTxn txn, TxnId txnId, Timestamp executeAt, PartialDeps deps, Route<?> route, Writes writes, Result result)
     {
-        switch (Commands.apply(safeStore, safeCommand, participants, txnId, route, executeAt, deps, txn, writes, result))
+        switch (Commands.apply(safeStore, safeCommand, participants, ballot, txnId, route, executeAt, deps, txn, writes, result))
         {
             default:
-            case Insufficient:
-                return ApplyReply.Insufficient;
-            case Redundant:
-                return ApplyReply.Redundant;
-            case Success:
-                return ApplyReply.Applied;
+            case Success: return ApplyReply.Applied;
+            case Redundant: return ApplyReply.Redundant;
+            case Insufficient: return ApplyReply.Insufficient;
+            case RaceWithRecovery: return ApplyReply.RaceWithRecovery;
         }
     }
 
@@ -174,7 +176,7 @@ public class Apply extends TxnRequest<ApplyReply>
 
     public enum ApplyReply implements Reply
     {
-        Applied, Redundant, Insufficient;
+        Applied, Redundant, Insufficient, RaceWithRecovery;
 
         @Override
         public MessageType type()

--- a/accord-core/src/main/java/accord/messages/ApplyThenWaitUntilApplied.java
+++ b/accord-core/src/main/java/accord/messages/ApplyThenWaitUntilApplied.java
@@ -26,6 +26,7 @@ import accord.local.Node;
 import accord.local.SafeCommandStore;
 import accord.local.StoreParticipants;
 import accord.messages.Apply.ApplyReply;
+import accord.primitives.Ballot;
 import accord.primitives.Deps;
 import accord.primitives.FullRoute;
 import accord.primitives.PartialDeps;
@@ -101,7 +102,7 @@ public class ApplyThenWaitUntilApplied extends WaitUntilApplied
     public CommitOrReadNack apply(SafeCommandStore safeStore)
     {
         StoreParticipants participants = StoreParticipants.execute(safeStore, route, txnId.epoch(), txnId, executeAtEpoch);
-        ApplyReply applyReply = Apply.apply(safeStore, participants, txn, txnId, executeAt, deps, route, writes, result);
+        ApplyReply applyReply = Apply.apply(safeStore, participants, Ballot.ZERO, txn, txnId, executeAt, deps, route, writes, result);
         switch (applyReply)
         {
             default:
@@ -112,6 +113,7 @@ public class ApplyThenWaitUntilApplied extends WaitUntilApplied
             case Redundant:
                 // TODO (required): redundant is not necessarily safe for awaitsOnlyDeps commands as might need a future epoch
             case Applied:
+            case RaceWithRecovery:
                 // In both cases it's fine to continue to process and return a response saying
                 // things were applied
                 break;

--- a/accord-core/src/main/java/accord/messages/CheckStatus.java
+++ b/accord-core/src/main/java/accord/messages/CheckStatus.java
@@ -113,19 +113,23 @@ public class CheckStatus extends AbstractRequest<CheckStatus.CheckStatusReply>
     public final Participants<?> query;
     public final long sourceEpoch;
     public final IncludeInfo includeInfo;
+    // if set, simply ensure the ballot on the command is equal or greater to this ballot
+    public final @Nullable Ballot bumpBallot;
 
-    public CheckStatus(TxnId txnId, Participants<?> query, long sourceEpoch, IncludeInfo includeInfo)
+    public CheckStatus(TxnId txnId, Participants<?> query, long sourceEpoch, IncludeInfo includeInfo, @Nullable Ballot bumpBallot)
     {
         super(txnId);
+        this.bumpBallot = bumpBallot;
         Invariants.require(txnId.is(query.domain()));
         this.query = query;
         this.sourceEpoch = sourceEpoch;
         this.includeInfo = includeInfo;
     }
 
-    public CheckStatus(Id to, Topologies topologies, TxnId txnId, Participants<?> query, long sourceEpoch, IncludeInfo includeInfo)
+    public CheckStatus(Id to, Topologies topologies, TxnId txnId, Participants<?> query, long sourceEpoch, IncludeInfo includeInfo, Ballot bumpBallot)
     {
         super(txnId);
+        this.bumpBallot = bumpBallot;
         if (isRoute(query)) this.query = computeScope(to, topologies, castToRoute(query), 0, Route::slice, Route::with);
         else this.query = computeScope(to, topologies, (Participants) query, 0, Participants::slice, Participants::with);
         this.sourceEpoch = sourceEpoch;
@@ -147,6 +151,8 @@ public class CheckStatus extends AbstractRequest<CheckStatus.CheckStatusReply>
         Command command = safeCommand.current();
 
         Commands.supplementParticipants(safeStore, safeCommand, participants);
+        if (bumpBallot != null && bumpBallot.compareTo(command.promised()) > 0)
+            safeCommand.updatePromised(bumpBallot);
 
         boolean isCoordinating = isCoordinating(node, command);
         Durability durability = command.durability();

--- a/accord-core/src/main/java/accord/messages/Commit.java
+++ b/accord-core/src/main/java/accord/messages/Commit.java
@@ -333,7 +333,7 @@ public class Commit extends TxnRequest.WithUnsynced<CommitOrReadNack>
         {
             // TODO (expected, safety): this kind of check needs to be inserted in all equivalent methods
             Invariants.require(untilEpoch >= txnId.epoch());
-            Invariants.require(node.topology().hasEpoch(untilEpoch));
+            Invariants.require(node.topology().hasAtLeastEpoch(untilEpoch));
             Topologies commitTo = node.topology().preciseEpochsIfExists(inform, txnId.epoch(), untilEpoch, SHARE);
             commitInvalidate(node, commitTo, txnId, inform);
         }

--- a/accord-core/src/main/java/accord/messages/Propagate.java
+++ b/accord-core/src/main/java/accord/messages/Propagate.java
@@ -70,6 +70,7 @@ import static accord.primitives.Known.Nothing;
 import static accord.primitives.SaveStatus.Stable;
 import static accord.primitives.Status.NotDefined;
 import static accord.primitives.Status.PreApplied;
+import static accord.primitives.Txn.Kind.ExclusiveSyncPoint;
 import static accord.primitives.WithQuorum.HasQuorum;
 import static accord.utils.Invariants.illegalState;
 
@@ -183,6 +184,7 @@ public class Propagate implements PreLoadContext, MapReduceConsume<SafeCommandSt
     public Void apply(SafeCommandStore safeStore)
     {
         long executeAtEpoch = committedExecuteAt == null ? txnId.epoch() : committedExecuteAt.epoch();
+        long lowEpoch = Math.min(this.lowEpoch, StoreParticipants.computePropagateLowEpoch(safeStore, txnId, route));
         StoreParticipants participants = StoreParticipants.update(safeStore, route, lowEpoch, txnId, executeAtEpoch, highEpoch, committedExecuteAt != null);
         // TODO (expected): can we come up with a better more universal pattern for avoiding updating a command we don't intersect with?
         //   ideally integrated with safeStore.get()
@@ -251,11 +253,11 @@ public class Propagate implements PreLoadContext, MapReduceConsume<SafeCommandSt
                 }
             }
 
-            Participants<?> txnNeeds = participants.stillOwnsOrWaitsOn(txnId);
+            Participants<?> needs = participants.stillOwns();
             if (found.isDefinitionKnown() && partialTxn == null && this.partialTxn != null)
             {
                 PartialTxn existing = command.partialTxn();
-                Participants<?> neededExtra = txnNeeds;
+                Participants<?> neededExtra = needs;
                 if (existing != null) neededExtra = neededExtra.without(existing.keys().toParticipants());
                 partialTxn = this.partialTxn.intersecting(neededExtra, true).reconstitutePartial(neededExtra);
             }
@@ -287,7 +289,7 @@ public class Propagate implements PreLoadContext, MapReduceConsume<SafeCommandSt
             case PreApplied:
                 Invariants.require(committedExecuteAt != null);
                 // we must use the remote executeAt, as it might have a uniqueHlc we aren't aware of at commit
-                confirm(Commands.apply(safeStore, safeCommand, participants, txnId, route, committedExecuteAt, stableDeps, partialTxn, writes, result));
+                confirm(Commands.apply(safeStore, safeCommand, participants, Ballot.ZERO, txnId, route, committedExecuteAt, stableDeps, partialTxn, writes, result));
                 break;
 
             case Stable:
@@ -375,19 +377,19 @@ public class Propagate implements PreLoadContext, MapReduceConsume<SafeCommandSt
         Known required = PreApplied.minKnown;
         Known requireExtra = required.subtract(command.known()); // the extra information we need to reach pre-applied
 
-        Participants<?> stillOwnsOrMayExecute = participants.stillOwnsOrWaitsOn(txnId);
+        Participants<?> stillOwnsOrMayExecute = txnId.is(ExclusiveSyncPoint) ? participants.stillTouches() : participants.stillOwns();
         Participants<?> notStaleTouches = known.knownFor(Nothing.with(requireExtra.deps()), stillTouches); // the ranges for which we can already successfully achieve this
-        Participants<?> notStaleOwnsOrMayExecutes = known.knownFor(requireExtra.with(DepsUnknown), stillOwnsOrMayExecute); // the ranges for which we can already successfully achieve this
+        Participants<?> notStaleOwnsOrMayExecute = known.knownFor(requireExtra.with(DepsUnknown), stillOwnsOrMayExecute); // the ranges for which we can already successfully achieve this
 
         // any ranges we execute but cannot achieve the pre-applied status for have been left behind and are stale
         Participants<?> staleTouches = stillTouches.without(notStaleTouches);
-        Participants<?> staleOwnsOrMayExecute = stillOwnsOrMayExecute.without(notStaleOwnsOrMayExecutes);
+        Participants<?> staleOwnsOrMayExecute = stillOwnsOrMayExecute.without(notStaleOwnsOrMayExecute);
         if (staleOwnsOrMayExecute.isEmpty())
         {
             if (staleTouches.isEmpty() && found.is(Outcome.Apply))
             {
                 Invariants.require(notStaleTouches.containsAll(stillTouches));
-                Invariants.require(notStaleOwnsOrMayExecutes.containsAll(stillOwnsOrMayExecute));
+                Invariants.require(notStaleOwnsOrMayExecute.containsAll(stillOwnsOrMayExecute));
                 return required;
             }
 
@@ -477,6 +479,7 @@ public class Propagate implements PreLoadContext, MapReduceConsume<SafeCommandSt
             default: throw illegalState("Unknown outcome: " + outcome);
             case Redundant:
             case Success:
+            case RaceWithRecovery:
                 return;
             case Insufficient: throw illegalState("Should have enough information");
         }

--- a/accord-core/src/main/java/accord/primitives/SaveStatus.java
+++ b/accord-core/src/main/java/accord/primitives/SaveStatus.java
@@ -275,8 +275,8 @@ public enum SaveStatus
                     case AcceptedMedium:
                     case AcceptedSlow:
                     case AcceptedInvalidate:
-                        known = known.with(DepsUnknown);
-                        // if the decision is known, we're really PreCommitted
+                        known = known.with(status.minKnown.deps());
+                        // if the decision is known, we're really PreCommitted, but we will update our dependency information
                 }
             }
             else

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -1074,10 +1074,9 @@ public class TopologyManager
 
         if (i == snapshot.epochs.length)
         {
-            // Epochs earlier than minEpoch might have been GC'd, so we can not collect
-            // matching ranges for them. However, if ranges were still present in the min epoch,
-            // we have reported them.
-            if (!select.isEmpty() && !select.without(snapshot.get(minEpoch).global.ranges).isEmpty())
+            // now we GC epochs, we cannot rely on addedRanges to remove all ranges, so we also remove the ranges found in the earliest epoch we have
+            select = (K)select.without(snapshot.epochs[snapshot.epochs.length - 1].global.ranges);
+            if (!select.isEmpty())
                 throw Invariants.illegalArgument("Ranges %s could not be found", select);
             return collectors.multi(collector);
         }
@@ -1104,11 +1103,10 @@ public class TopologyManager
         // need to remove sufficient / added else remaining may not be empty when the final matches are the last epoch
         remaining = remaining.without(isSufficientFor.apply(prev));
         remaining = remaining.without(prev.addedRanges);
-
-        // Epochs earlier than minEpoch might have been GC'd, so we can not collect
-        // matching ranges for them. However, if ranges were still present in the min epoch,
-        // we have reported them.
-        if (!remaining.isEmpty() && !select.without(snapshot.get(minEpoch).global.ranges).isEmpty())
+        // TODO (desired): propagate addedRanges to the earliest epoch we retain for consistency
+        // now we GC epochs, we cannot rely on addedRanges to remove all ranges, so we also remove the ranges found in the earliest epoch we have
+        remaining = remaining.without(snapshot.epochs[snapshot.epochs.length - 1].global.ranges);
+        if (!remaining.isEmpty())
             Invariants.illegalArgument("Ranges %s could not be found", remaining);
 
         return collectors.multi(collector);

--- a/accord-core/src/test/java/accord/impl/basic/Cluster.java
+++ b/accord-core/src/test/java/accord/impl/basic/Cluster.java
@@ -79,7 +79,6 @@ import accord.local.Cleanup;
 import accord.local.Command;
 import accord.local.CommandStore;
 import accord.local.CommandStores;
-import accord.local.DurableBefore;
 import accord.local.Node;
 import accord.local.Node.Id;
 import accord.local.RedundantBefore;
@@ -685,7 +684,7 @@ public class Cluster
                                      nodeExecutor.agent(),
                                      randomSupplier.get(), scheduler, SizeOfIntersectionSorter.SUPPLIER, DefaultRemoteListeners::new, DefaultTimeouts::new,
                                      DefaultProgressLogs::new, DefaultLocalListeners.Factory::new, DelayedCommandStores.factory(sinks.pending, cacheLoading), new CoordinationAdapter.DefaultFactory(),
-                                     DurableBefore.NOOP_PERSISTER, journal);
+                                     journal.durableBeforePersister(), journal);
                 journal.start(node);
                 DurabilityService durability = node.durability();
                 // TODO (desired): randomise

--- a/accord-core/src/test/java/accord/impl/basic/InMemoryJournal.java
+++ b/accord-core/src/test/java/accord/impl/basic/InMemoryJournal.java
@@ -297,7 +297,7 @@ public class InMemoryJournal implements Journal
     @Override
     public PersistentField.Persister<DurableBefore, DurableBefore> durableBeforePersister()
     {
-        throw new UnsupportedOperationException("Not implemented");
+        return DurableBefore.NOOP_PERSISTER;
     }
 
     @Override

--- a/accord-core/src/test/java/accord/impl/list/ListRequest.java
+++ b/accord-core/src/test/java/accord/impl/list/ListRequest.java
@@ -90,7 +90,7 @@ public class ListRequest implements Request
         int count = 0;
         protected CheckOnResult(Node node, TxnId txnId, RoutingKey homeKey, BiConsumer<Outcome, Throwable> callback)
         {
-            super(node, txnId, txnId.is(Key) ? RoutingKeys.of(homeKey) : Ranges.of(homeKey.asRange()), IncludeInfo.All, NotKnownToBeInvalid);
+            super(node, txnId, txnId.is(Key) ? RoutingKeys.of(homeKey) : Ranges.of(homeKey.asRange()), IncludeInfo.All, null, NotKnownToBeInvalid);
             this.callback = callback;
         }
 

--- a/accord-core/src/test/java/accord/local/CheckedCommands.java
+++ b/accord-core/src/test/java/accord/local/CheckedCommands.java
@@ -34,6 +34,8 @@ import accord.primitives.Writes;
 
 import java.util.function.BiConsumer;
 
+import static accord.local.Commands.ApplyOutcome.RaceWithRecovery;
+import static accord.local.Commands.ApplyOutcome.Success;
 import static accord.utils.Invariants.illegalState;
 
 public class CheckedCommands
@@ -96,9 +98,9 @@ public class CheckedCommands
         StoreParticipants participants = StoreParticipants.execute(safeStore, route, txnId.epoch(), txnId, executeAt.epoch());
         SafeCommand safeCommand = safeStore.get(txnId, participants);
         Command before = safeCommand.current();
-        Commands.ApplyOutcome outcome = Commands.apply(safeStore, safeCommand, participants, txnId, route, executeAt, partialDeps, partialTxn, writes, result);
+        Commands.ApplyOutcome outcome = Commands.apply(safeStore, safeCommand, participants, Ballot.ZERO, txnId, route, executeAt, partialDeps, partialTxn, writes, result);
         Command after = safeCommand.current();
-        if (outcome != Commands.ApplyOutcome.Success) throw illegalState("Command mutation rejected: " + outcome);
+        if (outcome != Success && outcome != RaceWithRecovery) throw illegalState("Command mutation rejected: " + outcome);
         consumer.accept(before, after);
     }
 }


### PR DESCRIPTION
 - cfk pruning+prebootstrap=invalid future dependency
 - exclude retired ranges when filtering RX stillTouches
 - propagate uses incorrect lowEpoch when fetch finds additional owned/touched ranges
 - node.withEpoch should callback with TopologyRetiredException, not throw
 - Recovery can race with durable-applied pruning; must not send durable unless latest ballot on apply
 - removeRedundantDependencies was not slicing pre-bootstrap range calculation to participating ranges
 - NPE in TopologyManager.atLeast caused by referencing an epoch that has been GC'd
 - use journal durableBeforePersister in burn test, not NOOP_PERSISTER
 - Fix failing invariant check(s), and burn test initialisation (TODO: confirm MaybeRecover check doesn't break forward progress)