### PR TITLE
Fixes

### DIFF
--- a/accord-core/src/main/java/accord/coordinate/AbstractCoordinatePreAccept.java
+++ b/accord-core/src/main/java/accord/coordinate/AbstractCoordinatePreAccept.java
@@ -30,7 +30,6 @@ import accord.primitives.TxnId;
 import accord.topology.Topologies;
 import accord.utils.Invariants;
 import accord.utils.WrappableException;
-import accord.utils.async.AsyncResults.SettableResult;
 
 import static accord.api.ProtocolModifiers.QuorumEpochIntersections;
 import static accord.topology.Topologies.SelectNodeOwnership.SHARE;
@@ -39,26 +38,28 @@ import static accord.topology.Topologies.SelectNodeOwnership.SHARE;
  * Abstract parent class for implementing preaccept-like operations where we may need to fetch additional replies
  * from future epochs.
  */
-abstract class AbstractCoordinatePreAccept<T, R> extends SettableResult<T> implements Callback<R>, BiConsumer<T, Throwable>
+abstract class AbstractCoordinatePreAccept<T, R> implements Callback<R>
 {
     final Node node;
     final TxnId txnId;
     final FullRoute<?> route;
 
     final Topologies topologies;
+    final BiConsumer<T, Throwable> callback;
     private boolean isDone;
 
-    AbstractCoordinatePreAccept(Node node, FullRoute<?> route, @Nonnull TxnId txnId)
+    AbstractCoordinatePreAccept(Node node, FullRoute<?> route, @Nonnull TxnId txnId, BiConsumer<T, Throwable> callback)
     {
-        this(node, route, txnId, node.topology().select(route, txnId, txnId, SHARE, QuorumEpochIntersections.preaccept.include));
+        this(node, route, txnId, node.topology().select(route, txnId, txnId, SHARE, QuorumEpochIntersections.preaccept.include), callback);
     }
 
-    AbstractCoordinatePreAccept(Node node, FullRoute<?> route, @Nonnull TxnId txnId, Topologies topologies)
+    AbstractCoordinatePreAccept(Node node, FullRoute<?> route, @Nonnull TxnId txnId, Topologies topologies, BiConsumer<T, Throwable> callback)
     {
         this.node = node;
         this.txnId = txnId;
         this.route = route;
         this.topologies = topologies;
+        this.callback = callback;
     }
 
     void start()
@@ -86,7 +87,8 @@ abstract class AbstractCoordinatePreAccept<T, R> extends SettableResult<T> imple
     {
         if (isDone) return false;
         isDone = true;
-        return tryFailure(failure);
+        callback.accept(null, failure);
+        return true;
     }
 
     @Override
@@ -103,19 +105,12 @@ abstract class AbstractCoordinatePreAccept<T, R> extends SettableResult<T> imple
             onSlowResponseInternal(from);
     }
 
-    @Override
-    public final boolean tryFailure(Throwable failure)
+    void setFailure(Throwable failure)
     {
-        if (!super.tryFailure(failure))
-            return false;
-        onFailure(failure);
-        return true;
-    }
-
-    private void onFailure(Throwable failure)
-    {
+        Invariants.require(!isDone);
         // we may already be complete, as we may receive a failure from a later phase; but it's fine to redundantly mark done
         isDone = true;
+        callback.accept(null, failure);
         if (failure instanceof CoordinationFailed)
         {
             ((CoordinationFailed) failure).set(txnId, route.homeKey());
@@ -133,7 +128,7 @@ abstract class AbstractCoordinatePreAccept<T, R> extends SettableResult<T> imple
         Invariants.require(!isDone);
         isDone = true;
         long latestEpoch = executeAtEpoch();
-        if (latestEpoch > topologies.currentEpoch()) node.withEpoch(latestEpoch, this, () -> onPreAcceptedInNewEpoch(topologies, latestEpoch));
+        if (latestEpoch > topologies.currentEpoch()) node.withEpochExact(latestEpoch, callback, t -> WrappableException.wrap(t), () -> onPreAcceptedInNewEpoch(topologies, latestEpoch));
         else onPreAccepted(topologies);
     }
 
@@ -142,12 +137,5 @@ abstract class AbstractCoordinatePreAccept<T, R> extends SettableResult<T> imple
         TopologyMismatch mismatch = TopologyMismatch.checkForMismatch(node.topology().globalForEpoch(latestEpoch), txnId, route.homeKey(), route);
         if (mismatch == null) onPreAccepted(topologies);
         else onNewEpochTopologyMismatch(mismatch);
-    }
-
-    @Override
-    public final void accept(T success, Throwable failure)
-    {
-        if (success != null) trySuccess(success);
-        else tryFailure(WrappableException.wrap(failure));
     }
 }

--- a/accord-core/src/main/java/accord/coordinate/CoordinateEphemeralRead.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinateEphemeralRead.java
@@ -19,6 +19,7 @@
 package accord.coordinate;
 
 import java.util.Collection;
+import java.util.function.BiConsumer;
 
 import accord.api.Result;
 import accord.coordinate.tracking.QuorumTracker;
@@ -35,7 +36,7 @@ import accord.topology.Topologies;
 import accord.utils.Invariants;
 import accord.utils.SortedListMap;
 import accord.utils.async.AsyncResult;
-import accord.utils.async.AsyncResults;
+import accord.utils.async.AsyncResults.SettableByCallback;
 
 import static accord.api.ProtocolModifiers.QuorumEpochIntersections;
 import static accord.api.ProtocolModifiers.QuorumEpochIntersections.Include.Owned;
@@ -60,14 +61,23 @@ public class CoordinateEphemeralRead extends AbstractCoordinatePreAccept<Result,
 {
     public static AsyncResult<Result> coordinate(Node node, FullRoute<?> route, TxnId txnId, Txn txn)
     {
+        SettableByCallback<Result> result = new SettableByCallback<>();
+        coordinate(node, route, txnId, txn, result);
+        return result;
+    }
+
+    public static void coordinate(Node node, FullRoute<?> route, TxnId txnId, Txn txn, BiConsumer<Result, Throwable> callback)
+    {
         TopologyMismatch mismatch = TopologyMismatch.checkForMismatchOrPendingRemoval(node.topology().globalForEpoch(txnId.epoch()), txnId, route.homeKey(), route);
         if (mismatch != null)
-            return AsyncResults.failure(mismatch);
+        {
+            callback.accept(null, mismatch);
+            return;
+        }
 
         Topologies topologies = node.topology().withUnsyncedEpochs(route, txnId, txnId);
-        CoordinateEphemeralRead coordinate = new CoordinateEphemeralRead(node, topologies, route, txnId, txn);
+        CoordinateEphemeralRead coordinate = new CoordinateEphemeralRead(node, topologies, route, txnId, txn, callback);
         coordinate.start();
-        return coordinate;
     }
 
     private final Txn txn;
@@ -75,10 +85,11 @@ public class CoordinateEphemeralRead extends AbstractCoordinatePreAccept<Result,
     private final QuorumTracker tracker;
     private final SortedListMap<Node.Id, GetEphemeralReadDepsOk> oks;
     private long executeAtEpoch;
+    private long retryInEpoch;
 
-    CoordinateEphemeralRead(Node node, Topologies topologies, FullRoute<?> route, TxnId txnId, Txn txn)
+    CoordinateEphemeralRead(Node node, Topologies topologies, FullRoute<?> route, TxnId txnId, Txn txn, BiConsumer<Result, Throwable> callback)
     {
-        super(node, route, txnId);
+        super(node, route, txnId, callback);
         this.txn = txn;
         this.tracker = new QuorumTracker(topologies);
         this.executeAtEpoch = txnId.epoch();
@@ -101,25 +112,42 @@ public class CoordinateEphemeralRead extends AbstractCoordinatePreAccept<Result,
     @Override
     public void onSuccessInternal(Node.Id from, GetEphemeralReadDepsOk ok)
     {
-        oks.put(from, ok);
-        if (ok.latestEpoch > executeAtEpoch)
-            executeAtEpoch = ok.latestEpoch;
+        if (ok.deps != null)
+        {
+            oks.put(from, ok);
+            if (ok.latestEpoch > executeAtEpoch)
+                executeAtEpoch = ok.latestEpoch;
 
-        if (tracker.recordSuccess(from) == Success)
-            onPreAcceptedOrNewEpoch();
+            if (tracker.recordSuccess(from) == Success)
+                onPreAcceptedOrNewEpoch();
+        }
+        else
+        {
+            retryInEpoch = ok.latestEpoch;
+            if (tracker.recordFailure(from) == Failed)
+                retry();
+        }
     }
 
     @Override
     public void onFailureInternal(Node.Id from, Throwable failure)
     {
         if (tracker.recordFailure(from) == Failed)
-            setFailure(new Timeout(txnId, route.homeKey()));
+        {
+            if (retryInEpoch > 0) retry();
+            else setFailure(new Timeout(txnId, route.homeKey()));
+        }
+    }
+
+    private void retry()
+    {
+        coordinate(node, route, txnId.withEpoch(retryInEpoch), txn, callback);
     }
 
     @Override
     void onNewEpochTopologyMismatch(TopologyMismatch mismatch)
     {
-        accept(null, mismatch);
+        setFailure(mismatch);
     }
 
     @Override
@@ -127,7 +155,7 @@ public class CoordinateEphemeralRead extends AbstractCoordinatePreAccept<Result,
     {
         Deps deps = Deps.merge(oks, oks.domainSize(), SortedListMap::getValue, ok -> ok.deps);
         topologies = node.topology().reselect(topologies, QuorumEpochIntersections.preaccept.include, route, executeAtEpoch, executeAtEpoch, SHARE, Owned);
-        new ExecuteEphemeralRead(node, topologies, route, txnId.withEpoch(executeAtEpoch), txn, deps, this).start();
+        new ExecuteEphemeralRead(node, topologies, route, txnId.withEpoch(executeAtEpoch), txn, deps, callback).start();
         if (!Invariants.debug()) oks.clear();
     }
 }

--- a/accord-core/src/main/java/accord/coordinate/CoordinateMaxConflict.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinateMaxConflict.java
@@ -19,6 +19,7 @@
 package accord.coordinate;
 
 import java.util.Collection;
+import java.util.function.BiConsumer;
 
 import accord.api.VisibleForImplementation;
 import accord.coordinate.tracking.QuorumTracker;
@@ -32,6 +33,7 @@ import accord.primitives.Timestamp;
 import accord.topology.Topologies;
 import accord.utils.async.AsyncResult;
 import accord.utils.async.AsyncResults;
+import accord.utils.async.AsyncResults.SettableByCallback;
 
 import static accord.coordinate.tracking.RequestStatus.Failed;
 import static accord.coordinate.tracking.RequestStatus.Success;
@@ -46,14 +48,14 @@ public class CoordinateMaxConflict extends AbstractCoordinatePreAccept<Timestamp
     Timestamp maxConflict;
     long executionEpoch;
 
-    private CoordinateMaxConflict(Node node, FullRoute<?> route, long executionEpoch)
+    private CoordinateMaxConflict(Node node, FullRoute<?> route, long executionEpoch, BiConsumer<Timestamp, Throwable> callback)
     {
-        this(node, route, executionEpoch, node.topology().withUnsyncedEpochs(route, executionEpoch, executionEpoch));
+        this(node, route, executionEpoch, node.topology().withUnsyncedEpochs(route, executionEpoch, executionEpoch), callback);
     }
 
-    private CoordinateMaxConflict(Node node, FullRoute<?> route, long executionEpoch, Topologies topologies)
+    private CoordinateMaxConflict(Node node, FullRoute<?> route, long executionEpoch, Topologies topologies, BiConsumer<Timestamp, Throwable> callback)
     {
-        super(node, route, null, topologies);
+        super(node, route, null, topologies, callback);
         this.maxConflict = Timestamp.NONE;
         this.executionEpoch = executionEpoch;
         this.tracker = new QuorumTracker(topologies);
@@ -66,9 +68,11 @@ public class CoordinateMaxConflict extends AbstractCoordinatePreAccept<Timestamp
         TopologyMismatch mismatch = TopologyMismatch.checkForMismatchOrPendingRemoval(node.topology().globalForEpoch(epoch), null, route.homeKey(), keysOrRanges);
         if (mismatch != null)
             return AsyncResults.failure(mismatch);
-        CoordinateMaxConflict coordinate = new CoordinateMaxConflict(node, route, epoch);
+
+        SettableByCallback<Timestamp> result = new SettableByCallback<>();
+        CoordinateMaxConflict coordinate = new CoordinateMaxConflict(node, route, epoch, result);
         coordinate.start();
-        return coordinate;
+        return result;
     }
 
     @Override
@@ -91,13 +95,13 @@ public class CoordinateMaxConflict extends AbstractCoordinatePreAccept<Timestamp
     void onFailureInternal(Node.Id from, Throwable failure)
     {
         if (tracker.recordFailure(from) == Failed)
-            tryFailure(failure);
+            setFailure(failure);
     }
 
     @Override
     void onNewEpochTopologyMismatch(TopologyMismatch mismatch)
     {
-        tryFailure(mismatch);
+        setFailure(mismatch);
     }
 
     @Override
@@ -109,6 +113,6 @@ public class CoordinateMaxConflict extends AbstractCoordinatePreAccept<Timestamp
     @Override
     void onPreAccepted(Topologies topologies)
     {
-        setSuccess(maxConflict);
+        callback.accept(maxConflict, null);
     }
 }

--- a/accord-core/src/main/java/accord/coordinate/CoordinatePreAccept.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinatePreAccept.java
@@ -19,6 +19,7 @@
 package accord.coordinate;
 
 import java.util.Collection;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 import accord.coordinate.tracking.FastPathTracker;
@@ -59,19 +60,19 @@ abstract class CoordinatePreAccept<T> extends AbstractCoordinatePreAccept<T, Pre
     final Txn txn;
     boolean fastPathEnabled = true;
 
-    CoordinatePreAccept(Node node, TxnId txnId, Txn txn, FullRoute<?> route)
+    CoordinatePreAccept(Node node, TxnId txnId, Txn txn, FullRoute<?> route, BiConsumer<T, Throwable> callback)
     {
-        this(node, txnId, txn, route, node.topology().select(route, txnId, txnId, SHARE, QuorumEpochIntersections.preaccept.include));
+        this(node, txnId, txn, route, node.topology().select(route, txnId, txnId, SHARE, QuorumEpochIntersections.preaccept.include), callback);
     }
 
-    CoordinatePreAccept(Node node, TxnId txnId, Txn txn, FullRoute<?> route, Topologies topologies)
+    CoordinatePreAccept(Node node, TxnId txnId, Txn txn, FullRoute<?> route, Topologies topologies, BiConsumer<T, Throwable> callback)
     {
-        this(node, txnId, txn, route, topologies, FastPathTracker::new);
+        this(node, txnId, txn, route, topologies, FastPathTracker::new, callback);
     }
 
-    CoordinatePreAccept(Node node, TxnId txnId, Txn txn, FullRoute<?> route, Topologies topologies, BiFunction<Topologies, TxnId, PreAcceptTracker<?>> trackerFactory)
+    CoordinatePreAccept(Node node, TxnId txnId, Txn txn, FullRoute<?> route, Topologies topologies, BiFunction<Topologies, TxnId, PreAcceptTracker<?>> trackerFactory, BiConsumer<T, Throwable> callback)
     {
-        super(node, route, txnId, topologies);
+        super(node, route, txnId, topologies, callback);
         this.tracker = trackerFactory.apply(topologies, txnId);
         this.oks = new SortedListMap<>(topologies.nodes(), PreAcceptOk[]::new);
         this.txn = txn;
@@ -141,7 +142,7 @@ abstract class CoordinatePreAccept<T> extends AbstractCoordinatePreAccept<T, Pre
         proposeInvalidate(node, node.uniqueTimestamp(Ballot::fromValues), txnId, route.homeKey(), (outcome, failure) -> {
             if (failure != null)
                 mismatch.addSuppressed(failure);
-            accept(null, mismatch);
+            setFailure(mismatch);
         });
     }
 
@@ -149,7 +150,7 @@ abstract class CoordinatePreAccept<T> extends AbstractCoordinatePreAccept<T, Pre
     void onPreAccepted(Topologies topologies)
     {
         Timestamp executeAt = oks.foldlNonNullValues((ok, prev) -> mergeMaxAndFlags(ok.witnessedAt, prev), Timestamp.NONE);
-        node.withEpoch(executeAt.epoch(), this, t -> WrappableException.wrap(t), () -> {
+        node.withEpochExact(executeAt.epoch(), callback, t -> WrappableException.wrap(t), () -> {
             onPreAccepted(topologies, executeAt, oks);
             if (!Invariants.debug()) oks.clear();
         });

--- a/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
@@ -19,6 +19,7 @@
 package accord.coordinate;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import javax.annotation.Nullable;
 
@@ -49,6 +50,7 @@ import accord.utils.Invariants;
 import accord.utils.SortedListMap;
 import accord.utils.async.AsyncResult;
 import accord.utils.async.AsyncResults;
+import accord.utils.async.AsyncResults.SettableByCallback;
 
 import static accord.coordinate.ExecutePath.FAST;
 import static accord.coordinate.Propose.NotAccept.proposeAndCommitInvalidate;
@@ -73,9 +75,9 @@ public class CoordinateSyncPoint<R> extends CoordinatePreAccept<R>
 
     final CoordinationAdapter<R> adapter;
 
-    private CoordinateSyncPoint(Node node, TxnId txnId, Topologies topologies, Txn txn, FullRoute<?> route, SyncPointAdapter<R> adapter)
+    private CoordinateSyncPoint(Node node, TxnId txnId, Topologies topologies, Txn txn, FullRoute<?> route, SyncPointAdapter<R> adapter, BiConsumer<R, Throwable> callback)
     {
-        super(node, txnId, txn, route, topologies, adapter.preacceptTrackerFactory);
+        super(node, txnId, txn, route, topologies, adapter.preacceptTrackerFactory, callback);
         this.adapter = adapter;
     }
 
@@ -108,14 +110,14 @@ public class CoordinateSyncPoint<R> extends CoordinatePreAccept<R>
     {
         Invariants.requireArgument(kind.isSyncPoint());
         TxnId txnId = node.nextTxnId(kind, keysOrRanges.domain(), cardinality(keysOrRanges));
-        return node.withEpoch(txnId.epoch(), () -> coordinate(node, txnId, keysOrRanges, adapter)).beginAsResult();
+        return node.withEpochExact(txnId.epoch(), () -> coordinate(node, txnId, keysOrRanges, adapter)).beginAsResult();
     }
 
     public static <U extends Unseekable> AsyncResult<SyncPoint<U>> coordinate(Node node, Kind kind, FullRoute<U> route, SyncPointAdapter<SyncPoint<U>> adapter)
     {
         Invariants.requireArgument(kind.isSyncPoint());
         TxnId txnId = node.nextTxnId(kind, route.domain(), cardinality(route));
-        return node.withEpoch(txnId.epoch(), () -> coordinate(node, txnId, route, adapter)).beginAsResult();
+        return node.withEpochExact(txnId.epoch(), () -> coordinate(node, txnId, route, adapter)).beginAsResult();
     }
 
     private static <U extends Unseekable> AsyncResult<SyncPoint<U>> coordinate(Node node, TxnId txnId, Unseekables<U> keysOrRanges, SyncPointAdapter<SyncPoint<U>> adapter)
@@ -131,9 +133,11 @@ public class CoordinateSyncPoint<R> extends CoordinatePreAccept<R>
         TopologyMismatch mismatch = TopologyMismatch.checkForMismatch(node.topology().globalForEpoch(txnId.epoch()), txnId, route.homeKey(), route);
         if (mismatch != null)
             return AsyncResults.failure(mismatch);
-        CoordinateSyncPoint<SyncPoint<U>> coordinate = new CoordinateSyncPoint<>(node, txnId, adapter.forDecision(node, route, SHARE, txnId, txnId), node.agent().emptySystemTxn(txnId.kind(), txnId.domain()), route, adapter);
+
+        SettableByCallback<SyncPoint<U>> result = new SettableByCallback<>();
+        CoordinateSyncPoint<SyncPoint<U>> coordinate = new CoordinateSyncPoint<>(node, txnId, adapter.forDecision(node, route, SHARE, txnId, txnId), node.agent().emptySystemTxn(txnId.kind(), txnId.domain()), route, adapter, result);
         coordinate.start();
-        return coordinate;
+        return result;
     }
 
     @Override
@@ -147,7 +151,7 @@ public class CoordinateSyncPoint<R> extends CoordinatePreAccept<R>
     {
         if (executeAt.is(REJECTED))
         {
-            proposeAndCommitInvalidate(node, Ballot.ZERO, txnId, route.homeKey(), route, executeAt, this);
+            proposeAndCommitInvalidate(node, Ballot.ZERO, txnId, route.homeKey(), route, executeAt, callback);
         }
         else
         {
@@ -156,11 +160,11 @@ public class CoordinateSyncPoint<R> extends CoordinatePreAccept<R>
                 withFlags = txnId.addFlag(HLC_BOUND);
             Deps deps = Deps.merge(oks.valuesAsNullableList(), oks.domainSize(), List::get, ok -> ok.deps);
             if (tracker.hasFastPathAccepted())
-                adapter.execute(node, topologies, route, Ballot.ZERO, FAST, ExecuteFlags.none(), txnId, txn, withFlags, deps, deps, this);
+                adapter.execute(node, topologies, route, Ballot.ZERO, FAST, ExecuteFlags.none(), txnId, txn, withFlags, deps, deps, callback);
             else if (tracker.hasMediumPathAccepted())
-                adapter.propose(node, topologies, route, Accept.Kind.MEDIUM, Ballot.ZERO, txnId, txn, withFlags, deps, this);
+                adapter.propose(node, topologies, route, Accept.Kind.MEDIUM, Ballot.ZERO, txnId, txn, withFlags, deps, callback);
             else
-                adapter.propose(node, topologies, route, Accept.Kind.SLOW, Ballot.ZERO, txnId, txn, executeAt, deps, this);
+                adapter.propose(node, topologies, route, Accept.Kind.SLOW, Ballot.ZERO, txnId, txn, executeAt, deps, callback);
         }
     }
 

--- a/accord-core/src/main/java/accord/coordinate/CoordinateTransaction.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinateTransaction.java
@@ -19,6 +19,7 @@
 package accord.coordinate;
 
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import javax.annotation.Nullable;
 
@@ -56,6 +57,7 @@ import accord.utils.MapReduceConsume;
 import accord.utils.SortedListMap;
 import accord.utils.async.AsyncResult;
 import accord.utils.async.AsyncResults;
+import accord.utils.async.AsyncResults.SettableByCallback;
 import accord.utils.async.Cancellable;
 
 import static accord.coordinate.CoordinateTransaction.LocalExecuteState.PENDING;
@@ -77,9 +79,9 @@ import static java.util.concurrent.TimeUnit.MICROSECONDS;
  */
 public class CoordinateTransaction extends CoordinatePreAccept<Result>
 {
-    private CoordinateTransaction(Node node, TxnId txnId, Txn txn, FullRoute<?> route)
+    private CoordinateTransaction(Node node, TxnId txnId, Txn txn, FullRoute<?> route, BiConsumer<Result, Throwable> callback)
     {
-        super(node, txnId, txn, route);
+        super(node, txnId, txn, route, callback);
     }
 
     public static AsyncResult<Result> coordinate(Node node, FullRoute<?> route, TxnId txnId, Txn txn)
@@ -87,9 +89,11 @@ public class CoordinateTransaction extends CoordinatePreAccept<Result>
         TopologyMismatch mismatch = TopologyMismatch.checkForMismatchOrPendingRemoval(node.topology().globalForEpoch(txnId.epoch()), txnId, route.homeKey(), txn.keys());
         if (mismatch != null)
             return AsyncResults.failure(mismatch);
-        CoordinateTransaction coordinate = new CoordinateTransaction(node, txnId, txn, route);
+
+        SettableByCallback<Result> result = new SettableByCallback<>();
+        CoordinateTransaction coordinate = new CoordinateTransaction(node, txnId, txn, route, result);
         coordinate.start();
-        return coordinate;
+        return result;
     }
 
     @Override
@@ -111,7 +115,7 @@ public class CoordinateTransaction extends CoordinatePreAccept<Result>
                 // note: we merge all Deps regardless of witnessedAt. While we only need fast path votes,
                 // we must include Deps from fast path votes from earlier epochs that may have witnessed later transactions
                 // TODO (desired): we might mask some bugs by merging more responses than we strictly need, so optimise this to optionally merge minimal deps
-                executeAdapter().execute(node, topologies, route, Ballot.ZERO, FAST, executeFlags, txnId, txn, txnId, deps, deps, settingCallback());
+                executeAdapter().execute(node, topologies, route, Ballot.ZERO, FAST, executeFlags, txnId, txn, txnId, deps, deps, callback);
                 node.agent().eventListener().onFastPathTaken(txnId, deps);
                 return;
             }
@@ -121,20 +125,20 @@ public class CoordinateTransaction extends CoordinatePreAccept<Result>
             Deps deps = mergeFastOrMediumDeps(oks);
             if (deps != null)
             {
-                proposeAdapter().propose(node, topologies, route, Accept.Kind.MEDIUM, Ballot.ZERO, txnId, txn, txnId, deps, this);
+                proposeAdapter().propose(node, topologies, route, Accept.Kind.MEDIUM, Ballot.ZERO, txnId, txn, txnId, deps, callback);
                 node.agent().eventListener().onMediumPathTaken(txnId, deps);
                 return;
             }
         }
         else if (executeAt.is(REJECTED))
         {
-            proposeAndCommitInvalidate(node, Ballot.ZERO, txnId, route.homeKey(), route, executeAt,this);
+            proposeAndCommitInvalidate(node, Ballot.ZERO, txnId, route.homeKey(), route, executeAt, callback);
             node.agent().eventListener().onRejected(txnId);
             return;
         }
 
         Deps deps = Deps.merge(oks.valuesAsNullableList(), oks.domainSize(), List::get, ok -> ok.deps);
-        proposeAdapter().propose(node, topologies, route, Accept.Kind.SLOW, Ballot.ZERO, txnId, txn, executeAt, deps, this);
+        proposeAdapter().propose(node, topologies, route, Accept.Kind.SLOW, Ballot.ZERO, txnId, txn, executeAt, deps, callback);
         node.agent().eventListener().onSlowPathTaken(txnId, deps);
     }
 
@@ -203,7 +207,7 @@ public class CoordinateTransaction extends CoordinatePreAccept<Result>
             success();
             if (failure != null)
             {
-                CoordinateTransaction.this.accept(null, failure);
+                setFailure(failure);
             }
             else
             {
@@ -224,7 +228,7 @@ public class CoordinateTransaction extends CoordinatePreAccept<Result>
                 }
                 else
                 {
-                    CoordinateTransaction.this.accept(null, new Preempted(txnId, route.homeKey()));
+                    setFailure(new Preempted(txnId, route.homeKey()));
                 }
             }
 

--- a/accord-core/src/main/java/accord/coordinate/CoordinationAdapter.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinationAdapter.java
@@ -74,10 +74,10 @@ public interface CoordinationAdapter<R>
     void stabilise(Node node, @Nullable Topologies any, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, BiConsumer<? super R, Throwable> callback);
     void stabiliseOnly(Node node, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, BiConsumer<? super Deps, Throwable> callback);
     void execute(Node node, @Nullable Topologies any, FullRoute<?> route, Ballot ballot, ExecutePath path, ExecuteFlags executeFlags, TxnId txnId, Txn txn, Timestamp executeAt, Deps stableDeps, Deps sendDeps, BiConsumer<? super R, Throwable> callback);
-    void persist(Node node, @Nullable Topologies any, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super R, Throwable> callback);
+    void persist(Node node, @Nullable Topologies any, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, boolean informDurableOnDone, BiConsumer<? super R, Throwable> callback);
     default void persist(Node node, @Nullable Topologies any, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super R, Throwable> callback)
     {
-        persist(node, any, route, route, SHARE, route, ballot, txnId, txn, executeAt, deps, writes, result, callback);
+        persist(node, any, route, route, SHARE, route, ballot, txnId, txn, executeAt, deps, writes, result, true, callback);
     }
 
     class DefaultFactory implements Factory
@@ -156,7 +156,7 @@ public interface CoordinationAdapter<R>
             {
                 if (!node.topology().hasEpoch(executeAt.epoch()))
                 {
-                    node.withEpoch(executeAt.epoch(), (success, fail) -> {
+                    node.withEpochAtLeast(executeAt.epoch(), (success, fail) -> {
                         if (fail != null) callback.accept(null, fail);
                         else stabilise(node, accept, route, ballot, txnId, txn, executeAt, deps, callback);
                     });
@@ -176,7 +176,7 @@ public interface CoordinationAdapter<R>
             {
                 if (!node.topology().hasEpoch(executeAt.epoch()))
                 {
-                    node.withEpoch(executeAt.epoch(), (success, fail) -> {
+                    node.withEpochAtLeast(executeAt.epoch(), (success, fail) -> {
                         if (fail != null) callback.accept(null, fail);
                         else stabiliseOnly(node, require, sendTo, selectNodeOwnership, route, ballot, txnId, txn, executeAt, deps, callback);
                     });
@@ -208,12 +208,12 @@ public interface CoordinationAdapter<R>
             }
 
             @Override
-            public void persist(Node node, Topologies any, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super Result, Throwable> callback)
+            public void persist(Node node, Topologies any, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, boolean informDurableOnDone, BiConsumer<? super Result, Throwable> callback)
             {
                 Topologies all = execution(node, any, sendTo, selectNodeOwnership, route, txnId, executeAt);
 
                 if (callback != null) callback.accept(result, null);
-                new PersistTxn(node, all, txnId, ballot, require, txn, executeAt, deps, writes, result, route, Apply.FACTORY)
+                new PersistTxn(node, all, txnId, ballot, require, txn, executeAt, deps, writes, result, route, informDurableOnDone, Apply.FACTORY)
                 .start(applyKind, all, writes, result);
             }
 
@@ -275,12 +275,12 @@ public interface CoordinationAdapter<R>
             }
 
             @Override
-            public void persist(Node node, Topologies ignore, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, BiConsumer<? super R, Throwable> callback)
+            public void persist(Node node, Topologies ignore, Route<?> require, Route<?> sendTo, SelectNodeOwnership selectNodeOwnership, FullRoute<?> route, Ballot ballot, TxnId txnId, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, boolean informDurableOnDone, BiConsumer<? super R, Throwable> callback)
             {
                 Topologies all = forExecution(node, sendTo, selectNodeOwnership, txnId, executeAt, deps);
 
                 invokeSuccess(node, route, txnId, executeAt, txn, deps, callback);
-                new PersistSyncPoint(node, all, txnId, ballot, sendTo, txn, executeAt, deps, writes, result, route)
+                new PersistSyncPoint(node, all, txnId, ballot, sendTo, txn, executeAt, deps, writes, result, informDurableOnDone, route)
                 .start(Maximal, all, writes, result);
             }
         }

--- a/accord-core/src/main/java/accord/coordinate/ExecuteEphemeralRead.java
+++ b/accord-core/src/main/java/accord/coordinate/ExecuteEphemeralRead.java
@@ -100,7 +100,7 @@ public class ExecuteEphemeralRead extends ReadCoordinator<ReadReply>
             if (ok.futureEpoch > allTopologies.currentEpoch())
             {
                 // TODO (expected): only submit new requests for the keys that execute in a later epoch
-                node.withEpoch(ok.futureEpoch, callback, t -> WrappableException.wrap(t), () -> {
+                node.withEpochExact(ok.futureEpoch, callback, t -> WrappableException.wrap(t), () -> {
                     new ExecuteEphemeralRead(node, node.topology().preciseEpochs(route, ok.futureEpoch, ok.futureEpoch, SHARE), route, txnId.withEpoch(ok.futureEpoch), txn, deps, callback).start();
                 });
                 return Aborted;

--- a/accord-core/src/main/java/accord/coordinate/ExecuteSyncPoint.java
+++ b/accord-core/src/main/java/accord/coordinate/ExecuteSyncPoint.java
@@ -171,7 +171,7 @@ public class ExecuteSyncPoint extends SettableResult<DurabilityResult> implement
 
         if (retryInFutureEpoch > tracker.topologies().currentEpoch())
         {
-            node.withEpoch(retryInFutureEpoch, (ignore, failure) -> tryFailure(WrappableException.wrap(failure)), () -> {
+            node.withEpochAtLeast(retryInFutureEpoch, (ignore, failure) -> tryFailure(WrappableException.wrap(failure)), () -> {
                 ExecuteSyncPoint continuation = new ExecuteSyncPoint(node, syncPoint, node.topology().preciseEpochs(syncPoint.route(), tracker.topologies().currentEpoch(), retryInFutureEpoch, SHARE), excludeSuccess, executor, attempt, current());
                 continuation.invoke((success, failure) -> {
                     if (failure == null) trySuccess(success);

--- a/accord-core/src/main/java/accord/coordinate/FetchData.java
+++ b/accord-core/src/main/java/accord/coordinate/FetchData.java
@@ -34,6 +34,8 @@ import accord.primitives.Route;
 import accord.primitives.Timestamp;
 import accord.primitives.TxnId;
 import accord.primitives.Unseekables;
+import accord.topology.TopologyManager;
+import accord.topology.TopologyManager.TopologyRetiredException;
 import accord.utils.Invariants;
 
 import javax.annotation.Nonnull;
@@ -97,7 +99,14 @@ public class FetchData extends CheckShards<Route<?>>
 
         Ranges localRanges(Node node)
         {
-            return node.topology().localRangesForEpochs(lowEpoch, highEpoch);
+            try
+            {
+                return node.topology().localRangesForEpochs(lowEpoch, highEpoch);
+            }
+            catch (TopologyRetiredException t)
+            {
+                throw new TopologyRetiredException("Failed to read local ranges for " + txnId + " between " + lowEpoch + " and " + highEpoch, t);
+            }
         }
     }
 
@@ -128,7 +137,7 @@ public class FetchData extends CheckShards<Route<?>>
         long srcEpoch = request.srcEpoch;
         if (!node.topology().hasEpoch(srcEpoch))
         {
-            node.withEpoch(srcEpoch, request.callback, () -> fetch(node, route, request));
+            node.withEpochAtLeast(srcEpoch, request.callback, () -> fetch(node, route, request));
             return;
         }
 
@@ -166,7 +175,7 @@ public class FetchData extends CheckShards<Route<?>>
         long srcEpoch = request.srcEpoch;
         if (!node.topology().hasEpoch(srcEpoch))
         {
-            node.withEpoch(srcEpoch, request.callback, () -> fetchSpecific(node, query, maxRoute, request));
+            node.withEpochAtLeast(srcEpoch, request.callback, () -> fetchSpecific(node, query, maxRoute, request));
             return;
         }
 
@@ -255,7 +264,7 @@ public class FetchData extends CheckShards<Route<?>>
 
     public static void fetch(Node node, FullRoute<?> route, FetchRequest request)
     {
-        node.withEpoch(request.srcEpoch, request.callback, () -> {
+        node.withEpochAtLeast(request.srcEpoch, request.callback, () -> {
             Ranges ranges = request.localRanges(node);
             fetchInternal(node, ranges, route, request);
         });

--- a/accord-core/src/main/java/accord/coordinate/FindSomeRoute.java
+++ b/accord-core/src/main/java/accord/coordinate/FindSomeRoute.java
@@ -61,7 +61,7 @@ public class FindSomeRoute extends CheckShards<Participants<?>>
     {
         if (!node.topology().hasEpoch(txnId.epoch()))
         {
-            node.withEpoch(txnId.epoch(), callback, () -> findSomeRoute(node, txnId, invalidIf, unseekables, callback));
+            node.withEpochAtLeast(txnId.epoch(), callback, () -> findSomeRoute(node, txnId, invalidIf, unseekables, callback));
             return;
         }
 

--- a/accord-core/src/main/java/accord/coordinate/Persist.java
+++ b/accord-core/src/main/java/accord/coordinate/Persist.java
@@ -58,9 +58,10 @@ public abstract class Persist implements Callback<ApplyReply>
     // TODO (expected): track separate ALL and Quorum, so we can report Universal durability to permit faster GC
     protected final QuorumTracker tracker;
     protected final Apply.Factory factory;
+    protected final boolean informDurableOnDone;
     boolean isDone;
 
-    protected Persist(Node node, Topologies all, TxnId txnId, Ballot ballot, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps stableDeps, Writes writes, Result result, FullRoute<?> route, Apply.Factory factory)
+    protected Persist(Node node, Topologies all, TxnId txnId, Ballot ballot, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps stableDeps, Writes writes, Result result, FullRoute<?> route, boolean informDurableOnDone, Apply.Factory factory)
     {
         this.node = node;
         this.txnId = txnId;
@@ -75,6 +76,7 @@ public abstract class Persist implements Callback<ApplyReply>
         this.topologies = all;
         this.tracker = new QuorumTracker(all);
         this.factory = factory;
+        this.informDurableOnDone = informDurableOnDone;
         Invariants.require((writes != null) == txnId.is(Txn.Kind.Write), "%s: writes %s", txnId, writes);
     }
 
@@ -86,13 +88,12 @@ public abstract class Persist implements Callback<ApplyReply>
             default: throw new IllegalStateException();
             case Redundant:
             case Applied:
-                if (sendTo == route && tracker.recordSuccess(from) == Success)
+                if (tracker.recordSuccess(from) == Success && informDurableOnDone && !isDone)
                 {
-                    if (!isDone)
-                    {
-                        isDone = true;
-                        InformDurable.informDefault(node, topologies, txnId, route, executeAt, Majority);
-                    }
+                    // note: we enter this branch whether or not sendTo == route,
+                    // since we should only invoke Persist with sendTo != route when the remainder of the route is already persisted and truncated
+                    isDone = true;
+                    InformDurable.informDefault(node, topologies, txnId, route, executeAt, Majority);
                 }
             case RaceWithRecovery:
                 // don't count this towards durability; otherwise it is possible (though very unlikely)

--- a/accord-core/src/main/java/accord/coordinate/PersistSyncPoint.java
+++ b/accord-core/src/main/java/accord/coordinate/PersistSyncPoint.java
@@ -34,9 +34,9 @@ import accord.utils.SortedArrays;
 
 public class PersistSyncPoint extends Persist
 {
-    public PersistSyncPoint(Node node, Topologies topologies, TxnId txnId, Ballot ballot, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, FullRoute<?> route)
+    public PersistSyncPoint(Node node, Topologies topologies, TxnId txnId, Ballot ballot, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, boolean informDurableOnDone, FullRoute<?> route)
     {
-        super(node, topologies, txnId, ballot, sendTo, txn, executeAt, deps, writes, result, route, Apply.FACTORY);
+        super(node, topologies, txnId, ballot, sendTo, txn, executeAt, deps, writes, result, route, informDurableOnDone, Apply.FACTORY);
     }
 
     @Override

--- a/accord-core/src/main/java/accord/coordinate/PersistTxn.java
+++ b/accord-core/src/main/java/accord/coordinate/PersistTxn.java
@@ -34,8 +34,8 @@ import accord.topology.Topologies;
 public class PersistTxn extends Persist
 {
     // TODO (desired): standardise parameter order with CoordinationAdapter (and others)
-    public PersistTxn(Node node, Topologies topologies, TxnId txnId, Ballot ballot, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, FullRoute<?> route, Apply.Factory factory)
+    public PersistTxn(Node node, Topologies topologies, TxnId txnId, Ballot ballot, Route<?> sendTo, Txn txn, Timestamp executeAt, Deps deps, Writes writes, Result result, FullRoute<?> route, boolean informDurableOnDone, Apply.Factory factory)
     {
-        super(node, topologies, txnId, ballot, sendTo, txn, executeAt, deps, writes, result, route, factory);
+        super(node, topologies, txnId, ballot, sendTo, txn, executeAt, deps, writes, result, route, informDurableOnDone, factory);
     }
 }

--- a/accord-core/src/main/java/accord/coordinate/Propose.java
+++ b/accord-core/src/main/java/accord/coordinate/Propose.java
@@ -280,7 +280,7 @@ abstract class Propose<R> implements Callback<AcceptReply>
                 }
                 else
                 {
-                    node.withEpoch(invalidateUntil.epoch(), callback, t -> WrappableException.wrap(t), () -> {
+                    node.withEpochExact(invalidateUntil.epoch(), callback, t -> WrappableException.wrap(t), () -> {
                         commitInvalidate(node, txnId, commitInvalidationTo, invalidateUntil);
                         callback.accept(null, new Invalidated(txnId, invalidateWithParticipant));
                     });

--- a/accord-core/src/main/java/accord/coordinate/Recover.java
+++ b/accord-core/src/main/java/accord/coordinate/Recover.java
@@ -524,7 +524,7 @@ public class Recover implements Callback<RecoverReply>, BiConsumer<Result, Throw
     private void commitInvalidate(Timestamp invalidateUntil)
     {
         long highEpoch = Math.max(invalidateUntil.epoch(), reportHighEpoch);
-        node.withEpoch(highEpoch, node.agent(), () -> {
+        node.withEpochAtLeast(highEpoch, node.agent(), () -> {
             Commit.Invalidate.commitInvalidate(node, txnId, route, invalidateUntil);
         });
         isDone = true;
@@ -539,7 +539,7 @@ public class Recover implements Callback<RecoverReply>, BiConsumer<Result, Throw
 
     private void propose(Accept.Kind kind, Timestamp executeAt, Deps deps)
     {
-        node.withEpoch(executeAt.epoch(), this, () -> {
+        node.withEpochAtLeast(executeAt.epoch(), this, () -> {
             adapter.propose(node, null, route, kind, ballot, txnId, txn, executeAt, deps, this);
         });
     }
@@ -555,7 +555,7 @@ public class Recover implements Callback<RecoverReply>, BiConsumer<Result, Throw
     AsyncResult<InferredFastPath> awaitEarlier(Node node, Deps waitOn, BlockedUntil blockedUntil)
     {
         long requireEpoch = waitOn.maxTxnId(txnId).epoch();
-        return node.withEpoch(requireEpoch, () -> {
+        return node.withEpochExact(requireEpoch, () -> {
             TxnId recoverId = this.txnId;
             List<AsyncResult<InferredFastPath>> requests = new ArrayList<>();
             for (int i = 0 ; i < waitOn.txnIdCount() ; ++i)
@@ -619,7 +619,7 @@ public class Recover implements Callback<RecoverReply>, BiConsumer<Result, Throw
             return AsyncResults.success(InferredFastPath.Accept);
 
         long requireEpoch = waitOn.maxTxnId(txnId).epoch();
-        return node.withEpoch(requireEpoch, () -> {
+        return node.withEpochExact(requireEpoch, () -> {
             TxnId recoverId = this.txnId;
             List<AsyncResult<InferredFastPath>> requests = new ArrayList<>();
             for (int i = 0 ; i < waitOn.txnIdCount() ; ++i)

--- a/accord-core/src/main/java/accord/coordinate/RecoverWithRoute.java
+++ b/accord-core/src/main/java/accord/coordinate/RecoverWithRoute.java
@@ -46,6 +46,7 @@ import accord.utils.Invariants;
 import accord.utils.WrappableException;
 
 import static accord.coordinate.CoordinationAdapter.Factory.Kind.Recovery;
+import static accord.coordinate.ReadCoordinator.Success.Quorum;
 import static accord.primitives.Known.KnownDeps.DepsKnown;
 import static accord.primitives.Known.KnownExecuteAt.ApplyAtKnown;
 import static accord.primitives.Known.Outcome.Apply;
@@ -185,6 +186,7 @@ public class RecoverWithRoute extends CheckShards<FullRoute<?>>
                             }
                             else
                             {
+                                boolean informDurableOnDone = success == Quorum; // if we have a quorum of truncated responses for the part of the remote we have removed, it is safe to consider this part durable
                                 known = full.knownFor(txnId, trySendTo, trySendTo);
                                 if (known.isDefinitionKnown() && known.is(ApplyAtKnown) && known.outcome() == Apply)
                                 {
@@ -197,14 +199,14 @@ public class RecoverWithRoute extends CheckShards<FullRoute<?>>
 
                                         LatestDeps.withStable(node.coordinationAdapter(txnId, Recovery), node, txnId, full.executeAt, full.partialTxn, stable, haveUnstable, trySendTo, SLICE, route, callback, deps -> {
                                             Deps stableDeps = deps.intersecting(trySendTo);
-                                            node.coordinationAdapter(txnId, Recovery).persist(node, null, trySendTo, trySendTo, SLICE, route, bumpBallot, txnId, full.partialTxn, full.executeAt, stableDeps, full.writes, full.result, null);
+                                            node.coordinationAdapter(txnId, Recovery).persist(node, null, trySendTo, trySendTo, SLICE, route, bumpBallot, txnId, full.partialTxn, full.executeAt, stableDeps, full.writes, full.result, informDurableOnDone, null);
                                         });
                                     }
                                     else
                                     {
                                         Invariants.require(full.stableDeps.covers(trySendTo));
                                         Invariants.require(txnId.isSystemTxn() || full.partialTxn.covers(trySendTo));
-                                        node.coordinationAdapter(txnId, Recovery).persist(node, null, trySendTo, trySendTo, SLICE, route, bumpBallot, txnId, full.partialTxn, full.executeAt, full.stableDeps, full.writes, full.result, null);
+                                        node.coordinationAdapter(txnId, Recovery).persist(node, null, trySendTo, trySendTo, SLICE, route, bumpBallot, txnId, full.partialTxn, full.executeAt, full.stableDeps, full.writes, full.result, informDurableOnDone, null);
                                     }
                                 }
                             }
@@ -251,7 +253,7 @@ public class RecoverWithRoute extends CheckShards<FullRoute<?>>
                         }
                     }
                     LatestDeps.withStable(node.coordinationAdapter(txnId, Recovery), node, txnId, full.executeAt, full.partialTxn, deps, missingDeps, route, SHARE, route, callback, mergedDeps -> {
-                        node.withEpoch(full.executeAt.epoch(), node.agent(), t -> WrappableException.wrap(t), () -> {
+                        node.withEpochExact(full.executeAt.epoch(), node.agent(), t -> WrappableException.wrap(t), () -> {
                             node.coordinationAdapter(txnId, Recovery).persist(node, topologies, route, bumpBallot, txnId, txn, full.executeAt, mergedDeps, full.writes, full.result, (s, f) -> {
                                 callback.accept(f == null ? APPLIED : null, f);
                             });

--- a/accord-core/src/main/java/accord/coordinate/TopologyMismatch.java
+++ b/accord-core/src/main/java/accord/coordinate/TopologyMismatch.java
@@ -82,17 +82,16 @@ public class TopologyMismatch extends CoordinationFailed
     private static TopologyMismatch checkForPendingRemoval(Topology t, @Nullable TxnId txnId, @Nullable RoutingKey homeKey, Routables<?> keysOrRanges)
     {
         EnumSet<TopologyMismatch.Reason> reasons = null;
-        if (homeKey != null && !t.reduce(true, s -> s.contains(homeKey), (result, s) -> result & !s.is(PENDING_REMOVAL)))
+        if (homeKey != null)
         {
-            if (reasons == null)
-                reasons = EnumSet.noneOf(TopologyMismatch.Reason.class);
-            reasons.add(TopologyMismatch.Reason.HOME_KEY);
+            int i = t.indexForKey(homeKey);
+            if (i >= 0 && t.get(i).is(PENDING_REMOVAL))
+                reasons = EnumSet.of(Reason.HOME_KEY);
         }
-        if (!t.reduce(true, s -> keysOrRanges.intersects(s.range), (result, s) -> result & !s.is(PENDING_REMOVAL)))
+        if (t.foldl(keysOrRanges, (shard, v, i) -> v || shard.is(PENDING_REMOVAL), false))
         {
-            if (reasons == null)
-                reasons = EnumSet.noneOf(TopologyMismatch.Reason.class);
-            reasons.add(TopologyMismatch.Reason.KEYS_OR_RANGES);
+            if (reasons == null) reasons = EnumSet.of(TopologyMismatch.Reason.KEYS_OR_RANGES);
+            else reasons.add(TopologyMismatch.Reason.KEYS_OR_RANGES);
         }
         return reasons == null ? null : new TopologyMismatch(reasons, t, txnId, homeKey, keysOrRanges);
     }
@@ -118,15 +117,12 @@ public class TopologyMismatch extends CoordinationFailed
         EnumSet<TopologyMismatch.Reason> reasons = null;
         if (!t.ranges().contains(homeKey))
         {
-            if (reasons == null)
-                reasons = EnumSet.noneOf(TopologyMismatch.Reason.class);
-            reasons.add(TopologyMismatch.Reason.HOME_KEY);
+            reasons = EnumSet.of(Reason.HOME_KEY);
         }
         if (!t.ranges().containsAll(keysOrRanges))
         {
-            if (reasons == null)
-                reasons = EnumSet.noneOf(TopologyMismatch.Reason.class);
-            reasons.add(TopologyMismatch.Reason.KEYS_OR_RANGES);
+            if (reasons == null) reasons = EnumSet.of(TopologyMismatch.Reason.KEYS_OR_RANGES);
+            else reasons.add(TopologyMismatch.Reason.KEYS_OR_RANGES);
         }
         return reasons == null ? null : new TopologyMismatch(reasons, t, txnId, homeKey, keysOrRanges);
     }

--- a/accord-core/src/main/java/accord/impl/progresslog/DefaultProgressLog.java
+++ b/accord-core/src/main/java/accord/impl/progresslog/DefaultProgressLog.java
@@ -497,7 +497,7 @@ public class DefaultProgressLog implements ProgressLog, Consumer<SafeCommandStor
             minEpoch = Math.min(awaitingEpochBuffer[i].run.txnId.epoch(), minEpoch);
         Invariants.requireArgument(minEpoch != Long.MAX_VALUE);
         isAwaitingEpoch = true;
-        node.withEpoch(minEpoch, (success, fail) -> commandStore.execute(empty(), ss -> {
+        node.withEpochAtLeast(minEpoch, (success, fail) -> commandStore.execute(empty(), ss -> {
             isAwaitingEpoch = false;
             accept(ss);
         }, node.agent()));

--- a/accord-core/src/main/java/accord/impl/progresslog/WaitingState.java
+++ b/accord-core/src/main/java/accord/impl/progresslog/WaitingState.java
@@ -730,7 +730,7 @@ abstract class WaitingState extends BaseTxnState
         long epoch = blockedUntil.fetchEpoch(txnId, executeAt);
         // we MUST allocate the invoker before invoking withEpoch as this may be asynchronous and we must first register our callback for cancellation
         BiConsumer<AsynchronousAwait.SynchronousResult, Throwable> invoker = invokeWaitingCallback(owner, txnId, blockedUntil, callback);
-        owner.node().withEpoch(epoch, invoker, () -> {
+        owner.node().withEpochAtLeast(epoch, invoker, () -> {
             AsynchronousAwait.awaitAny(owner.node(), contact(owner, route, epoch), txnId, route, blockedUntil, callbackId, invoker);
         });
     }

--- a/accord-core/src/main/java/accord/local/Bootstrap.java
+++ b/accord-core/src/main/java/accord/local/Bootstrap.java
@@ -19,6 +19,7 @@
 package accord.local;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
 import javax.annotation.Nonnull;
@@ -124,7 +125,7 @@ class Bootstrap
             if (!node.topology().hasEpoch(globalSyncId.epoch()))
             {
                 // Ignore timeouts fetching the epoch, always keep trying to bootstrap
-                node.withEpoch(globalSyncId.epoch(), (ignored, failure) -> store.execute(empty(), Attempt.this::start, (ignored1, failure2) -> {
+                node.withEpochAtLeast(globalSyncId.epoch(), (ignored, failure) -> store.execute(empty(), Attempt.this::start, (ignored1, failure2) -> {
                     if (failure2 != null)
                         node.agent().acceptAndWrap(null, failure2);
                 }));
@@ -142,7 +143,7 @@ class Bootstrap
                          return CoordinateSyncPoint.exclusive(node, globalSyncId, commitRanges);
                      })
                      .flatMap(i -> i)
-                     .flatMap(syncPoint -> node.withEpoch(epoch, () -> store.build(empty(), safeStore1 -> {
+                     .flatMap(syncPoint -> node.withEpochAtLeast(epoch, () -> store.build(empty(), safeStore1 -> {
                          if (valid.isEmpty()) // we've lost ownership of the range
                              return AsyncResults.success(Ranges.EMPTY);
                          return fetch = safeStore1.dataStore().fetch(node, safeStore1, valid, syncPoint, this);
@@ -272,7 +273,9 @@ class Bootstrap
                 accept(null, failure);
 
             store.agent().onFailedBootstrap(attempt, "PartialFetch", newFailures, () -> {
-                store.execute(empty(), safeStore -> restart(safeStore, newFailures.slice(allValid), attempt + 1), store.agent());
+                node.scheduler().selfRecurring(() -> {
+                    store.execute(empty(), safeStore -> restart(safeStore, newFailures.slice(allValid), attempt + 1), store.agent());
+                }, 0L, TimeUnit.NANOSECONDS);
             }, failure);
             Invariants.require(!newFailures.intersects(fetchedAndSafeToRead));
         }
@@ -346,7 +349,9 @@ class Bootstrap
             if (!retry.isEmpty())
             {
                 store.agent().onFailedBootstrap(attempt, "Fetch", retry, () -> {
-                    store.execute(empty(), safeStore -> restart(safeStore, retry, attempt + 1), node.agent());
+                    node.scheduler().selfRecurring(() -> {
+                        store.execute(empty(), safeStore -> restart(safeStore, retry, attempt + 1), node.agent());
+                    }, 0L, TimeUnit.NANOSECONDS);
                 }, fetchOutcome);
             }
         }

--- a/accord-core/src/main/java/accord/local/Command.java
+++ b/accord-core/src/main/java/accord/local/Command.java
@@ -285,17 +285,20 @@ public abstract class Command implements ICommand
      */
     public @Nullable Timestamp executesAtLeast()
     {
+        return executesAtLeast(null);
+    }
+
+    public @Nullable Timestamp executesAtLeast(@Nullable Timestamp orElse)
+    {
         WaitingOn waitingOn = waitingOn();
         if (waitingOn == null)
-            return null;
+            return orElse;
         return waitingOn.executeAtLeast();
     }
 
     public final Timestamp executeAtIfKnownElseTxnId()
     {
-        if (known().isExecuteAtKnown())
-            return executeAt();
-        return txnId();
+        return executeAtIfKnown(txnId);
     }
 
     public final Timestamp executeAtIfKnown()
@@ -313,12 +316,6 @@ public abstract class Command implements ICommand
     public final Timestamp executeAtOrTxnId()
     {
         Timestamp executeAt = executeAt();
-        return executeAt == null || executeAt.equals(Timestamp.NONE) ? txnId() : executeAt;
-    }
-
-    public final Timestamp executeAtIfKnownOrTxnId()
-    {
-        Timestamp executeAt = executeAtIfKnown();
         return executeAt == null || executeAt.equals(Timestamp.NONE) ? txnId() : executeAt;
     }
 

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -719,10 +719,40 @@ public abstract class CommandStores
     private static class StoreSelector extends SimpleBitSet implements IndexedQuadConsumer<Object, Object, Object, Object>, IndexedRangeQuadConsumer<Object, Object, Object, Object>
     {
         final int[] indexMap;
-        public StoreSelector(int size, int[] indexMap)
+
+        private StoreSelector(int size, int[] indexMap)
         {
             super(size);
             this.indexMap = indexMap;
+        }
+
+        public StoreSelector(Snapshot snapshot)
+        {
+            this(snapshot.shards.length, snapshot.indexForRange);
+        }
+
+        static StoreSelector select(Snapshot snapshot, Unseekables<?> unseekables)
+        {
+            StoreSelector selector = new StoreSelector(snapshot);
+            switch (unseekables.domain())
+            {
+                default: throw new UnhandledEnum(unseekables.domain());
+                case Range:
+                {
+                    int minIndex = 0;
+                    for (Range range : (AbstractRanges)unseekables)
+                        minIndex = snapshot.lookupByRange.forEachRange(range, selector, selector, null, null, null, null, minIndex);
+                    break;
+                }
+                case Key:
+                {
+                    int minIndex = 0;
+                    for (RoutingKey key : (AbstractUnseekableKeys)unseekables)
+                        minIndex = snapshot.lookupByRange.forEachKey(key, selector, selector, null, null, null, null, minIndex);
+                    break;
+                }
+            }
+            return selector;
         }
 
         @Override
@@ -744,26 +774,7 @@ public abstract class CommandStores
         AsyncChain<O> chain = null;
         BiFunction<O, O, O> reducer = mapReduce::reduce;
         Snapshot snapshot = current;
-        StoreSelector selector = new StoreSelector(snapshot.shards.length, snapshot.indexForRange);
-        switch (unseekables.domain())
-        {
-            default: throw new UnhandledEnum(unseekables.domain());
-            case Range:
-            {
-                int minIndex = 0;
-                for (Range range : (AbstractRanges)unseekables)
-                    minIndex = snapshot.lookupByRange.forEachRange(range, selector, selector, null, null, null, null, minIndex);
-                break;
-            }
-            case Key:
-            {
-                int minIndex = 0;
-                for (RoutingKey key : (AbstractUnseekableKeys)unseekables)
-                    minIndex = snapshot.lookupByRange.forEachKey(key, selector, selector, null, null, null, null, minIndex);
-                break;
-            }
-        }
-
+        StoreSelector selector = StoreSelector.select(snapshot, unseekables);
         for (int i = selector.nextSetBit(0, -1); i >= 0 ; i = selector.nextSetBit(i + 1, -1))
         {
             ShardHolder shard = snapshot.shards[i];
@@ -878,28 +889,16 @@ public abstract class CommandStores
 
     public CommandStore select(RoutingKey key)
     {
-        return select(ranges -> ranges.contains(key));
-    }
-
-    public CommandStore select(Route<?> route)
-    {
-        return select(ranges -> ranges.intersects(route));
+        return select(RoutingKeys.of(key));
     }
 
     public CommandStore select(Participants<?> participants)
     {
-        return select(ranges -> ranges.intersects(participants));
-    }
-
-    private CommandStore select(Predicate<Ranges> fn)
-    {
-        ShardHolder[] shards = current.shards;
-        for (ShardHolder holder : shards)
-        {
-            if (fn.test(holder.ranges().currentRanges()))
-                return holder.store;
-        }
-        return any();
+        Snapshot snapshot = current;
+        StoreSelector selector = StoreSelector.select(snapshot, participants);
+        int i = selector.firstSetBit();
+        if (i < 0) return any();
+        return snapshot.shards[i].store;
     }
 
     @VisibleForTesting

--- a/accord-core/src/main/java/accord/local/Commands.java
+++ b/accord-core/src/main/java/accord/local/Commands.java
@@ -1258,8 +1258,8 @@ public class Commands
         RedundantBefore redundantBefore = safeStore.redundantBefore();
         Update update = new Update(current.waitingOn);
         TxnId minWaitingOnTxnId = update.minWaitingOnTxnId();
-        if (minWaitingOnTxnId != null && redundantBefore.hasLocallyRedundantDependencies(update.minWaitingOnTxnId(), current.executeAt(), current.participants().owns()))
-            redundantBefore.removeRedundantDependencies(current.participants().owns(), update);
+        if (minWaitingOnTxnId != null && redundantBefore.hasLocallyRedundantDependencies(update.minWaitingOnTxnId(), current.executeAt(), current.participants().waitsOn()))
+            redundantBefore.removeRedundantDependencies(current.participants().waitsOn(), update);
 
         // if we are a range transaction, being redundant for this transaction does not imply we are redundant for all transactions
         if (redundant != null)

--- a/accord-core/src/main/java/accord/local/Node.java
+++ b/accord-core/src/main/java/accord/local/Node.java
@@ -321,7 +321,7 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
 
     public AsyncResult<?> markDurable(DurableBefore addDurableBefore)
     {
-        return withEpoch(addDurableBefore.maxEpoch(), () -> persistDurableBefore.mergeAndUpdate(DurableBefore.merge(durableBefore, addDurableBefore)))
+        return withEpochExact(addDurableBefore.maxEpoch(), () -> persistDurableBefore.mergeAndUpdate(DurableBefore.merge(durableBefore, addDurableBefore)))
                .beginAsResult();
     }
 
@@ -384,23 +384,20 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
         durabilityService.onEpochRetired(ranges, epoch);
     }
 
+    // TODO (required): audit use of withEpochAtLeast vs withEpochExact
     // TODO (required): audit error handling, as the refactor to provide epoch timeouts appears to have broken a number of coordination
     // TODO (expected): provide a deadline
-    public void withEpoch(EpochSupplier epochSupplier, BiConsumer<Void, Throwable> callback)
+    public void withEpochAtLeast(EpochSupplier epochSupplier, BiConsumer<Void, Throwable> callback)
     {
         if (epochSupplier == null)
             callback.accept(null, null);
         else
-            withEpoch(epochSupplier.epoch(), callback);
+            withEpochAtLeast(epochSupplier.epoch(), callback);
     }
 
-    public void withEpoch(long epoch, BiConsumer<Void, Throwable> callback)
+    public void withEpochAtLeast(long epoch, BiConsumer<Void, Throwable> callback)
     {
-        if (epoch < topology.minEpoch())
-        {
-            callback.accept(null, new TopologyManager.TopologyRetiredException(epoch, topology.minEpoch()));
-        }
-        else if (topology.hasAtLeastEpoch(epoch))
+        if (topology.hasAtLeastEpoch(epoch))
         {
             callback.accept(null, null);
         }
@@ -411,13 +408,9 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
         }
     }
 
-    public void withEpoch(long epoch, BiConsumer<?, ? super Throwable> ifFailure, Runnable ifSuccess)
+    public void withEpochAtLeast(long epoch, BiConsumer<?, ? super Throwable> ifFailure, Runnable ifSuccess)
     {
-        if (epoch < topology.minEpoch())
-        {
-            ifFailure.accept(null, new TopologyManager.TopologyRetiredException(epoch, topology.minEpoch()));
-        }
-        else if (topology.hasAtLeastEpoch(epoch))
+        if (topology.hasAtLeastEpoch(epoch))
         {
             ifSuccess.run();
         }
@@ -431,7 +424,7 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
         }
     }
 
-    public void withEpoch(long epoch, BiConsumer<?, Throwable> ifFailure, Function<Throwable, Throwable> onFailure, Runnable ifSuccess)
+    public void withEpochExact(long epoch, BiConsumer<?, Throwable> ifFailure, Function<Throwable, Throwable> onFailure, Runnable ifSuccess)
     {
         if (epoch < topology.minEpoch())
         {
@@ -452,13 +445,28 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
     }
 
     @Inline
-    public <T> AsyncChain<T> withEpoch(long epoch, Supplier<? extends AsyncChain<T>> supplier)
+    public <T> AsyncChain<T> withEpochExact(long epoch, Supplier<? extends AsyncChain<T>> supplier)
     {
         if (epoch < topology.minEpoch())
         {
             return AsyncChains.failure(new TopologyManager.TopologyRetiredException(epoch, topology.minEpoch()));
         }
         else if (topology.hasEpoch(epoch))
+        {
+            return supplier.get();
+        }
+        else
+        {
+            AsyncChain<T> res = topology.awaitEpoch(epoch).flatMap(ignore -> supplier.get());
+            configService.fetchTopologyForEpoch(epoch);
+            return res;
+        }
+    }
+
+    @Inline
+    public <T> AsyncChain<T> withEpochAtLeast(long epoch, Supplier<? extends AsyncChain<T>> supplier)
+    {
+        if (epoch < topology.minEpoch() || topology.hasEpoch(epoch))
         {
             return supplier.get();
         }
@@ -795,7 +803,7 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
     // TODO (required): plumb deadlineNanos in (perhaps on integration side, but maybe introduce some context we can pass through for the MessageSink)
     public AsyncResult<Result> coordinate(TxnId txnId, Txn txn, long minEpoch, long deadlineNanos)
     {
-        AsyncResult<Result> result = withEpoch(Math.max(txnId.epoch(), minEpoch), () -> initiateCoordination(txnId, txn)).beginAsResult();
+        AsyncResult<Result> result = withEpochExact(Math.max(txnId.epoch(), minEpoch), () -> initiateCoordination(txnId, txn)).beginAsResult();
         coordinating.putIfAbsent(txnId, result);
         result.invoke((success, fail) -> coordinating.remove(txnId, result));
         return result;
@@ -856,7 +864,7 @@ public class Node implements ConfigurationService.Listener, NodeCommandStoreServ
                 return result;
         }
 
-        AsyncResult<Outcome> result = withEpoch(txnId.epoch(), () -> {
+        AsyncResult<Outcome> result = withEpochExact(txnId.epoch(), () -> {
             RecoverFuture<Outcome> future = new RecoverFuture<>();
             RecoverWithRoute.recover(this, txnId, invalidIf, route, null, reportLowEpoch, reportHighEpoch, future);
             return future;

--- a/accord-core/src/main/java/accord/local/cfk/PostProcess.java
+++ b/accord-core/src/main/java/accord/local/cfk/PostProcess.java
@@ -154,7 +154,7 @@ abstract class PostProcess
         for (TxnInfo txn : prev.committedByExecuteAt)
         {
             if (txn.compareTo(newBounds.bootstrappedAt) >= 0)
-                break;
+                continue;
 
             if (txn.is(STABLE))
             {

--- a/accord-core/src/main/java/accord/local/durability/ShardDurability.java
+++ b/accord-core/src/main/java/accord/local/durability/ShardDurability.java
@@ -318,8 +318,8 @@ public class ShardDurability
 
             scheduled = node.agent().awaitStaleId(node, staleId, activeIndex >= 0)
                             .flatMap(
-                                syncId -> node.withEpoch(syncId.epoch(),
-                                    () -> syncPointControl.submit(
+                                syncId -> node.withEpochExact(syncId.epoch(),
+                                                              () -> syncPointControl.submit(
                                         () -> CoordinateSyncPoint.exclusive(node, syncId, (FullRoute<Range>) node.computeRoute(syncId, ranges))
                                                                  .invoke(logSyncPoint(syncId, ranges))
                             )))

--- a/accord-core/src/main/java/accord/messages/GetEphemeralReadDeps.java
+++ b/accord-core/src/main/java/accord/messages/GetEphemeralReadDeps.java
@@ -19,6 +19,7 @@
 package accord.messages;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import accord.coordinate.ExecuteFlag.ExecuteFlags;
 import accord.local.DepsCalculator;
@@ -70,7 +71,13 @@ public class GetEphemeralReadDeps extends TxnRequest.WithUnsynced<GetEphemeralRe
     @Override
     public GetEphemeralReadDepsOk apply(SafeCommandStore safeStore)
     {
-        StoreParticipants participants = StoreParticipants.read(safeStore, scope, txnId, minEpoch, Long.MAX_VALUE);
+        long latestEpoch = Math.max(safeStore.node().epoch(), node.epoch());
+
+        // TODO (desired): only return failure if we've participated in a sync point that could migrate coordination to the newer epoch
+        if (latestEpoch > executionEpoch && safeStore.ranges().removed(executionEpoch, latestEpoch).intersects(scope))
+            return new GetEphemeralReadDepsOk(latestEpoch);
+
+        StoreParticipants participants = StoreParticipants.read(safeStore, scope, txnId, minEpoch, latestEpoch);
         Deps deps;
         ExecuteFlags flags;
         try (DepsCalculator calculator = new DepsCalculator())
@@ -78,7 +85,7 @@ public class GetEphemeralReadDeps extends TxnRequest.WithUnsynced<GetEphemeralRe
              deps = calculateDeps(safeStore, txnId, participants, minEpoch, Timestamp.MAX, false);
              flags = calculator.executeFlags(txnId);
         }
-        return new GetEphemeralReadDepsOk(deps, Math.max(safeStore.node().epoch(), node.epoch()), flags);
+        return new GetEphemeralReadDepsOk(deps, latestEpoch, flags);
     }
 
     @Override
@@ -112,7 +119,7 @@ public class GetEphemeralReadDeps extends TxnRequest.WithUnsynced<GetEphemeralRe
     {
         public enum Flag { READY_TO_EXECUTE }
 
-        public final Deps deps;
+        public final @Nullable Deps deps; // if null, unsuccessful
         public final long latestEpoch;
         public final ExecuteFlags flags;
 
@@ -121,6 +128,13 @@ public class GetEphemeralReadDeps extends TxnRequest.WithUnsynced<GetEphemeralRe
             this.deps = Invariants.nonNull(deps);
             this.latestEpoch = latestEpoch;
             this.flags = flags;
+        }
+
+        public GetEphemeralReadDepsOk(long latestEpoch)
+        {
+            this.deps = null;
+            this.latestEpoch = latestEpoch;
+            this.flags = ExecuteFlags.none();
         }
 
         @Override

--- a/accord-core/src/main/java/accord/messages/Propagate.java
+++ b/accord-core/src/main/java/accord/messages/Propagate.java
@@ -171,7 +171,7 @@ public class Propagate implements PreLoadContext, MapReduceConsume<SafeCommandSt
         long untilEpoch = full.executeAt == null ? highEpoch : Math.max(highEpoch, full.executeAt.epoch());
 
         Route<?> finalRoute = queried;
-        node.withEpoch(highEpoch, propagate, () -> node.mapReduceConsumeLocal(propagate, finalRoute, lowEpoch, untilEpoch, propagate));
+        node.withEpochAtLeast(highEpoch, propagate, () -> node.mapReduceConsumeLocal(propagate, finalRoute, lowEpoch, untilEpoch, propagate));
     }
 
     @Override

--- a/accord-core/src/main/java/accord/messages/ReadData.java
+++ b/accord-core/src/main/java/accord/messages/ReadData.java
@@ -60,6 +60,7 @@ import static accord.messages.TxnRequest.latestRelevantEpochIndex;
 import static accord.primitives.Routables.Slice.Minimal;
 import static accord.primitives.Txn.Kind.Write;
 import static accord.utils.Invariants.illegalState;
+import static accord.utils.Invariants.nonNull;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
 // TODO (required): (v1.1) if one shard times out waiting to reply, but another shard produces a reply, return a partial response (or response with suitably populated unavailable)
@@ -364,13 +365,24 @@ public abstract class ReadData implements PreLoadContext, Request, MapReduceCons
 
     static Ranges unavailable(SafeCommandStore safeStore, Command command)
     {
-        Timestamp executeAt = command.executesAtLeast();
-        if (executeAt == null) executeAt = command.executeAtOrTxnId();
-        // TODO (required): for awaitsOnlyDeps commands, if we cannot infer an actual executeAtLeast we should confirm no situation where txnId is not an adequately conservative value for unavailable/unsafeToRead
-        Ranges ranges = safeStore.unsafeToReadAt(executeAt);
-        if (ranges.size() > command.route().size())
-            ranges = ranges.intersecting(command.route(), Minimal);
-        return ranges;
+        // note: syncpoints and ephemeral reads simply consume the latest information (whatever it is),
+        //  which is represented by the latest possible safeToRead entry (which is only updated on successful bootstrap)
+        //  We DO NOT use executesAtLeast here, which is used only to compute retryInFutureEpoch, indicating we may not
+        //  own data new enough to answer the query.
+        TxnId txnId = command.txnId();
+        Timestamp executeAt = command.executeAtIfKnown();
+        if (executeAt == null)
+        {
+            Invariants.require(txnId.awaitsOnlyDeps());
+            executeAt = txnId;
+        }
+        Timestamp readAt = txnId.awaitsOnlyDeps() ? Timestamp.MAX : executeAt;
+        Ranges safeToRead = safeStore.safeToReadAt(readAt);
+        Ranges reads = safeStore.ranges().allAt(executeAt);
+        Ranges unsafeToRead = reads.without(safeToRead);
+        if (unsafeToRead.size() > command.route().size())
+            unsafeToRead = unsafeToRead.intersecting(command.route(), Minimal);
+        return unsafeToRead;
     }
 
     protected void read(SafeCommandStore safeStore, Command command)
@@ -391,13 +403,26 @@ public abstract class ReadData implements PreLoadContext, Request, MapReduceCons
         }
 
         CommandStore unsafeStore = safeStore.commandStore();
-        Participants<?> executes = command.participants().stillExecutes().without(unavailable);
+        // note: we DO NOT use stillExecutes() here, as we do not know what the remote replica requires
+        StoreParticipants participants = command.participants();
+        Participants<?> executes = nonNull(participants.executes());
+        if (executes != participants.stillExecutes() && !txnId.isSystemTxn())
+        {
+            // if stillExecutes has been filtered, we may have also filtered
+            PartialTxn txn = command.partialTxn();
+            Participants<?> covers = txn == null ? executes.slice(0, 0) : txn.keys().toParticipants();
+            Participants<?> missing = executes.without(covers).without(unavailable);
+            if (!missing.isEmpty())
+                unavailable = unavailable.with(missing.toRanges());
+        }
+        executes = executes.without(unavailable);
         if (executes.isEmpty())
         {
             readComplete(unsafeStore, null, unavailable);
         }
         else
         {
+            Ranges finalUnavailable = unavailable;
             beginRead(safeStore, command.executeAt(), command.partialTxn(), executes).begin((next, throwable) -> {
                 if (throwable != null)
                 {
@@ -407,7 +432,7 @@ public abstract class ReadData implements PreLoadContext, Request, MapReduceCons
                 }
                 else
                 {
-                    readComplete(unsafeStore, next, unavailable);
+                    readComplete(unsafeStore, next, finalUnavailable);
                 }
             });
         }

--- a/accord-core/src/main/java/accord/primitives/Deps.java
+++ b/accord-core/src/main/java/accord/primitives/Deps.java
@@ -410,7 +410,7 @@ public class Deps
         return TxnId.nonNullOrMax(maxKeyDep, maxRangeDep);
     }
 
-    public TxnId maxTxnId(TxnId orElse)
+    public TxnId maxTxnId(@Nullable TxnId orElse)
     {
         return TxnId.nonNullOrMax(maxTxnId(), orElse);
     }
@@ -420,6 +420,20 @@ public class Deps
         TxnId minKeyDep = keyDeps.isEmpty() ? null : keyDeps.txnId(0);
         TxnId minRangeDep = rangeDeps.isEmpty() ? null : rangeDeps.txnId(0);
         return TxnId.nonNullOrMin(minKeyDep, minRangeDep);
+    }
+
+    public @Nullable TxnId minTxnId(Range range, @Nullable TxnId orElse)
+    {
+        TxnId minKeyDep = keyDeps.minTxnId(range, orElse);
+        TxnId minRangeDep = rangeDeps.minTxnId(range, orElse);
+        return TxnId.nonNullOrMin(minKeyDep, minRangeDep);
+    }
+
+    public @Nullable TxnId maxTxnId(Range range, @Nullable TxnId orElse)
+    {
+        TxnId maxKeyDep = keyDeps.maxTxnId(range, orElse);
+        TxnId maxRangeDep = rangeDeps.maxTxnId(range, orElse);
+        return TxnId.nonNullOrMax(maxKeyDep, maxRangeDep);
     }
 
     public TxnId minTxnId(TxnId orElse)

--- a/accord-core/src/main/java/accord/primitives/KeyDeps.java
+++ b/accord-core/src/main/java/accord/primitives/KeyDeps.java
@@ -495,6 +495,64 @@ public class KeyDeps implements Iterable<Map.Entry<RoutingKey, TxnId>>, KeyOrRan
         }
     }
 
+    /**
+     * Find the minimum intersecting transaction id for the range
+     */
+    public TxnId minTxnId(Range range, TxnId orElse)
+    {
+        int startKeyIndex = keys.indexOf(range.start());
+        if (startKeyIndex < 0) startKeyIndex = -1 - startKeyIndex;
+        else if (!range.startInclusive()) ++startKeyIndex;
+
+        int endKeyIndex = keys.indexOf(range.end());
+        if (endKeyIndex < 0) endKeyIndex = -1 - startKeyIndex;
+        else if (range.endInclusive()) ++endKeyIndex;
+
+        if (endKeyIndex <= startKeyIndex)
+            return orElse;
+
+        int minIndex = Integer.MAX_VALUE;
+        for (int keyIndex = startKeyIndex ; keyIndex < endKeyIndex ; ++keyIndex)
+        {
+            int index = startOffset(keyIndex);
+            minIndex = Math.min(minIndex, keysToTxnIds[index]);
+        }
+
+        if (minIndex == Integer.MAX_VALUE)
+            return orElse;
+
+        return txnIds[minIndex];
+    }
+
+    /**
+     * Find the maximum intersecting transaction id for the range
+     */
+    public TxnId maxTxnId(Range range, TxnId orElse)
+    {
+        int startKeyIndex = keys.indexOf(range.start());
+        if (startKeyIndex < 0) startKeyIndex = -1 - startKeyIndex;
+        else if (!range.startInclusive()) ++startKeyIndex;
+
+        int endKeyIndex = keys.indexOf(range.end());
+        if (endKeyIndex < 0) endKeyIndex = -1 - startKeyIndex;
+        else if (range.endInclusive()) ++endKeyIndex;
+
+        if (endKeyIndex <= startKeyIndex)
+            return orElse;
+
+        int maxIndex = -1;
+        for (int keyIndex = startKeyIndex ; keyIndex < endKeyIndex ; ++keyIndex)
+        {
+            int index = endOffset(keyIndex) - 1;
+            maxIndex = Math.max(maxIndex, keysToTxnIds[index]);
+        }
+
+        if (maxIndex == -1)
+            return orElse;
+
+        return txnIds[maxIndex];
+    }
+
     public void forEach(RoutingKey key, IndexedConsumer<TxnId> forEach)
     {
         int keyIndex = keys.indexOf(key);

--- a/accord-core/src/main/java/accord/primitives/LatestDeps.java
+++ b/accord-core/src/main/java/accord/primitives/LatestDeps.java
@@ -69,7 +69,7 @@ public class LatestDeps extends ReducingRangeMap<LatestDeps.LatestEntry>
     {
         if (!node.topology().hasEpoch(executeAt.epoch()))
         {
-            node.withEpoch(executeAt.epoch(), failureCallback, () -> withCommitted(adapter, node, merge, route, ballot, txnId, executeAt, txn, failureCallback, withDeps));
+            node.withEpochAtLeast(executeAt.epoch(), failureCallback, () -> withCommitted(adapter, node, merge, route, ballot, txnId, executeAt, txn, failureCallback, withDeps));
             return;
         }
 
@@ -97,7 +97,7 @@ public class LatestDeps extends ReducingRangeMap<LatestDeps.LatestEntry>
         Invariants.require(sendTo == null || selectSendTo != null);
         if (!node.topology().hasEpoch(executeAt.epoch()))
         {
-            node.withEpoch(executeAt.epoch(), failureCallback, () -> withStable(adapter, node, merge, alreadyStableDeps, require, sendTo, selectSendTo, route, ballot, txnId, executeAt, txn, failureCallback, withDeps));
+            node.withEpochAtLeast(executeAt.epoch(), failureCallback, () -> withStable(adapter, node, merge, alreadyStableDeps, require, sendTo, selectSendTo, route, ballot, txnId, executeAt, txn, failureCallback, withDeps));
             return;
         }
 
@@ -146,7 +146,7 @@ public class LatestDeps extends ReducingRangeMap<LatestDeps.LatestEntry>
         Invariants.require(sendTo == null || selectSendTo != null);
         if (!node.topology().hasEpoch(executeAt.epoch()))
         {
-            node.withEpoch(executeAt.epoch(), failureCallback, () -> withStable(adapter, node, txnId, executeAt, txn, alreadyStableDeps, require, sendTo, selectSendTo, route, failureCallback, withDeps));
+            node.withEpochAtLeast(executeAt.epoch(), failureCallback, () -> withStable(adapter, node, txnId, executeAt, txn, alreadyStableDeps, require, sendTo, selectSendTo, route, failureCallback, withDeps));
         }
         else if (require.isEmpty())
         {

--- a/accord-core/src/main/java/accord/primitives/RangeDeps.java
+++ b/accord-core/src/main/java/accord/primitives/RangeDeps.java
@@ -839,6 +839,42 @@ public class RangeDeps implements Iterable<Map.Entry<Range, TxnId>>, KeyOrRangeD
         return ranges.length;
     }
 
+    static class Min extends SimpleCollector<Object, Object>
+    {
+        int minIndex = Integer.MAX_VALUE;
+        @Override
+        public void accept(Range[] ranges, int[] rangesToTxnIds, Object p1, Object p2, int fromIndex, int toIndex)
+        {
+            for (int i = startOffset(ranges, rangesToTxnIds, fromIndex), maxi = endOffset(rangesToTxnIds, toIndex); i < maxi ; ++i)
+                minIndex = Math.min(minIndex, rangesToTxnIds[i]);
+        }
+    }
+
+    public TxnId minTxnId(Range range, TxnId orElse)
+    {
+        Min min = new Min();
+        forEach(range, min, min, ranges, rangesToTxnIds, null, null, 0);
+        return min.minIndex == Integer.MAX_VALUE ? orElse : txnIds[min.minIndex];
+    }
+
+    static class Max extends SimpleCollector<Object, Object>
+    {
+        int maxIndex = -1;
+        @Override
+        public void accept(Range[] ranges, int[] rangesToTxnIds, Object p1, Object p2, int fromIndex, int toIndex)
+        {
+            for (int i = startOffset(ranges, rangesToTxnIds, fromIndex), maxi = endOffset(rangesToTxnIds, toIndex); i < maxi ; ++i)
+                maxIndex = Math.max(maxIndex, rangesToTxnIds[i]);
+        }
+    }
+
+    public TxnId maxTxnId(Range range, TxnId orElse)
+    {
+        Max max = new Max();
+        forEach(range, max, max, ranges, rangesToTxnIds, null, null, 0);
+        return max.maxIndex < 0 ? orElse : txnIds[max.maxIndex];
+    }
+
     public TxnId maxTxnId(TxnId orElse)
     {
         return txnIdCount() == 0 ? orElse : txnId(txnIdCount() - 1);
@@ -896,6 +932,17 @@ public class RangeDeps implements Iterable<Map.Entry<Range, TxnId>>, KeyOrRangeD
     public boolean isSearchable()
     {
         return searchable != null;
+    }
+
+    static abstract class SimpleCollector<P1, P2> implements
+            IndexedRangeQuadConsumer<Range[], int[], P1, P2>,
+            IndexedQuadConsumer<Range[], int[], P1, P2>
+    {
+        @Override
+        public void accept(Range[] ranges, int[] rangesToTxnIds, P1 p1, P2 p2, int rangeIndex)
+        {
+            accept(ranges, rangesToTxnIds, p1, p2, rangeIndex, rangeIndex + 1);
+        }
     }
 
     static class RangeCollector implements

--- a/accord-core/src/main/java/accord/topology/Topology.java
+++ b/accord-core/src/main/java/accord/topology/Topology.java
@@ -22,6 +22,7 @@ import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -600,6 +601,24 @@ public class Topology
             {
                 return supersetIndexes.length;
             }
+
+            @Override
+            public Iterator<Shard> iterator()
+            {
+                return new Iterator<>()
+                {
+                    int i = 0;
+                    @Override public boolean hasNext() { return i < supersetIndexes.length; }
+                    @Override public Shard next() { return shards[supersetIndexes[i++]]; }
+                };
+            }
+
+            @Override
+            public void forEach(Consumer<? super Shard> consumer)
+            {
+                for (int i = 0; i < supersetIndexes.length ; ++i)
+                    consumer.accept(shards[supersetIndexes[i]]);
+            }
         };
     }
 
@@ -607,13 +626,6 @@ public class Topology
     {
         for (int i : supersetIndexes)
             forEach.accept(shards[i]);
-    }
-
-    public <A> A reduce(A zero,
-                        Predicate<Shard> filter,
-                        BiFunction<A, ? super Shard, A> reducer)
-    {
-        return Utils.reduce(zero, shards(), filter, reducer);
     }
 
     public SortedArrayList<Id> nodes()

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -1490,5 +1490,10 @@ public class TopologyManager
         {
             super(String.format("Topology %s retired. Min topology %d", epoch, minEpoch));
         }
+
+        public TopologyRetiredException(String message, TopologyRetiredException t)
+        {
+            super(message, t);
+        }
     }
 }

--- a/accord-core/src/main/java/accord/utils/SortedArrays.java
+++ b/accord-core/src/main/java/accord/utils/SortedArrays.java
@@ -23,8 +23,10 @@ import java.util.AbstractList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.IntBinaryOperator;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
@@ -114,6 +116,25 @@ public class SortedArrays
         public boolean containsAll(SortedArrayList<T> test)
         {
             return isSubset(Comparable::compareTo, test.array, 0, test.array.length, array, 0, array.length);
+        }
+
+        @Override
+        public final void forEach(Consumer<? super T> action)
+        {
+            for (T t : array)
+                action.accept(t);
+        }
+
+        @Override
+        @Nonnull
+        public final Iterator<T> iterator()
+        {
+            return new Iterator<T>()
+            {
+                int i = 0;
+                @Override public boolean hasNext() { return i < array.length; }
+                @Override public T next() { return array[i++]; }
+            };
         }
 
         @Override

--- a/accord-core/src/test/java/accord/impl/basic/Cluster.java
+++ b/accord-core/src/test/java/accord/impl/basic/Cluster.java
@@ -276,8 +276,13 @@ public class Cluster
     public void processAll()
     {
         List<Pending> pending = new ArrayList<>();
-        while (this.pending.size() > 0)
-            pending.add(this.pending.poll());
+        {
+            // TODO (expected): this doesn't actually process all pending, as any queued tasks on executors aren't processed.
+            //   should we perhaps queue them and then process them?
+            Pending next;
+            while (null != (next = this.pending.poll()))
+                pending.add(next);
+        }
 
         for (Pending next : pending)
         {

--- a/accord-core/src/test/java/accord/impl/basic/DelayedCommandStores.java
+++ b/accord-core/src/test/java/accord/impl/basic/DelayedCommandStores.java
@@ -336,6 +336,7 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
                     protected Cancellable start(BiConsumer<? super T, Throwable> callback)
                     {
                         boolean wasEmpty = pending.isEmpty();
+                        executor.preregister(task);
                         pending.add(task);
                         if (wasEmpty)
                             runNextTask();
@@ -344,6 +345,7 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
                             if (pending.peek() != task)
                             {
                                 pending.remove(task);
+                                executor.cancel(task);
                                 task.cancel(false);
                             }
                         };
@@ -362,7 +364,7 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
 
             next.invoke(agent()); // used to track unexpected exceptions and notify simulations
             next.invoke(this::afterExecution);
-            executor.execute(next);
+            executor.executePreregistered(next);
         }
 
         private void afterExecution()

--- a/accord-core/src/test/java/accord/impl/basic/MonitoredPendingQueue.java
+++ b/accord-core/src/test/java/accord/impl/basic/MonitoredPendingQueue.java
@@ -76,6 +76,12 @@ public class MonitoredPendingQueue implements PendingQueue
     }
 
     @Override
+    public void preregister(Pending item)
+    {
+        wrapped.preregister(item);
+    }
+
+    @Override
     public boolean remove(Pending item)
     {
         return wrapped.remove(item);

--- a/accord-core/src/test/java/accord/impl/basic/PendingQueue.java
+++ b/accord-core/src/test/java/accord/impl/basic/PendingQueue.java
@@ -27,6 +27,15 @@ public interface PendingQueue extends Iterable<Pending>
     void add(Pending item);
     void addNoDelay(Pending item);
     void add(Pending item, long delay, TimeUnit units);
+
+    /**
+     * Register an item we intend to add later.
+     * This is primarily for tracking the number of recurring tasks there are pending to run,
+     * including those that are being tracked pre-submission as e.g. tasks in a logical executor that cannot be
+     * scheduled until the preceding tasks have completed.
+     */
+    void preregister(Pending item);
+
     boolean remove(Pending item);
     Pending poll();
     List<Pending> drain(Predicate<Pending> toDrain);

--- a/accord-core/src/test/java/accord/impl/basic/RandomDelayQueue.java
+++ b/accord-core/src/test/java/accord/impl/basic/RandomDelayQueue.java
@@ -19,6 +19,7 @@
 package accord.impl.basic;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -102,6 +103,7 @@ public class RandomDelayQueue implements PendingQueue
     private final LongSupplier jitterMillis;
     long now;
     int seq;
+    final IdentityHashMap<Pending, Boolean> preregistered = new IdentityHashMap<>();
     int recurring;
 
     public RandomDelayQueue(RandomSource random)
@@ -123,9 +125,9 @@ public class RandomDelayQueue implements PendingQueue
     @Override
     public void addNoDelay(Pending item)
     {
-        queue.add(new Item(now, seq++, item));
-        if (isRecurring(item))
+        if (null == preregistered.remove(item) && isRecurring(item))
             ++recurring;
+        queue.add(new Item(now, seq++, item));
     }
 
     @Override
@@ -133,7 +135,16 @@ public class RandomDelayQueue implements PendingQueue
     {
         if (delay < 0)
             throw illegalArgument("Delay must be positive or 0, but given " + delay);
+        if (null == preregistered.remove(item) && isRecurring(item))
+            ++recurring;
         queue.add(new Item(now + units.toMillis(delay) + jitterMillis.getAsLong(), seq++, item));
+    }
+
+    @Override
+    public void preregister(Pending item)
+    {
+        if (null != preregistered.put(item, true))
+            throw new IllegalStateException();
         if (isRecurring(item))
             ++recurring;
     }
@@ -141,9 +152,12 @@ public class RandomDelayQueue implements PendingQueue
     @Override
     public boolean remove(Pending item)
     {
+        if (!queue.removeIf(i -> i.item == item) && preregistered.remove(item) == null)
+            return false;
+
         if (isRecurring(item))
             --recurring;
-        return queue.removeIf(i -> i.item == item);
+        return true;
     }
 
     @Override
@@ -165,19 +179,18 @@ public class RandomDelayQueue implements PendingQueue
     {
         List<Item> items = new ArrayList<>(queue);
         queue.clear();
-        recurring = 0;
         List<Pending> ret = new ArrayList<>();
         for (Item item : items)
         {
             if (toDrain.test(item.item))
             {
+                if (isRecurring(item.item))
+                    --recurring;
                 ret.add(item.item);
             }
             else
             {
                 queue.add(item);
-                if (isRecurring(item.item))
-                    ++recurring;
             }
         }
         return ret;
@@ -198,7 +211,7 @@ public class RandomDelayQueue implements PendingQueue
     @Override
     public boolean hasNonRecurring()
     {
-        return recurring != queue.size();
+        return recurring != queue.size() + preregistered.size();
     }
 
     @Override

--- a/accord-core/src/test/java/accord/impl/basic/SimulatedDelayedExecutorService.java
+++ b/accord-core/src/test/java/accord/impl/basic/SimulatedDelayedExecutorService.java
@@ -176,6 +176,21 @@ public class SimulatedDelayedExecutorService extends TaskExecutorService impleme
         pending.add(task);
     }
 
+    public void preregister(Task<?> task)
+    {
+        pending.preregister(task);
+    }
+
+    public void cancel(Task<?> task)
+    {
+        pending.remove(task);
+    }
+
+    public void executePreregistered(Task<?> task)
+    {
+        pending.add(task);
+    }
+
     private void schedule(Task<?> task, long delay, TimeUnit unit)
     {
         pending.add(task, delay, unit);

--- a/accord-core/src/test/java/accord/impl/list/ListRequest.java
+++ b/accord-core/src/test/java/accord/impl/list/ListRequest.java
@@ -210,7 +210,7 @@ public class ListRequest implements Request
             if (node.epoch() < txnId.epoch())
             {
                 RoutingKey hk = homeKey;
-                node.withEpoch(txnId.epoch(), (success, fail) -> checkOnResult(hk, txnId, attempt + 1, t));
+                node.withEpochAtLeast(txnId.epoch(), (success, fail) -> checkOnResult(hk, txnId, attempt + 1, t));
                 return;
             }
 


### PR DESCRIPTION
 - Don't assume stillExecutes applies to remote request - must mark unavailable any keys we don't have the txn definition for
 - Don't exit notifyManagedPreBootstrap notify loop early, as could have later transactions with lower txnId
 - CoordinateEphemeralRead must retry if insufficient responses from replicas that still own the range