### PR TITLE
Fixes 251228

### DIFF
--- a/accord-core/src/main/java/accord/api/ProtocolModifiers.java
+++ b/accord-core/src/main/java/accord/api/ProtocolModifiers.java
@@ -127,7 +127,7 @@ public class ProtocolModifiers
                         case "accept": accept = include; Invariants.require(cfp == DoNotChase, "Invalid to specify ChaseFixedPoint.Chase for accept"); break;
                         case "commit": commit = include; Invariants.require(cfp == DoNotChase, "Invalid to specify ChaseFixedPoint.Chase for commit"); break;
                         case "stable": stable = include; Invariants.require(cfp == DoNotChase, "Invalid to specify ChaseFixedPoint.Chase for stable"); break;
-                        case "recover": recover = include; Invariants.require(cfp == DoNotChase, "Invalid to specify ChaseFixedPoint.Chase for stable"); break;
+                        case "recover": recover = include; Invariants.require(cfp == DoNotChase, "Invalid to specify ChaseFixedPoint.Chase for recover"); break;
                     }
                 }
 
@@ -194,6 +194,32 @@ public class ProtocolModifiers
         }
     }
 
+    public static class RangeSpecParam
+    {
+        // Implementations may set this prior to creating any Range object to specify whether the start or end bound of its ranges are inclusive.
+        public static boolean END_INCLUSIVE = true;
+    }
+    public static class RangeSpec
+    {
+        public static final boolean END_INCLUSIVE = RangeSpecParam.END_INCLUSIVE;
+        public static boolean isEndInclusive()
+        {
+            return END_INCLUSIVE;
+        }
+        public static boolean isEndExclusive()
+        {
+            return !END_INCLUSIVE;
+        }
+        public static boolean isStartInclusive()
+        {
+            return !END_INCLUSIVE;
+        }
+        public static boolean isStartExclusive()
+        {
+            return END_INCLUSIVE;
+        }
+    }
+
     public static class Toggles
     {
         private static FastPaths permittedFastPaths = new FastPaths(FastPath.values());
@@ -205,9 +231,24 @@ public class ProtocolModifiers
         public static MediumPath defaultMediumPath() { return defaultMediumPath; }
         public static void setDefaultMediumPath(MediumPath newDefaultMediumPath) { defaultMediumPath = newDefaultMediumPath; }
 
+        private static boolean recoveryAwaitsSupersedingSyncPoints = true;
+        public static boolean recoveryAwaitsSupersedingSyncPoints() { return recoveryAwaitsSupersedingSyncPoints; }
+        public static void setRecoveryAwaitsSupersedingSyncPoints(boolean newRecoveryAwaitsSupersedingSyncPoints) { recoveryAwaitsSupersedingSyncPoints = newRecoveryAwaitsSupersedingSyncPoints; }
+
+        // TODO (required): default this to false once released support via recoveryAwaitsSupersedingSyncPoints
+        private static boolean syncPointsTrackUnstableMediumPathDependencies = true;
+        public static boolean syncPointsTrackUnstableMediumPathDependencies() { return syncPointsTrackUnstableMediumPathDependencies; }
+        public static void setSyncPointsTrackUnstableMediumPathDependencies(boolean newSyncPointsTrackUnstableMediumPathDependencies) { syncPointsTrackUnstableMediumPathDependencies = newSyncPointsTrackUnstableMediumPathDependencies; }
+
+        private static boolean recoverPartialAcceptPhaseIfNoFastPath = false;
+        public static boolean recoverPartialAcceptPhaseIfNoFastPath() { return recoverPartialAcceptPhaseIfNoFastPath; }
+        public static void setRecoverPartialAcceptPhaseIfNoFastPath(boolean newSyncPointsRecoverPartialAcceptPhase) {recoverPartialAcceptPhaseIfNoFastPath = newSyncPointsRecoverPartialAcceptPhase; }
+
         private static boolean filterDuplicateDependenciesFromAcceptReply = true;
         public static boolean filterDuplicateDependenciesFromAcceptReply() { return filterDuplicateDependenciesFromAcceptReply; }
         public static void setFilterDuplicateDependenciesFromAcceptReply(boolean newFilterDuplicateDependenciesFromAcceptReply) { filterDuplicateDependenciesFromAcceptReply = newFilterDuplicateDependenciesFromAcceptReply; }
+
+
 
         public enum SendStableMessages { TO_ALL, FOR_READS, FOR_READS_OR_NONE_IF_FASTEXEC}
         private static SendStableMessages sendStableMessages = FOR_READS_OR_NONE_IF_FASTEXEC;

--- a/accord-core/src/main/java/accord/coordinate/ExecuteEphemeralRead.java
+++ b/accord-core/src/main/java/accord/coordinate/ExecuteEphemeralRead.java
@@ -54,7 +54,6 @@ import accord.utils.UnhandledEnum;
 
 import static accord.api.ProtocolModifiers.Toggles.permitLocalExecution;
 import static accord.coordinate.ExecutePath.EPHEMERAL;
-import static accord.coordinate.ExecutePath.FAST;
 import static accord.coordinate.ReadCoordinator.Action.Approve;
 import static accord.coordinate.ReadCoordinator.Action.ApprovePartial;
 import static accord.primitives.Status.Phase.Execute;

--- a/accord-core/src/main/java/accord/coordinate/ExecuteTxn.java
+++ b/accord-core/src/main/java/accord/coordinate/ExecuteTxn.java
@@ -399,20 +399,23 @@ public class ExecuteTxn extends ReadCoordinator<Result, ReadReply>
         }
         else
         {
-            stable.informStableOnceQuorum();
-            if (sendOnlyReadStableMessages())
+            if (!isPrivilegedVoteCommitting)
             {
-                // send additional stable messages to record the transaction outcome
-                Commit.Kind kind = commitKind();
-                if (!candidates.isEmpty())
+                stable.informStableOnceQuorum();
+                if (sendOnlyReadStableMessages())
                 {
-                    for (int i = 0, size = candidates.size() ; i < size ; ++i)
-                        sendStableOnly(candidates.get(i), kind);
-                }
-                if (unstableFastReads != null)
-                {
-                    for (Node.Id to : unstableFastReads)
-                        sendStableOnly(to, kind);
+                    // send additional stable messages to record the transaction outcome
+                    Commit.Kind kind = commitKind();
+                    if (!candidates.isEmpty())
+                    {
+                        for (int i = 0, size = candidates.size() ; i < size ; ++i)
+                            sendStableOnly(candidates.get(i), kind);
+                    }
+                    if (unstableFastReads != null)
+                    {
+                        for (Node.Id to : unstableFastReads)
+                            sendStableOnly(to, kind);
+                    }
                 }
             }
             invokeCallback(null, failure);
@@ -430,9 +433,8 @@ public class ExecuteTxn extends ReadCoordinator<Result, ReadReply>
     @Override
     public void onFailure(Id from, Throwable failure)
     {
-        super.onFailure(from, failure);
-        if (isPrivilegedVoteCommitting && from.id == node.id().id)
-            tryFinishOnFailure();
+        if (isPrivilegedVoteCommitting && from.id == node.id().id) finishWithFailure(failure);
+        else super.onFailure(from, failure);
     }
 
     protected CoordinationAdapter<Result> adapter()

--- a/accord-core/src/main/java/accord/coordinate/FetchDurableBefore.java
+++ b/accord-core/src/main/java/accord/coordinate/FetchDurableBefore.java
@@ -52,8 +52,10 @@ public class FetchDurableBefore extends AbstractCoordination<Ranges, DurableBefo
     {
         super.start();
         contact(ignore -> new GetDurableBefore(), id -> !node.id().equals(id));
-        markSelfContacted();
-        onSuccess(node.id(), new DurableBeforeReply(node.durableBefore()));
+        executor.executeMaybeImmediately(() -> {
+            markSelfContacted();
+            onSuccess(node.id(), new DurableBeforeReply(node.durableBefore()));
+        });
     }
 
     public static AsyncChain<DurableBefore> catchup(Node node)

--- a/accord-core/src/main/java/accord/coordinate/KeyBarriers.java
+++ b/accord-core/src/main/java/accord/coordinate/KeyBarriers.java
@@ -24,6 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import accord.api.RoutingKey;
+import accord.api.VisibleForImplementation;
 import accord.local.CommandSummaries;
 import accord.local.MapReduceConsumeCommandStores;
 import accord.local.Node;
@@ -48,8 +49,6 @@ import javax.annotation.Nullable;
 import static accord.local.CommandSummaries.SummaryStatus.APPLIED;
 import static accord.local.CommandSummaries.SummaryStatus.COMMITTED;
 import static accord.local.CommandSummaries.SummaryStatus.INVALIDATED;
-import static accord.local.CommandSummaries.ComputeIsDep.IGNORE;
-import static accord.local.CommandSummaries.TestStartedAt.STARTED_AFTER;
 import static accord.local.durability.DurabilityService.SyncLocal.NoLocal;
 import static accord.local.durability.DurabilityService.SyncLocal.Self;
 import static accord.local.durability.DurabilityService.SyncRemote.NoRemote;
@@ -63,6 +62,7 @@ import static accord.utils.Invariants.illegalState;
  * Facility for finding existing key transactions that can serve as a barrier transaction,
  * ensuring all reads/writes after some point in the txn log have been executed.
  */
+@VisibleForImplementation
 public class KeyBarriers
 {
     @SuppressWarnings("unused")
@@ -84,7 +84,7 @@ public class KeyBarriers
         }
     }
 
-    public static AsyncResult<Found> find(Node node, Timestamp min, RoutingKey key, SyncLocal syncLocal, SyncRemote syncRemote)
+    public static AsyncResult<Found> find(Node node, TxnId min, RoutingKey key, SyncLocal syncLocal, SyncRemote syncRemote)
     {
         Find find = new Find(min, key, syncLocal, syncRemote);
         node.commandStores().mapReduceConsume(min.epoch(), Long.MAX_VALUE, find);
@@ -98,16 +98,16 @@ public class KeyBarriers
      * For Applied we can return success immediately with the executeAt epoch. For PreApplied we can add
      * a listener for when it transitions to Applied and then return success.
      */
-    static class Find extends MapReduceConsumeCommandStores<RoutingKeys, Found> implements CommandSummaries.AllCommandVisitor
+    static class Find extends MapReduceConsumeCommandStores<RoutingKeys, Found> implements CommandSummaries.SupersedingCommandVisitor
     {
         final AsyncResults.SettableByCallback<Found> result = new AsyncResults.SettableByCallback<>();
-        final Timestamp min;
+        final TxnId min;
         final RoutingKey find;
         final SyncLocal syncLocal;
         final SyncRemote syncRemote;
         Found found;
 
-        Find(Timestamp min, RoutingKey find, SyncLocal syncLocal, SyncRemote syncRemote)
+        Find(TxnId min, RoutingKey find, SyncLocal syncLocal, SyncRemote syncRemote)
         {
             super(RoutingKeys.of(find));
             this.min = min;
@@ -122,7 +122,7 @@ public class KeyBarriers
             // Barriers are trying to establish that committed transactions are applied before the barrier (or in this case just minEpoch)
             // so all existing transaction types should ensure that at this point. An earlier txnid may have an executeAt that is after
             // this barrier or the transaction we listen on and that is fine
-            safeStore.visit(scope, TxnId.NONE, Ws, STARTED_AFTER, min, IGNORE, this);
+            safeStore.visit(scope, min, Ws, this);
             return found;
         }
 

--- a/accord-core/src/main/java/accord/coordinate/Propose.java
+++ b/accord-core/src/main/java/accord/coordinate/Propose.java
@@ -31,6 +31,7 @@ import accord.local.Node;
 import accord.local.Node.Id;
 import accord.local.SequentialAsyncExecutor;
 import accord.messages.Accept;
+import accord.messages.Accept.AcceptFlags;
 import accord.messages.Accept.AcceptReply;
 import accord.messages.Callback;
 import accord.primitives.Ballot;
@@ -47,9 +48,9 @@ import accord.utils.Invariants;
 import accord.utils.SortedListMap;
 import accord.utils.Rethrowable;
 
-import static accord.api.ProtocolModifiers.Toggles.filterDuplicateDependenciesFromAcceptReply;
 import static accord.coordinate.tracking.RequestStatus.Failed;
 import static accord.coordinate.tracking.RequestStatus.Success;
+import static accord.messages.Accept.AcceptFlags.filterDeps;
 import static accord.messages.Commit.Invalidate.commitInvalidate;
 import static accord.primitives.Routables.Slice.Minimal;
 import static accord.primitives.Status.AcceptedInvalidate;
@@ -66,6 +67,7 @@ abstract class Propose<R> extends AbstractCoordination<FullRoute<?>, R, AcceptRe
 
     final Timestamp executeAt;
     final QuorumTracker tracker;
+    final int acceptFlags;
 
     Propose(Node node, SequentialAsyncExecutor executor, Topologies topologies, Accept.Kind kind, Ballot ballot, TxnId txnId, Txn txn, Route<?> require, FullRoute<?> route, Timestamp executeAt, Deps deps, BiConsumer<? super R, Throwable> callback)
     {
@@ -77,6 +79,7 @@ abstract class Propose<R> extends AbstractCoordination<FullRoute<?>, R, AcceptRe
         this.deps = deps;
         this.executeAt = executeAt;
         this.tracker = new QuorumTracker(topologies);
+        this.acceptFlags = AcceptFlags.encode(txnId, require != scope);
         Invariants.require(txnId.isSyncPoint() || deps.maxTxnId(txnId).compareTo(executeAt) <= 0,
                            "Attempted to propose %s with an earlier executeAt than a conflicting transaction it witnessed: %s vs executeAt: %s", txnId, deps, executeAt);
         Invariants.require(topologies.currentEpoch() == executeAt.epoch());
@@ -86,7 +89,7 @@ abstract class Propose<R> extends AbstractCoordination<FullRoute<?>, R, AcceptRe
     void start()
     {
         super.start();
-        contact(to -> new Accept(to, tracker.topologies(), kind, ballot, txnId, scope, executeAt, deps, require != scope));
+        contact(to -> new Accept(to, tracker.topologies(), kind, ballot, txnId, scope, executeAt, deps, acceptFlags));
     }
 
     @Override
@@ -163,6 +166,9 @@ abstract class Propose<R> extends AbstractCoordination<FullRoute<?>, R, AcceptRe
     Deps mergeNewDeps()
     {
         SortedListMap<Node.Id, AcceptReply> oks = finishOks();
+        if (!AcceptFlags.calculateDeps(acceptFlags))
+            return Deps.NONE;
+
         Deps deps = Deps.merge(oks, oks.domainSize(), SortedListMap::getValue, ok -> ok.deps);
         if (Faults.discardPreAcceptDeps(txnId))
             return deps;
@@ -170,8 +176,12 @@ abstract class Propose<R> extends AbstractCoordination<FullRoute<?>, R, AcceptRe
         if (txnId.is(TrackStable))
         {
             // we must not propose as stable any dep < txnId that we did not propose as part of this phase
-            if (filterDuplicateDependenciesFromAcceptReply())
+            if (!filterDeps(acceptFlags))
+            {
+                // if the replicas haven't filtered their responses, we need to remove
+                // anything we sent to ensure we don't mark them as unstable
                 deps = deps.without(this.deps);
+            }
 
             deps = deps.markUnstableBefore(txnId);
         }
@@ -180,7 +190,6 @@ abstract class Propose<R> extends AbstractCoordination<FullRoute<?>, R, AcceptRe
     }
 
     abstract CoordinationAdapter<R> adapter();
-
 
     @Override
     public CoordinationKind kind()

--- a/accord-core/src/main/java/accord/coordinate/Recover.java
+++ b/accord-core/src/main/java/accord/coordinate/Recover.java
@@ -70,6 +70,7 @@ import accord.utils.async.AsyncChain;
 import accord.utils.async.AsyncChains;
 
 import static accord.api.ProtocolModifiers.QuorumEpochIntersections;
+import static accord.api.ProtocolModifiers.Toggles.recoverPartialAcceptPhaseIfNoFastPath;
 import static accord.coordinate.CoordinationAdapter.Factory.Kind.Recovery;
 import static accord.coordinate.ExecutePath.RECOVER;
 import static accord.coordinate.Infer.InvalidateAndCallback.locallyInvalidateAndCallback;
@@ -86,6 +87,10 @@ import static accord.messages.BeginRecovery.RecoverOk.maxAccepted;
 import static accord.messages.BeginRecovery.RecoverOk.maxAcceptedNotTruncated;
 import static accord.messages.BeginRecovery.RecoveryFlags.FAST_PATH_DECIDED;
 import static accord.messages.BeginRecovery.RecoveryFlags.FORCE_RECOVER_FAST_PATH;
+import static accord.messages.BeginRecovery.RecoveryFlags.NO_CALCULATE_DEPS;
+import static accord.messages.BeginRecovery.RecoveryFlags.calculateDeps;
+import static accord.messages.BeginRecovery.RecoveryFlags.forceRecoverFastPath;
+import static accord.messages.BeginRecovery.RecoveryFlags.isFastPathDecided;
 import static accord.primitives.ProgressToken.TRUNCATED_DURABLE_OR_INVALIDATED;
 import static accord.primitives.Routables.Slice.Minimal;
 import static accord.primitives.Status.AcceptedMedium;
@@ -124,7 +129,7 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
                     BiConsumer<? super Outcome, Throwable> callback)
     {
         super(node, executor, txnId, route, topologies.nodes(), callback);
-        this.flags = computeFlags(isFastPathDecided, topologies);
+        this.flags = computeFlags(txnId, isFastPathDecided, topologies);
         Invariants.require(txnId.isVisible());
         this.adapter = node.coordinationAdapter(txnId, Recovery);
         this.ballot = ballot;
@@ -134,9 +139,11 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
         this.tracker = new RecoveryTracker(topologies);
     }
 
-    private static int computeFlags(boolean isFastPathDecided, Topologies topologies)
+    private static int computeFlags(TxnId txnId, boolean isFastPathDecided, Topologies topologies)
     {
-        int flags = (isFastPathDecided ? TinyEnumSet.encode(FAST_PATH_DECIDED) : 0);
+        int flags = (isFastPathDecided ? TinyEnumSet.encode(FAST_PATH_DECIDED) : 0)
+                    | (!txnId.hasFastPath() && !recoverPartialAcceptPhaseIfNoFastPath() ? TinyEnumSet.encode(NO_CALCULATE_DEPS) : 0);
+
         for (int i = 0 ; i < topologies.size() ; ++i)
         {
             Topology topology = topologies.get(i);
@@ -284,16 +291,16 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
         {
             Timestamp executeAt = acceptOrCommitNotTruncated.executeAt;
             Status status; {
-                Status tmp = acceptOrCommitNotTruncated.status;
-                if (committedExecuteAt != null)
-                {
-                    Invariants.require(acceptOrCommitNotTruncated.status.compareTo(Status.PreCommitted) < 0 || executeAt.equals(committedExecuteAt));
-                    // if we know from a prior Accept attempt that this is committed we can go straight to the commit phase
-                    if (tmp == AcceptedMedium || tmp == AcceptedSlow)
-                        tmp = Status.Committed;
-                }
-                status = tmp;
+            Status tmp = acceptOrCommitNotTruncated.status;
+            if (committedExecuteAt != null)
+            {
+                Invariants.require(acceptOrCommitNotTruncated.status.compareTo(Status.PreCommitted) < 0 || executeAt.equals(committedExecuteAt));
+                // if we know from a prior Accept attempt that this is committed we can go straight to the commit phase
+                if (tmp == AcceptedMedium || tmp == AcceptedSlow)
+                    tmp = Status.Committed;
             }
+            status = tmp;
+        }
 
             switch (status)
             {
@@ -312,7 +319,7 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
                     if (tracing != null)
                         tracing.trace(null, "found AcceptedInvalidate: continuing Invalidate.");
 
-                    invalidate(oks);
+                    finishAndInvalidate(oks);
                     return;
                 }
 
@@ -323,7 +330,23 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
 
             LatestDeps.Merge merge = mergeDeps(okList);
             Participants<?> await = merge.notAccepted(scope);
-            awaitPartialEarlier(okList, await, () -> {
+
+            if (!calculateDeps(flags))
+            {
+                Invariants.require(!txnId.hasFastPath());
+                switch (status)
+                {
+                    case AcceptedMedium:
+                    case AcceptedSlow:
+                        if (!await.isEmpty())
+                        {
+                            finishAndInvalidate(oks);
+                            return;
+                        }
+                }
+            }
+
+            awaitPartialSimple(okList, await, () -> {
                 BiConsumer<Result, Throwable> callback = finishAndTakeResultCallback();
                 switch (status)
                 {
@@ -411,19 +434,19 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
         }
 
         Invariants.require(committedExecuteAt == null || committedExecuteAt.equals(txnId));
-        Invariants.require(!TinyEnumSet.contains(flags, FAST_PATH_DECIDED) || TinyEnumSet.contains(flags, FORCE_RECOVER_FAST_PATH));
+        Invariants.require(!isFastPathDecided(flags) || forceRecoverFastPath(flags));
 
         boolean coordinatorInRecoveryQuorum = oks.get(txnId.node) != null;
         Participants<?> extraCoordVotes = extraCoordinatorVotes(txnId, coordinatorInRecoveryQuorum, okList);
-        Participants<?> extraRejects = Deps.merge(okList, okList.size(), List::get, ok -> ok.laterCoordRejects)
+        Participants<?> extraRejects = Deps.merge(okList, okList.size(), List::get, ok -> ok.supersedingCoordRejects)
                                            .intersecting(scope, id -> !oks.containsKey(id.node));
         InferredFastPath fastPath;
         if (txnId.hasPrivilegedCoordinator() && coordinatorInRecoveryQuorum) fastPath = Reject;
         else if (txnId.isSyncPoint()) fastPath = Reject;
         else fastPath = merge(
-            supersedingRejects(okList) ? Reject : Unknown,
-            tracker.inferFastPathDecision(txnId, extraCoordVotes, extraRejects)
-        );
+                supersedingRejects(okList) ? Reject : Unknown,
+                tracker.inferFastPathDecision(txnId, extraCoordVotes, extraRejects)
+            );
 
         switch (fastPath)
         {
@@ -432,7 +455,7 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
                 if (tracing != null)
                     tracing.trace(null, "found fast path rejection; invoking Invalidate.");
 
-                invalidate(oks);
+                finishAndInvalidate(oks);
                 return;
             }
             case Accept:
@@ -444,8 +467,8 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
             case Unknown:
             {
                 // should all be PreAccept
-                Deps earlierWait = Deps.merge(okList, okList.size(), List::get, ok -> ok.earlierWait);
-                Deps earlierNoWait = Deps.merge(okList, okList.size(), List::get, ok -> ok.earlierNoWait);
+                Deps earlierWait = Deps.merge(okList, okList.size(), List::get, ok -> ok.simpleWait);
+                Deps earlierNoWait = Deps.merge(okList, okList.size(), List::get, ok -> ok.simpleNoWait);
                 earlierWait = earlierWait.without(earlierNoWait);
                 Deps laterWitnessedCoordRejects = Deps.merge(oks, oks.domainSize(), (map, i) -> selectCoordinatorReplies(map.getKey(i), map.getValue(i)), Function.identity());
 
@@ -455,37 +478,37 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
                     // we have to be certain these commands have not successfully committed without witnessing us (thereby
                     // ruling out a fast path decision for us and changing our recovery decision).
                     // So, we wait for these commands to commit and recompute supersedingRejects for them.
-                    awaitToFinish(AsyncChains.reduce(awaitEarlier(node, earlierWait, HasCommittedDeps),
-                                              awaitLater(node, laterWitnessedCoordRejects, CommittedOrNotFastPathCommit, extraCoordVotes),
-                                              InferredFastPath::merge)
-                                      .invokeIfSuccess((inferred) -> {
-                                          switch (inferred)
-                                          {
-                                              default: throw new UnhandledEnum(inferred);
-                                              case Accept:
-                                              {
-                                                  if (tracing != null)
-                                                      tracing.trace(null, "found accepted fast path; proposing.");
-                                                  propose(SLOW, txnId, okList);
-                                                  break;
-                                              }
-                                              case Unknown:
-                                              {
-                                                  if (tracing != null)
-                                                      tracing.trace(null, "found unknown fast path decision; retrying.");
-                                                  retry(committedExecuteAt, finishAndUnwrapCallback());
-                                                  break;
-                                              }
-                                              case Reject:
-                                              {
-                                                  if (tracing != null)
-                                                      tracing.trace(null, "found fast path rejection; invoking Invalidate.");
+                    awaitToFinish(AsyncChains.reduce(awaitSimple(node, earlierWait, HasCommittedDeps),
+                                                     awaitSupersedingCoord(node, laterWitnessedCoordRejects, CommittedOrNotFastPathCommit, extraCoordVotes),
+                                                     InferredFastPath::merge)
+                                             .invokeIfSuccess((inferred) -> {
+                                                 switch (inferred)
+                                                 {
+                                                     default: throw new UnhandledEnum(inferred);
+                                                     case Accept:
+                                                     {
+                                                         if (tracing != null)
+                                                             tracing.trace(null, "found accepted fast path; proposing.");
+                                                         propose(SLOW, txnId, okList);
+                                                         break;
+                                                     }
+                                                     case Unknown:
+                                                     {
+                                                         if (tracing != null)
+                                                             tracing.trace(null, "found unknown fast path decision; retrying.");
+                                                         retry(committedExecuteAt, finishAndUnwrapCallback());
+                                                         break;
+                                                     }
+                                                     case Reject:
+                                                     {
+                                                         if (tracing != null)
+                                                             tracing.trace(null, "found fast path rejection; invoking Invalidate.");
 
-                                                  invalidate(oks);
-                                                  break;
-                                              }
-                                          }
-                                      }));
+                                                         finishAndInvalidate(oks);
+                                                         break;
+                                                     }
+                                                 }
+                                             }));
                 }
                 else
                 {
@@ -502,13 +525,13 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
         return LatestDeps.merge(nullableRecoverOkList, ok -> ok == null ? null : ok.deps);
     }
 
-    private void awaitPartialEarlier(List<RecoverOk> nullableRecoverOkList, Participants<?> participants, Runnable whenReady)
+    private void awaitPartialSimple(List<RecoverOk> nullableRecoverOkList, Participants<?> participants, Runnable whenReady)
     {
-        Deps earlierWait = Deps.merge(nullableRecoverOkList, nullableRecoverOkList.size(), List::get, ok -> ok.earlierWait);
-        Deps earlierNoWait = Deps.merge(nullableRecoverOkList, nullableRecoverOkList.size(), List::get, ok -> ok.earlierNoWait);
+        Deps earlierWait = Deps.merge(nullableRecoverOkList, nullableRecoverOkList.size(), List::get, ok -> ok.simpleWait);
+        Deps earlierNoWait = Deps.merge(nullableRecoverOkList, nullableRecoverOkList.size(), List::get, ok -> ok.simpleNoWait);
         earlierWait = earlierWait.without(earlierNoWait);
         earlierWait = earlierWait.intersecting(participants);
-        awaitToFinish(awaitEarlier(node, earlierWait, HasDecidedExecuteAt).invokeIfSuccess(whenReady));
+        awaitToFinish(awaitSimple(node, earlierWait, HasDecidedExecuteAt).invokeIfSuccess(whenReady));
     }
 
     private static boolean supersedingRejects(List<RecoverOk> oks)
@@ -555,7 +578,7 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
         if (ok == null)
             return null;
 
-        return ok.laterCoordRejects.with(id -> from.equals(id.node));
+        return ok.supersedingCoordRejects.with(id -> from.equals(id.node));
     }
 
     private void withCommittedDeps(LatestDeps.Merge merge, Timestamp executeAt, BiConsumer<?, Throwable> failureCallback, Consumer<Deps> withDeps)
@@ -568,10 +591,14 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
         LatestDeps.withStable(adapter, node, executor, merge, Deps.NONE, scope, null, null, scope, ballot, txnId, executeAt, txn, failureCallback, withDeps);
     }
 
-    private void invalidate(SortedListMap<Id, RecoverOk> recoverOks)
+    private void finishAndInvalidate(SortedListMap<Id, RecoverOk> recoverOks)
+    {
+        invalidate(recoverOks, finishAndTakeCallback());
+    }
+
+    private void invalidate(SortedListMap<Id, RecoverOk> recoverOks, BiConsumer<? super Outcome, Throwable> callback)
     {
         Timestamp invalidateUntil = invalidateUntil(recoverOks);
-        BiConsumer<? super Outcome, Throwable> callback = finishAndTakeCallback();
         proposeInvalidate(node, executor, ballot, txnId, scope.homeKey(), (success, fail) -> {
             if (fail != null) callback.accept(null, fail);
             else commitInvalidate(invalidateUntil, callback);
@@ -618,13 +645,13 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
     private void retry(Timestamp executeAt, BiConsumer<? super Outcome, Throwable> callback)
     {
         Ballot ballot = node.uniqueTimestamp(Ballot::fromValues);
-        Recover.recover(node, tracker.topologies(), ballot, txnId, txn, scope, executeAt, TinyEnumSet.contains(flags, FAST_PATH_DECIDED), reportTo, callback);
+        Recover.recover(node, tracker.topologies(), ballot, txnId, txn, scope, executeAt, isFastPathDecided(flags), reportTo, callback);
     }
 
-    AsyncChain<InferredFastPath> awaitEarlier(Node node, Deps waitOn, Await.Until awaitUntil)
+    AsyncChain<InferredFastPath> awaitSimple(Node node, Deps waitOn, Await.Until awaitUntil)
     {
         if (tracing != null)
-            tracing.trace(null, "awaiting earlier decisions: " + waitOn.txnIds());
+            tracing.trace(null, "awaiting decisions: " + waitOn.txnIds());
 
         long requireEpoch = waitOn.maxTxnId(txnId).epoch();
         return node.withEpochAtLeast(requireEpoch, executor, () -> {
@@ -633,7 +660,7 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
             for (int i = 0 ; i < waitOn.txnIdCount() ; ++i)
             {
                 TxnId awaitId = waitOn.txnId(i);
-                Invariants.require(awaitId.compareTo(recoverId) < 0);
+                Invariants.require(awaitId.compareTo(recoverId) < 0 || !awaitId.hasFastPath());
                 Participants<?> participants = waitOn.participants(awaitId);
 
                 Topologies topologies;
@@ -651,7 +678,7 @@ public class Recover extends AbstractCoordination<FullRoute<?>, Outcome, Recover
         });
     }
 
-    AsyncChain<InferredFastPath> awaitLater(Node node, Deps waitOn, Await.Until awaitUntil, @Nullable Participants<?> selfCoordVotes)
+    AsyncChain<InferredFastPath> awaitSupersedingCoord(Node node, Deps waitOn, Await.Until awaitUntil, @Nullable Participants<?> selfCoordVotes)
     {
         if (tracing != null)
             tracing.trace(null, "awaiting later decisions or recoveries: " + waitOn.txnIds());

--- a/accord-core/src/main/java/accord/coordinate/tracking/DurabilityTracker.java
+++ b/accord-core/src/main/java/accord/coordinate/tracking/DurabilityTracker.java
@@ -26,7 +26,6 @@ import accord.local.durability.DurabilityService.SyncLocal;
 import accord.local.durability.DurabilityService.SyncRemote;
 import accord.topology.Shard;
 import accord.topology.Topologies;
-import accord.topology.Topology;
 import accord.utils.Invariants;
 import accord.utils.ReducingRangeMap;
 import accord.utils.SortedArrays.SortedArrayList;
@@ -186,22 +185,6 @@ public class DurabilityTracker extends SimpleTracker<DurabilityTracker.Durabilit
         return all(DurabilityShardTracker::hasSucceeded);
     }
 
-    public SyncRemote achievedRemote()
-    {
-        if (hasSucceeded())
-            return SyncRemote.All;
-        if (hasQuorumSuccess())
-            return SyncRemote.Quorum;
-        if (hasMinorityQuorumSuccess())
-            return SyncRemote.MinorityQuorum;
-        return SyncRemote.NoRemote;
-    }
-
-    public SyncLocal achievedLocal(Node.Id self)
-    {
-        return successes.contains(self) ? SyncLocal.Self : SyncLocal.NoLocal;
-    }
-
     public Set<Node.Id> including()
     {
         return successes;
@@ -214,19 +197,8 @@ public class DurabilityTracker extends SimpleTracker<DurabilityTracker.Durabilit
 
     public ReducingRangeMap<DurabilityLevel> results(Node.Id self)
     {
-        boolean endInclusive = false;
-        for (int i = 0 ; i < topologies.size() ; ++i)
-        {
-            Topology topology = topologies.get(i);
-            if (topology.ranges().isEmpty())
-                continue;
-
-            endInclusive = topology.ranges().get(0).endInclusive();
-            break;
-        }
-
         ReducingRangeMap<DurabilityLevel> result = null;
-        ReducingRangeMap.Builder<DurabilityLevel> builder = new ReducingRangeMap.Builder<>(endInclusive, trackers.length);
+        ReducingRangeMap.Builder<DurabilityLevel> builder = new ReducingRangeMap.Builder<>(trackers.length);
         for (int topologyIndex = 0 ; topologyIndex < topologies.size() ; ++topologyIndex)
         {
             for (int i = topologyOffset(topologyIndex), max = topologyOffset(topologyIndex + 1); i < max ; ++i)

--- a/accord-core/src/main/java/accord/impl/DefaultLocalListeners.java
+++ b/accord-core/src/main/java/accord/impl/DefaultLocalListeners.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Enumeration;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 
@@ -659,7 +660,10 @@ public class DefaultLocalListeners implements LocalListeners
                 @Override
                 public TxnListener next()
                 {
-                    return new TxnListener(buffer[0], new TxnId(cur), cur.await);
+                    if (!hasNext())
+                        throw new NoSuchElementException();
+
+                    return new TxnListener(buffer[bufferIndex++], new TxnId(cur), cur.await);
                 }
             };
         };
@@ -726,7 +730,9 @@ public class DefaultLocalListeners implements LocalListeners
                 @Override
                 public Registered next()
                 {
-                    return (Registered) buffer[0];
+                    if (!hasNext())
+                        throw new NoSuchElementException();
+                    return (Registered) buffer[bufferIndex++];
                 }
             };
         };

--- a/accord-core/src/main/java/accord/impl/InMemoryCommandStore.java
+++ b/accord-core/src/main/java/accord/impl/InMemoryCommandStore.java
@@ -39,6 +39,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
@@ -50,13 +51,17 @@ import accord.api.Journal;
 import accord.api.LocalListeners;
 import accord.api.ProgressLog;
 import accord.api.RoutingKey;
+import accord.impl.cfr.InMemoryRangeSummaryIndex;
+import accord.impl.cfr.LoadListener;
 import accord.impl.progresslog.DefaultProgressLog;
 import accord.local.Cleanup;
 import accord.local.Command;
 import accord.local.CommandStore;
-import accord.local.CommandStores.RangesForEpoch;
 import accord.local.CommandSummaries;
+import accord.local.CommandSummaries.Summary;
+import accord.local.CommandSummaries.SummaryLoader;
 import accord.local.Commands;
+import accord.local.LoadKeysFor;
 import accord.local.MaxDecidedRX;
 import accord.local.NodeCommandStoreService;
 import accord.local.PreLoadContext;
@@ -69,12 +74,10 @@ import accord.local.StoreParticipants;
 import accord.local.cfk.CommandsForKey;
 import accord.local.cfk.SafeCommandsForKey;
 import accord.local.cfk.Serialize;
-import accord.primitives.AbstractRanges;
 import accord.primitives.AbstractUnseekableKeys;
 import accord.primitives.PartialDeps;
 import accord.primitives.Participants;
 import accord.primitives.Ranges;
-import accord.primitives.Routable.Domain;
 import accord.primitives.RoutableKey;
 import accord.primitives.Route;
 import accord.primitives.Status;
@@ -91,8 +94,11 @@ import accord.utils.async.AsyncResults;
 import accord.utils.async.Cancellable;
 import org.agrona.collections.ObjectHashSet;
 
+import static accord.api.ProtocolModifiers.RangeSpec.isEndInclusive;
+import static accord.api.ProtocolModifiers.RangeSpec.isStartInclusive;
 import static accord.local.Cleanup.Input.FULL;
 import static accord.local.LoadKeys.NONE;
+import static accord.local.LoadKeysFor.RECOVERY;
 import static accord.local.LoadKeysFor.WRITE;
 import static accord.local.RedundantStatus.Coverage.ALL;
 import static accord.local.StoreParticipants.Filter.LOAD;
@@ -100,14 +106,10 @@ import static accord.primitives.Routable.Domain.Key;
 import static accord.primitives.Routable.Domain.Range;
 import static accord.primitives.Routables.Slice.Minimal;
 import static accord.primitives.SaveStatus.Applying;
-import static accord.primitives.SaveStatus.Erased;
-import static accord.primitives.SaveStatus.NotDefined;
 import static accord.primitives.SaveStatus.ReadyToExecute;
-import static accord.primitives.SaveStatus.Vestigial;
 import static accord.primitives.Status.Applied;
 import static accord.primitives.Status.Committed;
 import static accord.primitives.Status.Durability.HasOutcome.Universal;
-import static accord.primitives.Status.Durability.NotDurable;
 import static accord.primitives.Status.Stable;
 import static accord.primitives.Status.Truncated;
 import static accord.primitives.Txn.Kind.EphemeralRead;
@@ -125,7 +127,6 @@ public abstract class InMemoryCommandStore extends CommandStore
 
         private final long id = nextId.incrementAndGet();
         private final NavigableMap<RoutingKey, ByteBuffer> commandsForKey = new TreeMap<>();
-        private final TreeMap<TxnId, Ranges> rangeCommands = new TreeMap<>();
         private int waitingForCfk;
 
         private Snapshot(){}
@@ -135,11 +136,7 @@ public abstract class InMemoryCommandStore extends CommandStore
             for (Map.Entry<RoutingKey, ByteBuffer> e : commandsForKey.entrySet())
                 commandStore.commandsForKey.computeIfAbsent(e.getKey(), GlobalCommandsForKey::new).value(Serialize.fromBytes(e.getKey(), e.getValue()));
 
-            for (Map.Entry<TxnId, Ranges> e : rangeCommands.entrySet())
-            {
-                RangeCommand rangeCommand = commandStore.rangeCommands.computeIfAbsent(e.getKey(), RangeCommand::new);
-                rangeCommand.ranges = e.getValue();
-            }
+            commandStore.commandsForRanges.prune(commandStore);
         }
 
         void saveCallback(CommandsForKey cfk)
@@ -164,8 +161,6 @@ public abstract class InMemoryCommandStore extends CommandStore
         public static AsyncResult<Snapshot> snapshot(InMemoryCommandStore commandStore)
         {
             Snapshot snapshot = new Snapshot();
-            for (Map.Entry<TxnId, RangeCommand> e : commandStore.rangeCommands.entrySet())
-                snapshot.rangeCommands.put(e.getKey(), e.getValue().ranges);
 
             for (Map.Entry<RoutableKey, GlobalCommandsForKey> e : commandStore.commandsForKey.entrySet())
             {
@@ -187,12 +182,31 @@ public abstract class InMemoryCommandStore extends CommandStore
         }
     }
 
-    final NavigableMap<TxnId, GlobalCommand> commands = new TreeMap<>();
+    public static class CommandsForRangeLoad implements Cancellable
+    {
+        public final SummaryLoader loader;
+        public final TreeMap<Timestamp, Summary> loaded;
+        public final Cancellable unregister;
+
+        public CommandsForRangeLoad(SummaryLoader loader, TreeMap<Timestamp, Summary> loaded, Cancellable unregister)
+        {
+            this.loader = loader;
+            this.loaded = loaded;
+            this.unregister = unregister;
+        }
+
+        @Override
+        public void cancel()
+        {
+            unregister.cancel();
+        }
+    }
+
+    protected final NavigableMap<TxnId, GlobalCommand> commands = new TreeMap<>();
     final NavigableMap<Timestamp, GlobalCommand> commandsByExecuteAt = new TreeMap<>();
     private final NavigableMap<RoutableKey, GlobalCommandsForKey> commandsForKey = new TreeMap<>();
 
-    private final TreeMap<TxnId, RangeCommand> rangeCommands = new TreeMap<>();
-    protected Timestamp maxRedundant = Timestamp.NONE;
+    protected final InMemoryRangeSummaryIndex commandsForRanges;
 
     private InMemorySafeStore current;
     private final Journal journal;
@@ -201,6 +215,7 @@ public abstract class InMemoryCommandStore extends CommandStore
     {
         super(id, node, agent, store, progressLogFactory, listenersFactory, epochUpdateHolder);
         this.journal = journal;
+        this.commandsForRanges = new InMemoryRangeSummaryIndex();
         progressLog.unsafeStart();
     }
 
@@ -358,7 +373,7 @@ public abstract class InMemoryCommandStore extends CommandStore
         {
             if (added.valueAt(i) != null)
             {
-                commandsForKey.subMap(added.startAt(i), !added.inclusiveEnds(), added.startAt(i + 1), added.inclusiveEnds()).forEach((forKey, forValue) -> {
+                commandsForKey.subMap(added.startAt(i), isStartInclusive(), added.startAt(i + 1), isEndInclusive()).forEach((forKey, forValue) -> {
                     if (!forValue.isEmpty())
                     {
                         InMemorySafeCommandsForKey safeCfk = forValue.createSafeReference();
@@ -393,42 +408,23 @@ public abstract class InMemoryCommandStore extends CommandStore
     public void markShardDurable(SafeCommandStore safeStore, TxnId syncId, Ranges ranges, HasOutcome level)
     {
         super.markShardDurable(safeStore, syncId, ranges, level);
+        // TODO (required): this should happen on markLocallyApplied
         if (level == Universal)
-            markShardDurable(syncId, ranges);
+            commandsForRanges.prune(syncId, ranges, safeStore.redundantBefore());
     }
 
-    private void markShardDurable(TxnId syncId, Ranges ranges)
-    {
-        rangeCommands.computeIfAbsent(syncId, RangeCommand::new).add(ranges);
-        rangeCommands.headMap(syncId, false).entrySet().removeIf(tx -> {
-            Ranges newRanges = tx.getValue().ranges.without(ranges);
-            if (!newRanges.isEmpty())
-            {
-                tx.getValue().ranges = newRanges;
-                return false;
-            }
-            else
-            {
-                GlobalCommand global = commands.get(tx.getKey());
-                if (global != null)
-                    maxRedundant = Timestamp.nonNullOrMax(maxRedundant, global.value().executeAt());
-                return true;
-            }
-        });
-    }
-
-    protected InMemorySafeStore createSafeStore(PreLoadContext context, RangesForEpoch ranges,
+    protected InMemorySafeStore createSafeStore(PreLoadContext context, CommandsForRangeLoad cfrLoad,
                                                 Map<TxnId, InMemorySafeCommand> commands,
                                                 Map<RoutableKey, InMemorySafeCommandsForKey> commandsForKeys)
     {
-        return new InMemorySafeStore(this, ranges, context, commands, commandsForKeys);
+        return new InMemorySafeStore(this, context, cfrLoad, commands, commandsForKeys);
     }
 
     protected void onRead(Command current) {}
     protected void onWrite(Command current) {}
     protected void onRead(CommandsForKey current) {}
 
-    protected final InMemorySafeStore createSafeStore(PreLoadContext context, RangesForEpoch ranges)
+    protected final InMemorySafeStore createSafeStore(PreLoadContext context, CommandsForRangeLoad cfrLoad)
     {
         Map<TxnId, InMemorySafeCommand> commands = new HashMap<>();
         Map<RoutableKey, InMemorySafeCommandsForKey> commandsForKey = new HashMap<>();
@@ -442,9 +438,9 @@ public abstract class InMemoryCommandStore extends CommandStore
                 for (RoutingKey key : (AbstractUnseekableKeys)unseekables)
                     commandsForKey.put(key, commandsForKey(key).createSafeReference());
             }
-            else
+            else if (context.loadKeysFor() != WRITE)
             {
-                CommandSummaries.SummaryLoader loader = CommandSummaries.SummaryLoader.loader(unsafeGetRedundantBefore(), unsafeGetMaxDecidedRX(), context);
+                SummaryLoader loader = SummaryLoader.loader(unsafeGetRedundantBefore(), unsafeGetMaxDecidedRX(), context);
                 for (GlobalCommandsForKey global : this.commandsForKey.values())
                 {
                     if (!unseekables.contains(global.key))
@@ -460,14 +456,14 @@ public abstract class InMemoryCommandStore extends CommandStore
             }
         }
 
-        return createSafeStore(context, ranges, commands, commandsForKey);
+        return createSafeStore(context, cfrLoad, commands, commandsForKey);
     }
 
-    public SafeCommandStore beginOperation(PreLoadContext context)
+    public SafeCommandStore beginOperation(PreLoadContext context, @Nullable CommandsForRangeLoad cfrLoad)
     {
         if (current != null)
             throw illegalState("Another operation is in progress or it's store was not cleared");
-        current = createSafeStore(context, rangesForEpoch);
+        current = createSafeStore(context, cfrLoad);
         updateRangesForEpoch(current);
         return current;
     }
@@ -492,9 +488,9 @@ public abstract class InMemoryCommandStore extends CommandStore
         }
     }
 
-    protected <T> T executeInContext(InMemoryCommandStore commandStore, PreLoadContext preLoadContext, Function<? super SafeCommandStore, T> function)
+    protected <T> T executeInContext(InMemoryCommandStore commandStore, PreLoadContext preLoadContext, @Nullable CommandsForRangeLoad cfrLoad, Function<? super SafeCommandStore, T> function)
     {
-        SafeCommandStore safeStore = commandStore.beginOperation(preLoadContext);
+        SafeCommandStore safeStore = commandStore.beginOperation(preLoadContext, cfrLoad);
         try
         {
             return function.apply(safeStore);
@@ -506,11 +502,11 @@ public abstract class InMemoryCommandStore extends CommandStore
         }
     }
 
-    protected <T> void executeInContext(InMemoryCommandStore commandStore, PreLoadContext context, Function<? super SafeCommandStore, T> function, BiConsumer<? super T, Throwable> callback)
+    protected <T> void executeInContext(InMemoryCommandStore commandStore, PreLoadContext context, @Nullable CommandsForRangeLoad cfrLoad, Function<? super SafeCommandStore, T> function, BiConsumer<? super T, Throwable> callback)
     {
         try
         {
-            T result = executeInContext(commandStore, context, function);
+            T result = executeInContext(commandStore, context, cfrLoad, function);
             callback.accept(result, null);
         }
         catch (Throwable t)
@@ -647,12 +643,13 @@ public abstract class InMemoryCommandStore extends CommandStore
     {
         protected final Map<TxnId, InMemorySafeCommand> commands;
         private final Map<RoutableKey, InMemorySafeCommandsForKey> commandsForKey;
+        private final CommandsForRangeLoad cfrLoad;
         private final Set<Object> hasLoaded = new ObjectHashSet<>();
         private ByTxnIdSnapshot commandsForRanges;
 
         public InMemorySafeStore(InMemoryCommandStore commandStore,
-                                 RangesForEpoch ranges,
                                  PreLoadContext context,
+                                 CommandsForRangeLoad cfrLoad,
                                  Map<TxnId, InMemorySafeCommand> commands,
                                  Map<RoutableKey, InMemorySafeCommandsForKey> commandsForKey)
         {
@@ -660,6 +657,7 @@ public abstract class InMemoryCommandStore extends CommandStore
 
             this.commands = commands;
             this.commandsForKey = commandsForKey;
+            this.cfrLoad = cfrLoad;
             for (InMemorySafeCommand cmd : commands.values())
             {
                 if (cmd.isUnset()) cmd.uninitialised();
@@ -668,6 +666,8 @@ public abstract class InMemoryCommandStore extends CommandStore
             {
                 if (cfk.isUnset()) cfk.initialize();
             }
+            if (cfrLoad != null)
+                cfrLoad.cancel();
         }
 
         @Override
@@ -757,20 +757,9 @@ public abstract class InMemoryCommandStore extends CommandStore
         }
 
         @Override
-        protected void update(Command prev, Command updated, boolean force)
+        public void updateCommandsForRanges(Command prev, Command updated, boolean force)
         {
-            super.update(prev, updated, force);
-
-            TxnId txnId = updated.txnId();
-            if (txnId.domain() != Domain.Range)
-                return;
-
-            // TODO (testing): consider removing if erased
-            if (updated.saveStatus() == Erased || updated.saveStatus() == Vestigial)
-                return;
-
-            commandStore().rangeCommands.computeIfAbsent(txnId, RangeCommand::new)
-                         .update(((AbstractRanges)updated.participants().stillTouches()).toRanges());
+            commandStore().commandsForRanges.update(prev, updated, force);
         }
 
         @Override
@@ -799,6 +788,7 @@ public abstract class InMemoryCommandStore extends CommandStore
 
         public void postExecute()
         {
+            commandStore().commandsForRanges.tryDrainPendingEdits();
             super.postExecute();
             commands.values().forEach(c -> {
                 if (c == null || c.current() == null)
@@ -829,27 +819,16 @@ public abstract class InMemoryCommandStore extends CommandStore
                 return commandsForRanges;
 
             Invariants.require(context.loadKeysFor() != WRITE);
+            // TODO (now): reuse existing loader
             MaxDecidedRX maxDecidedRX = commandStore().unsafeGetMaxDecidedRX();
             SummaryLoader loader = SummaryLoader.loader(redundantBefore(), maxDecidedRX, context);
-            TreeMap<Timestamp, Summary> summaries = new TreeMap<>();
-            for (RangeCommand rangeCommand : commandStore().rangeCommands.values())
-            {
-                GlobalCommand global = commandStore().commands.get(rangeCommand.txnId);
-                Command command = global == null ? null : global.value();
-                if (!loader.isMaybeRelevant(rangeCommand.txnId))
-                    continue;
 
-                Summary summary;
-                if (command == null) summary = loader.ifRelevant(rangeCommand.txnId, rangeCommand.txnId, NotDefined, NotDurable, rangeCommand.ranges, null);
-                else summary = loader.ifRelevant(command);
-                if (summary != null)
-                {
-                    summaries.put(summary.plainTxnId(), summary);
-                    loader.maybeRecordFutureRx(summary);
-                }
-            }
-
-            return commandsForRanges = () -> summaries;
+            TreeMap<Timestamp, Summary> loaded = new TreeMap<>();
+            commandStore().commandsForRanges.populateMinFutureRx(loader);
+            commandStore().commandsForRanges.search(loader, loaded::put, null);
+            if (cfrLoad != null)
+                loaded.putAll(cfrLoad.loaded);
+            return commandsForRanges = () -> loaded;
         }
 
         private boolean visitForKey(Unseekables<?> keysOrRanges, Predicate<CommandsForKey> forEach)
@@ -870,9 +849,9 @@ public abstract class InMemoryCommandStore extends CommandStore
             visitForKey(keysOrRanges, cfk -> { cfk.visit(startedBefore, testKind, visitor, p1, p2); return true; });
         }
 
-        public boolean visitForKey(Unseekables<?> keysOrRanges, TxnId testTxnId, Kinds testKind, TestStartedAt testStartedAt, Timestamp testStartedAtTimestamp, ComputeIsDep computeIsDep, AllCommandVisitor visit)
+        public boolean visitForKey(Unseekables<?> keysOrRanges, TxnId testTxnId, Kinds testKind, SupersedingCommandVisitor visit)
         {
-            return visitForKey(keysOrRanges, cfk -> cfk.visit(testTxnId, testKind, testStartedAt, testStartedAtTimestamp, computeIsDep, null, visit));
+            return visitForKey(keysOrRanges, cfk -> cfk.visit(testTxnId, testKind, visit));
         }
 
         @Override
@@ -883,10 +862,10 @@ public abstract class InMemoryCommandStore extends CommandStore
         }
 
         @Override
-        public boolean visit(Unseekables<?> keysOrRanges, TxnId testTxnId, Kinds testKind, TestStartedAt testStartedAt, Timestamp testStartedAtTimestamp, ComputeIsDep computeIsDep, AllCommandVisitor visit)
+        public boolean visit(Unseekables<?> keysOrRanges, TxnId testTxnId, Kinds testKind, SupersedingCommandVisitor visit)
         {
-            return visitForKey(keysOrRanges, testTxnId, testKind, testStartedAt, testStartedAtTimestamp, computeIsDep, visit)
-                   && commandsForRanges().visit(keysOrRanges, testTxnId, testKind, testStartedAt, testStartedAtTimestamp, computeIsDep, visit);
+            return visitForKey(keysOrRanges, testTxnId, testKind, visit)
+                   && commandsForRanges().visit(keysOrRanges, testTxnId, testKind, visit);
         }
 
         @Override
@@ -934,6 +913,24 @@ public abstract class InMemoryCommandStore extends CommandStore
         }
     }
 
+    protected CommandsForRangeLoad cfrLoad(PreLoadContext context)
+    {
+        if (context.loadKeysFor() != LoadKeysFor.RECOVERY)
+            return null;
+
+        SummaryLoader loader = SummaryLoader.loader(unsafeGetRedundantBefore(), unsafeGetMaxDecidedRX(), context);
+        commandsForRanges.populateMinFutureRx(loader);
+        TreeMap<Timestamp, Summary> loaded = new TreeMap<>();
+        commandsForRanges.search(loader, null, txnId -> {
+            Invariants.require(loader.loadKeysFor() == RECOVERY);
+            Command command = commands.get(txnId).value();
+            Summary summary = loader.ifRelevant(command);
+            Invariants.require(summary != null);
+            loaded.put(summary.plainTxnId(), summary);
+        });
+        return new CommandsForRangeLoad(loader, loaded, commandsForRanges.registerListener(new LoadListener(loader, loaded)));
+    }
+
     public static class Synchronized extends InMemoryCommandStore
     {
         Runnable active;
@@ -961,13 +958,17 @@ public abstract class InMemoryCommandStore extends CommandStore
             activeThread = null;
         }
 
-        private Cancellable enqueueAndRun(Runnable runnable)
+        private Cancellable enqueueAndRun(Runnable runnable, @Nullable Cancellable ifCancelled)
         {
             boolean result = queue.add(runnable);
             if (!result)
                 throw illegalState("could not add item to queue");
             maybeRun();
-            return () -> queue.remove(runnable);
+            return () -> {
+                queue.remove(runnable);
+                if (ifCancelled != null)
+                    ifCancelled.cancel();
+            };
         }
 
         @Override
@@ -990,7 +991,8 @@ public abstract class InMemoryCommandStore extends CommandStore
                 @Override
                 protected Cancellable start(BiConsumer<? super T, Throwable> callback)
                 {
-                    return enqueueAndRun(() -> executeInContext(InMemoryCommandStore.Synchronized.this, context, function, callback));
+                    CommandsForRangeLoad cfrLoad = cfrLoad(context);
+                    return enqueueAndRun(() -> executeInContext(InMemoryCommandStore.Synchronized.this, context, cfrLoad, function, callback), cfrLoad);
                 }
             };
         }
@@ -1001,7 +1003,7 @@ public abstract class InMemoryCommandStore extends CommandStore
         @Override
         public void execute(Runnable run)
         {
-            enqueueAndRun(run);
+            enqueueAndRun(run, null);
         }
     }
 
@@ -1048,7 +1050,9 @@ public abstract class InMemoryCommandStore extends CommandStore
         @Override
         public <T> AsyncChain<T> chain(PreLoadContext context, Function<? super SafeCommandStore, T> function)
         {
-            return chain(() -> executeInContext(SingleThread.this, context, function));
+            // TODO (expected): must unregister if chain is cancelled; should also only register when start() called
+            CommandsForRangeLoad cfrLoad = cfrLoad(context);
+            return chain(() -> executeInContext(SingleThread.this, context, cfrLoad, function));
         }
 
         @Override
@@ -1069,12 +1073,12 @@ public abstract class InMemoryCommandStore extends CommandStore
         class DebugSafeStore extends InMemorySafeStore
         {
             public DebugSafeStore(InMemoryCommandStore commandStore,
-                                  RangesForEpoch ranges,
                                   PreLoadContext context,
+                                  CommandsForRangeLoad cfrLoad,
                                   Map<TxnId, InMemorySafeCommand> commands,
                                   Map<RoutableKey, InMemorySafeCommandsForKey> commandsForKey)
             {
-                super(commandStore, ranges, context, commands, commandsForKey);
+                super(commandStore, context, cfrLoad, commands, commandsForKey);
             }
 
             @Override
@@ -1098,9 +1102,9 @@ public abstract class InMemoryCommandStore extends CommandStore
         }
 
         @Override
-        protected InMemorySafeStore createSafeStore(PreLoadContext context, RangesForEpoch ranges, Map<TxnId, InMemorySafeCommand> commands, Map<RoutableKey, InMemorySafeCommandsForKey> commandsForKeys)
+        protected InMemorySafeStore createSafeStore(PreLoadContext context, CommandsForRangeLoad cfrLoad, Map<TxnId, InMemorySafeCommand> commands, Map<RoutableKey, InMemorySafeCommandsForKey> commandsForKeys)
         {
-            return new DebugSafeStore(this, ranges, context, commands, commandsForKeys);
+            return new DebugSafeStore(this, context, cfrLoad, commands, commandsForKeys);
         }
     }
 
@@ -1211,7 +1215,7 @@ public abstract class InMemoryCommandStore extends CommandStore
         commands.clear();
         commandsByExecuteAt.clear();
         commandsForKey.clear();
-        rangeCommands.clear();
+        commandsForRanges.clear();
         progressLog.clear();
         unsafeSetRejectBefore(new RejectBefore());
         hasResumedBootstraps = false;
@@ -1237,6 +1241,7 @@ public abstract class InMemoryCommandStore extends CommandStore
         {
             return AsyncChains.success(commandStore.executeInContext(commandStore,
                                                                      PreLoadContext.contextFor(command.txnId(), "Replay"),
+                                                                     null,
                                                                      (SafeCommandStore safeStore) -> {
                                                                          initialiseState(safeStore, command.txnId());
                                                                          return null;

--- a/accord-core/src/main/java/accord/impl/RangeIntervalComparators.java
+++ b/accord-core/src/main/java/accord/impl/RangeIntervalComparators.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.impl;
+
+import java.util.Comparator;
+import java.util.function.Function;
+
+import accord.api.RoutingKey;
+import accord.primitives.Range;
+import accord.utils.AsymmetricComparator;
+import accord.utils.SymmetricComparator;
+import accord.utils.btree.IntervalBTree;
+
+import static accord.utils.btree.IntervalBTree.InclusiveEndHelper.endWithStart;
+import static accord.utils.btree.IntervalBTree.InclusiveEndHelper.keyEndWithStart;
+import static accord.utils.btree.IntervalBTree.InclusiveEndHelper.keyStartWithEnd;
+import static accord.utils.btree.IntervalBTree.InclusiveEndHelper.keyStartWithStart;
+import static accord.utils.btree.IntervalBTree.InclusiveEndHelper.startWithEnd;
+import static accord.utils.btree.IntervalBTree.InclusiveEndHelper.startWithStart;
+
+public class RangeIntervalComparators
+{
+    public static class InclusiveEndEntryComparators<R> implements IntervalBTree.IntervalComparators<R>
+    {
+        final Function<R, Range> get;
+        final Comparator<R> compareId;
+
+        public InclusiveEndEntryComparators(Function<R, Range> get, Comparator<R> compareId)
+        {
+            this.get = get;
+            this.compareId = compareId;
+        }
+
+        @Override public Comparator<R> totalOrder()
+        {
+            return (a, b) -> {
+                int c = get.apply(a).compare(get.apply(b));
+                if (c == 0) c = compareId.compare(a, b);
+                return c;
+            };
+        }
+        @Override public Comparator<R> endWithEndSorter() { return (a, b) -> get.apply(a).end().compareTo(get.apply(b).end()); }
+        @Override public SymmetricComparator<R> startWithStartSeeker() { return (a, b) -> startWithStart(get.apply(a).start().compareTo(get.apply(b).start())); }
+        @Override public SymmetricComparator<R> startWithEndSeeker() { return (a, b) -> startWithEnd(get.apply(a).start().compareTo(get.apply(b).end())); }
+        @Override public SymmetricComparator<R> endWithStartSeeker() { return (a, b) -> endWithStart(get.apply(a).end().compareTo(get.apply(b).start())); }
+    }
+
+    public static class InclusiveEndWithKeyComparators<R> implements IntervalBTree.WithIntervalComparators<RoutingKey, R>
+    {
+        final Function<R, Range> get;
+
+        public InclusiveEndWithKeyComparators(Function<R, Range> get)
+        {
+            this.get = get;
+        }
+
+        @Override public AsymmetricComparator<RoutingKey, R> startWithStartSeeker() { return (a, b) -> keyStartWithStart(a.compareTo(get.apply(b).start())); }
+        @Override public AsymmetricComparator<RoutingKey, R> startWithEndSeeker() { return (a, b) -> keyStartWithEnd(a.compareTo(get.apply(b).end())); }
+        @Override public AsymmetricComparator<RoutingKey, R> endWithStartSeeker() { return (a, b) -> keyEndWithStart(a.compareTo(get.apply(b).start())); }
+    }
+
+    public static class InclusiveEndWithRangeComparators<R> implements IntervalBTree.WithIntervalComparators<Range, R>
+    {
+        final Function<R, Range> get;
+
+        public InclusiveEndWithRangeComparators(Function<R, Range> get)
+        {
+            this.get = get;
+        }
+
+        @Override public AsymmetricComparator<Range, R> startWithStartSeeker() { return (a, b) -> startWithStart(a.start().compareTo(get.apply(b).start())); }
+        @Override public AsymmetricComparator<Range, R> startWithEndSeeker() { return (a, b) -> startWithEnd(a.start().compareTo(get.apply(b).end())); }
+        @Override public AsymmetricComparator<Range, R> endWithStartSeeker() { return (a, b) -> endWithStart(a.end().compareTo(get.apply(b).start())); }
+    }
+
+}

--- a/accord-core/src/main/java/accord/impl/cfr/IdEntry.java
+++ b/accord-core/src/main/java/accord/impl/cfr/IdEntry.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.impl.cfr;
+
+import accord.primitives.Range;
+import accord.primitives.Ranges;
+import accord.primitives.SaveStatus;
+import accord.primitives.Status;
+import accord.primitives.Timestamp;
+import accord.primitives.TxnId;
+import accord.utils.Invariants;
+
+public abstract class IdEntry extends TxnId
+{
+    public static class SerializerSupport
+    {
+        public static IdSingleEntry create(TxnId txnId, int encoded, Range range)
+        {
+            IdSingleEntry result = new IdSingleEntry(txnId, range);
+            result.encoded = encoded;
+            return result;
+        }
+
+        public static IdMultiEntry create(TxnId txnId, int encoded, Ranges ranges)
+        {
+            IdMultiEntry result = new IdMultiEntry(txnId, ranges);
+            result.encoded = encoded;
+            return result;
+        }
+    }
+
+    static final int SAVE_STATUS_SHIFT = Status.Durability.ENCODING_BITS;
+    static final int EXECUTE_AT_BIT = 1 << (SaveStatus.ENCODING_BITS + SAVE_STATUS_SHIFT);
+
+    int encoded;
+
+    TxnId plainTxnId()
+    {
+        return new TxnId(this);
+    }
+
+    Status.Durability durability()
+    {
+        return Status.Durability.forEncoded(encoded & Status.Durability.ENCODING_MASK);
+    }
+
+    SaveStatus saveStatus()
+    {
+        return SaveStatus.forOrdinal(saveStatusOrdinal());
+    }
+
+    int saveStatusOrdinal()
+    {
+        return (encoded >>> SAVE_STATUS_SHIFT) & SaveStatus.ENCODING_MASK;
+    }
+
+    Timestamp maybeExecuteAt()
+    {
+        if ((encoded & EXECUTE_AT_BIT) != 0)
+            return plainTxnId();
+        return null;
+    }
+
+    public IdEntry(TxnId txnId)
+    {
+        super(txnId);
+    }
+
+    abstract IdEntry copy();
+
+    abstract Ranges ranges();
+
+    public boolean update(SaveStatus saveStatus, Status.Durability durability, Timestamp executeAt)
+    {
+        int newEncoded = (saveStatus.ordinal() << SAVE_STATUS_SHIFT) | durability.encoded() | (super.equals(executeAt) ? EXECUTE_AT_BIT : 0);
+        if (encoded == newEncoded)
+            return false;
+        encoded = newEncoded;
+        Invariants.require(durability() == durability);
+        Invariants.require(saveStatus() == saveStatus);
+        return true;
+    }
+
+    public final int encoded()
+    {
+        return encoded;
+    }
+}

--- a/accord-core/src/main/java/accord/impl/cfr/IdMultiEntry.java
+++ b/accord-core/src/main/java/accord/impl/cfr/IdMultiEntry.java
@@ -16,24 +16,32 @@
  * limitations under the License.
  */
 
-package accord.primitives;
+package accord.impl.cfr;
 
-import org.junit.jupiter.api.Test;
+import accord.primitives.Ranges;
+import accord.primitives.TxnId;
 
-import accord.utils.AccordGens;
-import org.assertj.core.api.Assertions;
-
-import static accord.utils.Property.qt;
-
-class TxnIdTest
+public class IdMultiEntry extends IdEntry
 {
-    @Test
-    void stringSerde()
-    {
-        qt().forAll(AccordGens.txnIds()).check(id -> {
-            Assertions.assertThat(TxnId.parse(id.toString())).isEqualTo(id);
+    public final Ranges ranges;
 
-            Assertions.assertThat(Timestamp.parse(id.toStandardString())).isEqualTo(new Timestamp(id));
-        });
+    public IdMultiEntry(TxnId txnId, Ranges ranges)
+    {
+        super(txnId);
+        this.ranges = ranges;
+    }
+
+    @Override
+    IdEntry copy()
+    {
+        IdMultiEntry copy = new IdMultiEntry(this, ranges);
+        copy.encoded = encoded;
+        return copy;
+    }
+
+    @Override
+    Ranges ranges()
+    {
+        return ranges;
     }
 }

--- a/accord-core/src/main/java/accord/impl/cfr/IdSingleEntry.java
+++ b/accord-core/src/main/java/accord/impl/cfr/IdSingleEntry.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.impl.cfr;
+
+import accord.primitives.Range;
+import accord.primitives.Ranges;
+import accord.primitives.TxnId;
+
+public class IdSingleEntry extends IdEntry implements RangeEntry
+{
+    public final Range range;
+
+    public IdSingleEntry(TxnId txnId, Range range)
+    {
+        super(txnId);
+        this.range = range;
+    }
+
+    @Override
+    public Range range()
+    {
+        return range;
+    }
+
+    @Override
+    public IdEntry id()
+    {
+        return this;
+    }
+
+    @Override
+    IdEntry copy()
+    {
+        IdSingleEntry copy = new IdSingleEntry(this, range);
+        copy.encoded = encoded;
+        return copy;
+    }
+
+    @Override
+    Ranges ranges()
+    {
+        // TODO (desired): introduce an interface for iterating ranges for providing to e.g. foldl, so we can avoid wrapping each time
+        return Ranges.of(range);
+    }
+}

--- a/accord-core/src/main/java/accord/impl/cfr/InMemoryRangeSummaryIndex.java
+++ b/accord-core/src/main/java/accord/impl/cfr/InMemoryRangeSummaryIndex.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.impl.cfr;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+import javax.annotation.Nullable;
+
+import com.google.common.collect.ImmutableList;
+
+import accord.api.RoutingKey;
+import accord.local.Command;
+import accord.local.CommandStore;
+import accord.local.CommandSummaries.Summary;
+import accord.local.CommandSummaries.SummaryLoader;
+import accord.local.CommandSummaries.Relevance;
+import accord.local.RedundantBefore;
+import accord.primitives.AbstractRanges;
+import accord.primitives.AbstractUnseekableKeys;
+import accord.primitives.Participants;
+import accord.primitives.Range;
+import accord.primitives.Ranges;
+import accord.primitives.SaveStatus;
+import accord.primitives.TxnId;
+import accord.primitives.Unseekable;
+import accord.primitives.Unseekables;
+import accord.utils.Invariants;
+import accord.utils.SemiSyncIntervalTree;
+import accord.utils.UnhandledEnum;
+import accord.utils.async.Cancellable;
+import accord.utils.btree.BTree;
+import accord.utils.btree.IntervalBTree;
+import accord.utils.btree.IntervalBTree.FastIntervalTreeBuilder;
+
+import static accord.api.ProtocolModifiers.RangeSpec.isEndInclusive;
+import static accord.impl.cfr.ListenerEntry.LISTENER_ENTRIES;
+import static accord.impl.cfr.ListenerEntry.LISTENER_WITH_KEYS;
+import static accord.impl.cfr.ListenerEntry.LISTENER_WITH_RANGES;
+import static accord.impl.cfr.RangeEntry.ENTRIES;
+import static accord.impl.cfr.RangeEntry.WITH_KEY;
+import static accord.impl.cfr.RangeEntry.WITH_RANGE;
+import static accord.local.CommandSummaries.Relevance.ACTIVE;
+import static accord.local.RedundantStatus.Property.GC_BEFORE;
+import static accord.local.RedundantStatus.Property.LOCALLY_APPLIED;
+import static accord.local.RedundantStatus.Property.SHARD_APPLIED;
+import static accord.local.RedundantStatus.Property.UNREADY;
+
+/**
+ * An implementation filling the same niche as CommandsForKey, only we do not retain
+ * complete information, and may need to load a command to decide if it is relevant.
+ * We also don't consume this structure directly, instead building a set of summary records to work with.
+ */
+public class InMemoryRangeSummaryIndex extends SemiSyncIntervalTree<IdEntry>
+{
+    private final Map<TxnId, IdEntry> byId = new HashMap<>();
+    private Object[] listeners = IntervalBTree.empty();
+
+    public InMemoryRangeSummaryIndex()
+    {
+        super(ENTRIES);
+        Invariants.require(isEndInclusive(), "Need to implement range-exclusive IntervalComparators");
+    }
+
+    private boolean update(Command command)
+    {
+        TxnId txnId = command.txnId();
+        SaveStatus saveStatus = command.saveStatus();
+        AbstractRanges participants = (AbstractRanges) command.participants().stillTouches();
+        if (saveStatus.compareTo(SaveStatus.TruncatedUnapplied) >= 0 || participants.isEmpty())
+        {
+            IdEntry entry = byId.remove(txnId);
+            if (entry != null)
+                pushEdit(entry, null, entry);
+            return false;
+        }
+
+        IdEntry cur = byId.get(txnId);
+        IdEntry next = cur;
+        if (participants.size() == 1)
+        {
+            Range range = participants.get(0).asRange();
+            if (cur == null || cur.getClass() != IdSingleEntry.class || !((IdSingleEntry) cur).range.equals(range))
+                next = new IdSingleEntry(txnId, range);
+        }
+        else
+        {
+            if (cur == null || cur.getClass() != IdMultiEntry.class || !((IdMultiEntry) cur).ranges.hasSameRanges(participants))
+                next = new IdMultiEntry(txnId, participants.toRanges());
+        }
+        if (next != cur)
+        {
+            if (cur != null)
+                byId.remove(cur, cur);
+            byId.put(next, next);
+            pushEdit(next, next, cur);
+        }
+        return next.update(saveStatus, command.durability(), command.executeAtIfKnown()) || next != cur;
+    }
+
+    private static Object[] toMultiTree(IdMultiEntry entry)
+    {
+        try (FastIntervalTreeBuilder<RangeEntry> builder = IntervalBTree.fastBuilder(ENTRIES))
+        {
+            for (Range range : entry.ranges)
+                builder.add(new RangeMultiEntry(range, entry));
+            return builder.build();
+        }
+    }
+
+    public <A> A foldl(Unseekables<?> participants, BiFunction<IdEntry, A, A> f, A accumulator)
+    {
+        Object[] tree = get();
+        switch (participants.domain())
+        {
+            case Key:
+                for (RoutingKey key : (AbstractUnseekableKeys)participants)
+                    accumulator = IntervalBTree.accumulate(tree, WITH_KEY, key, InMemoryRangeSummaryIndex::foldl, f, participants, accumulator);
+                break;
+            case Range:
+                for (Range range : (AbstractRanges)participants)
+                    accumulator = IntervalBTree.accumulate(tree, WITH_RANGE, range, InMemoryRangeSummaryIndex::foldl, f, participants, accumulator);
+                break;
+        }
+        return accumulator;
+    }
+
+    public void populateMinFutureRx(SummaryLoader loader)
+    {
+        foldl(loader.participants(), (e, l) -> {
+            if (e.isSyncPoint() && l.shouldRecordFutureRx(e, e.saveStatus().summary))
+                l.recordFutureRx(e.plainTxnId(), e.ranges());
+            return l;
+        }, loader);
+    }
+
+    /**
+     * If we have enough information, simply directly build the Summary object and return a map of these objects;
+     * otherwise invoke the provided Consumer so that the implementation may build the summary
+     */
+    public void search(SummaryLoader loader, @Nullable BiConsumer<TxnId, Summary> found, @Nullable Consumer<TxnId> mustLoad)
+    {
+        foldl(loader.participants(), (e, l) -> {
+            Ranges ranges = e.ranges();
+            Relevance relevance = l.maxRelevance(e, e.saveStatus(), e.durability(), e.maybeExecuteAt(), ranges);
+            if (relevance == Relevance.IRRELEVANT)
+                return l;
+
+            TxnId txnId = e.plainTxnId();
+            switch (relevance)
+            {
+                default: throw new UnhandledEnum(relevance);
+                case ACTIVE:
+                    if (found != null)
+                    {
+                        Summary summary = l.get(ACTIVE, e.plainTxnId(), e.maybeExecuteAt(), e.saveStatus(), e.durability(), ranges, null);
+                        Invariants.nonNull(summary);
+                        // TODO (expected): we can post-filter collected txnId after recording future rx to remove those that are no longer needed
+                        //    (or, we can retain summary information to permit evicting them as we collect)
+                        found.accept(txnId, summary);
+                    }
+                    break;
+                case MAYBE_SUPERSEDING:
+                case MAYBE_BOTH:
+                case SUPERSEDING:
+                case BOTH:
+                    if (mustLoad != null)
+                        mustLoad.accept(txnId);
+            }
+            return l;
+        }, loader);
+    }
+
+    static < A> A foldl(BiFunction<IdEntry, A, A> f, Unseekables<?> find, RangeEntry e, A accumulator)
+    {
+        if (e.getClass() == IdSingleEntry.class)
+        {
+            return f.apply((IdSingleEntry)e, accumulator);
+        }
+        else
+        {
+            IdEntry id = e.id();
+            IdMultiEntry mid = (IdMultiEntry) id;
+            if (mid.ranges.size() > 1)
+            {
+                int i = (int) (find.findFirstIntersection(mid.ranges) >>> 32);
+                if (mid.ranges.get(i) != e.range())
+                    return accumulator;
+            }
+            return f.apply(id, accumulator);
+        }
+    }
+
+    public void update(Command prev, Command updated, boolean force)
+    {
+        if (!force
+             && updated.saveStatus() == prev.saveStatus()
+             && updated.participants().stillTouches().equals(prev.participants().touches())
+             && Objects.equals(updated.executeAt(), prev.executeAt()))
+            return;
+
+        if (update(updated))
+        {
+            // invoke listeners
+            Participants<?> stillTouches = updated.participants().stillTouches();
+            switch (stillTouches.domain())
+            {
+                default: throw new UnhandledEnum(stillTouches.domain());
+                case Key:
+                    for (RoutingKey key : (AbstractUnseekableKeys)stillTouches)
+                        IntervalBTree.accumulate(listeners, LISTENER_WITH_KEYS, key, InMemoryRangeSummaryIndex::visitListeners, stillTouches, updated, null);
+                    break;
+                case Range:
+                    for (Range range : (AbstractRanges)stillTouches)
+                        IntervalBTree.accumulate(listeners, LISTENER_WITH_RANGES, range, InMemoryRangeSummaryIndex::visitListeners, stillTouches, updated, null);
+                    break;
+            }
+        }
+    }
+
+    public Cancellable registerListener(Listener listener)
+    {
+        Object[] tree;
+        try (IntervalBTree.FastIntervalTreeBuilder<ListenerEntry> builder = IntervalBTree.fastBuilder(LISTENER_ENTRIES))
+        {
+            for (Unseekable u : listener.participants())
+                builder.add(new ListenerEntry(u.asRange(), listener));
+            tree = builder.build();
+        }
+        listeners = IntervalBTree.update(listeners, tree, LISTENER_ENTRIES);
+        return () -> listeners = IntervalBTree.subtract(listeners, tree, LISTENER_ENTRIES);
+    }
+
+    private static Object visitListeners(Participants participants, Command command, ListenerEntry entry, Object v)
+    {
+        Unseekables<?> searchingFor = entry.listener.participants();
+        if (searchingFor.size() > 1)
+        {
+            int i = (int) searchingFor.findNextIntersection(0, participants, 0);
+            if (!searchingFor.get(i).asRange().equals(entry.range))
+                return v;
+        }
+        entry.listener.accept(command);
+        return v;
+    }
+
+    public void prune(CommandStore commandStore)
+    {
+        prune(commandStore.unsafeGetRangesForEpoch().all(), commandStore.unsafeGetRedundantBefore());
+    }
+
+    public void prune(Ranges ranges, RedundantBefore redundantBefore)
+    {
+        prune(TxnId.MAX, ranges, redundantBefore);
+    }
+
+    public void prune(TxnId lessThan, Ranges ranges, RedundantBefore redundantBefore)
+    {
+        drainPendingEdits();
+        List<IdEntry> remove = new ArrayList<>();
+        foldl(ranges, (id, es) -> {
+            if (id.compareTo(lessThan) < 0 && redundantBefore.foldl(id.ranges(), InMemoryRangeSummaryIndex::prune, true, id))
+                es.add(id);
+            return es;
+        }, remove);
+        for (IdEntry e : remove)
+        {
+            byId.remove(e);
+            value = applyMultiple(value, null, tree(e));
+        }
+    }
+
+    private static Boolean prune(RedundantBefore.Bounds bounds, Boolean prune, TxnId txnId)
+    {
+        // TODO (expected): prune implied invalidations
+        if (!prune) return false;
+        if (bounds.maxBound(LOCALLY_APPLIED).compareTo(txnId) <= 0) return false;
+        if (!txnId.isSyncPoint()) return bounds.maxBound(GC_BEFORE).compareTo(txnId) > 0;
+        if (bounds.maxBound(SHARD_APPLIED).compareTo(txnId) > 0) return true;
+        return bounds.maxBound(UNREADY).compareTo(txnId) < 0;
+    }
+
+    @Override
+    protected Object[] tree(IdEntry edit)
+    {
+        if (edit.getClass() == IdMultiEntry.class)
+            return toMultiTree((IdMultiEntry) edit);
+        return BTree.singleton(edit);
+    }
+
+    public void restore(List<IdEntry> idEntries)
+    {
+        for (IdEntry original : idEntries)
+        {
+            IdEntry copy = original.copy();
+            Invariants.require(null == byId.put(copy, copy));
+            value = applyMultiple(value, tree(copy), null);
+        }
+    }
+
+    public List<IdEntry> snapshot()
+    {
+        drainPendingEdits();
+        ImmutableList.Builder<IdEntry> builder = ImmutableList.builder();
+        for (IdEntry e : byId.values())
+            builder.add(e.copy());
+        return builder.build();
+    }
+
+    public void clear()
+    {
+        drainPendingEdits();
+        byId.clear();
+        value = IntervalBTree.empty();
+    }
+
+    @Override
+    public boolean tryDrainPendingEdits()
+    {
+        return super.tryDrainPendingEdits();
+    }
+
+    @Override
+    public Object[] drainPendingEdits()
+    {
+        return super.drainPendingEdits();
+    }
+}

--- a/accord-core/src/main/java/accord/impl/cfr/Listener.java
+++ b/accord-core/src/main/java/accord/impl/cfr/Listener.java
@@ -16,24 +16,19 @@
  * limitations under the License.
  */
 
-package accord.primitives;
+package accord.impl.cfr;
 
-import org.junit.jupiter.api.Test;
+import java.util.concurrent.atomic.AtomicLong;
 
-import accord.utils.AccordGens;
-import org.assertj.core.api.Assertions;
+import accord.local.Command;
+import accord.primitives.Unseekables;
 
-import static accord.utils.Property.qt;
-
-class TxnIdTest
+public abstract class Listener
 {
-    @Test
-    void stringSerde()
-    {
-        qt().forAll(AccordGens.txnIds()).check(id -> {
-            Assertions.assertThat(TxnId.parse(id.toString())).isEqualTo(id);
+    private static final AtomicLong nextId = new AtomicLong();
 
-            Assertions.assertThat(Timestamp.parse(id.toStandardString())).isEqualTo(new Timestamp(id));
-        });
-    }
+    final long id = nextId.incrementAndGet();
+
+    protected abstract Unseekables<?> participants();
+    protected abstract void accept(Command command);
 }

--- a/accord-core/src/main/java/accord/impl/cfr/ListenerEntry.java
+++ b/accord-core/src/main/java/accord/impl/cfr/ListenerEntry.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.impl.cfr;
+
+import java.util.Comparator;
+
+import accord.api.RoutingKey;
+import accord.impl.RangeIntervalComparators;
+import accord.primitives.Range;
+import accord.utils.btree.IntervalBTree;
+
+class ListenerEntry
+{
+    static final IntervalBTree.IntervalComparators<ListenerEntry> LISTENER_ENTRIES = new RangeIntervalComparators.InclusiveEndEntryComparators<>(e -> e.range, Comparator.comparingLong(a -> a.listener.id));
+    static final IntervalBTree.WithIntervalComparators<RoutingKey, ListenerEntry> LISTENER_WITH_KEYS = new RangeIntervalComparators.InclusiveEndWithKeyComparators<>(e -> e.range);
+    static final IntervalBTree.WithIntervalComparators<Range, ListenerEntry> LISTENER_WITH_RANGES = new RangeIntervalComparators.InclusiveEndWithRangeComparators<>(e -> e.range);
+
+    final Range range;
+    final Listener listener;
+
+    ListenerEntry(Range range, Listener listener)
+    {
+        this.range = range;
+        this.listener = listener;
+    }
+}

--- a/accord-core/src/main/java/accord/impl/cfr/LoadListener.java
+++ b/accord-core/src/main/java/accord/impl/cfr/LoadListener.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.impl.cfr;
+
+import java.util.Map;
+
+import accord.local.Command;
+import accord.local.CommandSummaries;
+import accord.local.CommandSummaries.Summary;
+import accord.local.CommandSummaries.SummaryLoader;
+import accord.primitives.Timestamp;
+import accord.primitives.Unseekables;
+
+import static accord.local.CommandSummaries.Relevance.MAYBE_SUPERSEDING;
+
+public class LoadListener extends Listener
+{
+    final SummaryLoader loader;
+    final Map<Timestamp, Summary> into;
+
+    public LoadListener(SummaryLoader loader, Map<Timestamp, Summary> into)
+    {
+        this.loader = loader;
+        this.into = into;
+    }
+
+    public SummaryLoader loader()
+    {
+        return loader;
+    }
+
+    public Map<Timestamp, Summary> into()
+    {
+        return into;
+    }
+
+    @Override
+    protected Unseekables<?> participants()
+    {
+        return loader.participants();
+    }
+
+    @Override
+    protected void accept(Command command)
+    {
+        CommandSummaries.Relevance relevance = loader.relevance(command);
+        if (relevance.is(MAYBE_SUPERSEDING))
+        {
+            Summary summary = loader.get(relevance, command);
+            if (summary != null)
+                into.put(command.txnId(), summary);
+        }
+    }
+}

--- a/accord-core/src/main/java/accord/impl/cfr/RangeEntry.java
+++ b/accord-core/src/main/java/accord/impl/cfr/RangeEntry.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.impl.cfr;
+
+import accord.api.RoutingKey;
+import accord.impl.RangeIntervalComparators.InclusiveEndEntryComparators;
+import accord.impl.RangeIntervalComparators.InclusiveEndWithKeyComparators;
+import accord.impl.RangeIntervalComparators.InclusiveEndWithRangeComparators;
+import accord.primitives.Range;
+import accord.utils.btree.IntervalBTree.IntervalComparators;
+import accord.utils.btree.IntervalBTree.WithIntervalComparators;
+
+public interface RangeEntry
+{
+    Range range();
+    IdEntry id();
+
+    IntervalComparators<RangeEntry> ENTRIES = new InclusiveEndEntryComparators<>(RangeEntry::range, (a, b) -> a.id().compareTo(b.id()));
+    WithIntervalComparators<RoutingKey, RangeEntry> WITH_KEY = new InclusiveEndWithKeyComparators<>(RangeEntry::range);
+    WithIntervalComparators<Range, RangeEntry> WITH_RANGE = new InclusiveEndWithRangeComparators<>(RangeEntry::range);
+}

--- a/accord-core/src/main/java/accord/impl/cfr/RangeMultiEntry.java
+++ b/accord-core/src/main/java/accord/impl/cfr/RangeMultiEntry.java
@@ -16,24 +16,30 @@
  * limitations under the License.
  */
 
-package accord.primitives;
+package accord.impl.cfr;
 
-import org.junit.jupiter.api.Test;
+import accord.primitives.Range;
 
-import accord.utils.AccordGens;
-import org.assertj.core.api.Assertions;
-
-import static accord.utils.Property.qt;
-
-class TxnIdTest
+public class RangeMultiEntry implements RangeEntry
 {
-    @Test
-    void stringSerde()
-    {
-        qt().forAll(AccordGens.txnIds()).check(id -> {
-            Assertions.assertThat(TxnId.parse(id.toString())).isEqualTo(id);
+    public final Range range;
+    public final IdMultiEntry id;
 
-            Assertions.assertThat(Timestamp.parse(id.toStandardString())).isEqualTo(new Timestamp(id));
-        });
+    RangeMultiEntry(Range range, IdMultiEntry id)
+    {
+        this.range = range;
+        this.id = id;
+    }
+
+    @Override
+    public Range range()
+    {
+        return range;
+    }
+
+    @Override
+    public IdEntry id()
+    {
+        return id;
     }
 }

--- a/accord-core/src/main/java/accord/local/Bootstrap.java
+++ b/accord-core/src/main/java/accord/local/Bootstrap.java
@@ -144,11 +144,13 @@ class Bootstrap
             CommandStore commandStore = safeStore.commandStore();
             CoordinateSyncPoint.exclusive(node, globalSyncId, commitRanges)
                                .flatMap(success -> commandStore.chain((PreLoadContext.Empty) () -> "Mark Bootstrapping", safeStore0 -> {
+
                                    // we submit a separate execution so that we know markBootstrapping is durable before we initiate the fetch
-                                   Bootstrap.this.commandStore.markBootstrapping(safeStore0, globalSyncId, commitRanges);
+                                   if (!valid.isEmpty())
+                                       commandStore.markBootstrapping(safeStore0, globalSyncId, valid);
                                    return success;
                                }))
-                               .flatMap(syncPoint -> node.withEpochAtLeast(epoch, null, () -> Bootstrap.this.commandStore.chain((PreLoadContext.Empty) () -> "Start Bootstrap Fetch", safeStore1 -> {
+                               .flatMap(syncPoint -> node.withEpochAtLeast(epoch, null, () -> commandStore.chain((PreLoadContext.Empty) () -> "Start Bootstrap Fetch", safeStore1 -> {
                                    if (valid.isEmpty()) // we've lost ownership of the range
                                        return AsyncResults.success(Ranges.EMPTY);
                                    return fetch = safeStore1.dataStore().fetch(node, safeStore1, valid, syncPoint, this, Image);

--- a/accord-core/src/main/java/accord/local/Catchup.java
+++ b/accord-core/src/main/java/accord/local/Catchup.java
@@ -39,6 +39,7 @@ import accord.utils.async.AsyncResult;
 import accord.utils.async.AsyncResults;
 import accord.utils.async.AsyncResults.SettableResult;
 
+import static accord.api.ProgressLog.BlockedUntil.CanApply;
 import static accord.local.RedundantStatus.Property.LOCALLY_APPLIED;
 import static accord.primitives.Routables.Slice.Minimal;
 
@@ -55,13 +56,52 @@ public class Catchup
             this.durableBefore = durableBefore;
         }
 
-        void register(SafeCommandStore safeStore)
+        boolean register(SafeCommandStore safeStore)
         {
             waitingOn = safeStore.ranges().all().slice(durableBefore.ranges(Objects::nonNull), Minimal);
             updateWaitingOn(safeStore);
 
-            if (waitingOn.isEmpty()) setSuccess(null);
-            else safeStore.register(this);
+            if (!waitingOn.isEmpty())
+            {
+                logger.info("{}: catching-up {}", safeStore.commandStore(), durableBefore.foldlWithBounds(waitingOn, (entry, sb, start, end) -> {
+                    if (sb.length() > 0)
+                        sb.append(", ");
+                    if (start == null || end == null || entry == null)
+                    {
+                        sb.append("??(").append(start).append(',').append(end).append(',').append(entry).append(')');
+                    }
+                    else
+                    {
+                        TxnId txnId = entry.quorumBefore.withoutNonIdentityFlags();
+                        Range range = start.rangeFactory().newRange(start, end);
+                        markWaiting(safeStore, txnId, range);
+                        sb.append(range).append(": ").append(entry.quorumBefore);
+                    }
+                    return sb;
+                }, new StringBuilder(), ignore -> false));
+                safeStore.register(this);
+                return true;
+            }
+            else
+            {
+                done(safeStore);
+                return false;
+            }
+        }
+
+        private static void markWaiting(SafeCommandStore safeStore, TxnId txnId, Range range)
+        {
+            //noinspection DataFlowIssue
+            safeStore = safeStore;
+            PreLoadContext ctx = PreLoadContext.contextFor(txnId, "Catchup");
+            if (safeStore.canExecuteWith(ctx)) safeStore.progressLog().waiting(CanApply, safeStore, safeStore.get(txnId), null, Ranges.of(range), null);
+            else safeStore.commandStore().execute(ctx, safeStore0 -> safeStore0.progressLog().waiting(CanApply, safeStore0, safeStore0.get(txnId), null, Ranges.of(range), null));
+        }
+
+        private void done(SafeCommandStore safeStore)
+        {
+            setSuccess(null);
+            logger.info("{}: fully caught-up with quorums", safeStore.commandStore());
         }
 
         private void updateWaitingOn(SafeCommandStore safeStore)
@@ -106,13 +146,11 @@ public class Catchup
                 return;
 
             updateWaitingOn(safeStore);
-
-            if (!waitingOn.isEmpty())
-                return;
-
-            logger.info("{}: fully caught-up with quorums", safeStore.commandStore());
-            setSuccess(null);
-            safeStore.unregister(this);
+            if (waitingOn.isEmpty())
+            {
+                done(safeStore);
+                safeStore.unregister(this);
+            }
         }
     }
 
@@ -121,9 +159,9 @@ public class Catchup
         return FetchDurableBefore.catchup(node).flatMap(durableBefore -> {
             List<AsyncResult<Void>> results = new CopyOnWriteArrayList<>();
             return node.commandStores().forAll("Catchup", safeStore -> {
-                CommandStoreListener commandStoreListener = new CommandStoreListener(durableBefore);
-                commandStoreListener.register(safeStore);
-                results.add(commandStoreListener);
+                CommandStoreListener listener = new CommandStoreListener(durableBefore);
+                if (listener.register(safeStore))
+                    results.add(listener);
             }).flatMap(ignore -> {
                 List<AsyncResult<Void>> list = new ArrayList<>(results);
                 if (list.isEmpty())

--- a/accord-core/src/main/java/accord/local/CommandStore.java
+++ b/accord-core/src/main/java/accord/local/CommandStore.java
@@ -77,6 +77,8 @@ import accord.utils.async.Cancellable;
 import accord.utils.async.AsyncResults.SettableResult;
 import org.agrona.collections.LongHashSet;
 
+import static accord.local.RedundantStatus.Property.LOCALLY_APPLIED;
+import static accord.local.RedundantStatus.Property.UNREADY;
 import static accord.topology.EpochReady.DONE;
 import static accord.topology.EpochReady.done;
 import static accord.api.DataStore.FetchKind.Image;
@@ -527,9 +529,19 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
         unsafeSetMaxDecidedRX(maxDecidedRX.update(ranges, txnId));
     }
 
-    final void markExclusiveSyncPointLocallyApplied(SafeCommandStore safeStore, TxnId txnId, Ranges ranges)
+    final void markExclusiveSyncPointLocallyApplied(SafeCommandStore safeStore, TxnId txnId, Ranges ranges, SaveStatus prevStatus)
     {
         // TODO (desired): narrow ranges to those that are owned
+        if (prevStatus.compareTo(SaveStatus.Applied) < 0)
+        {
+            String alreadyApplied = redundantBefore.foldl(ranges, (b, m) -> {
+                if (b.maxBound(LOCALLY_APPLIED).compareTo(txnId) > 0 && b.maxBound(UNREADY).compareTo(txnId) <= 0 && !b.isLocallyRetired())
+                    return m + (m.isEmpty() ? "" : ", ") + b.range + ": " + b;
+                return m;
+            }, "");
+            Invariants.expect(alreadyApplied.isEmpty(), "%s should already have been applied: %s", txnId, alreadyApplied);
+        }
+
         Invariants.requireArgument(txnId.isSyncPoint());
         RedundantBefore addNow = RedundantBefore.create(ranges, txnId, LOCALLY_APPLIED_ONLY);
         safeStore.upsertRedundantBefore(addNow);

--- a/accord-core/src/main/java/accord/local/CommandSummaries.java
+++ b/accord-core/src/main/java/accord/local/CommandSummaries.java
@@ -32,6 +32,7 @@ import accord.primitives.PartialDeps;
 import accord.primitives.Participants;
 import accord.primitives.Ranges;
 import accord.primitives.SaveStatus;
+import accord.primitives.Status;
 import accord.primitives.Status.Durability;
 import accord.primitives.Timestamp;
 import accord.primitives.Txn;
@@ -44,14 +45,21 @@ import accord.utils.ReducingRangeMap;
 import accord.utils.TriPredicate;
 import accord.utils.UnhandledEnum;
 
+import static accord.local.CommandSummaries.Relevance.ACTIVE;
+import static accord.local.CommandSummaries.Relevance.IRRELEVANT;
+import static accord.local.CommandSummaries.Relevance.MAYBE_SUPERSEDING;
+import static accord.local.CommandSummaries.Relevance.SUPERSEDING;
 import static accord.local.CommandSummaries.SummaryStatus.ACCEPTED;
 import static accord.local.CommandSummaries.SummaryStatus.APPLIED;
+import static accord.local.CommandSummaries.SummaryStatus.NOTACCEPTED;
+import static accord.local.CommandSummaries.SummaryStatus.PREACCEPTED;
 import static accord.local.LoadKeysFor.RECOVERY;
+import static accord.local.LoadKeysFor.WRITE;
 import static accord.local.MaxDecidedRX.forDeps;
+import static accord.primitives.Known.KnownDeps.NoDeps;
 import static accord.primitives.Routables.Slice.Minimal;
 import static accord.primitives.Status.Durability.NotDurable;
 import static accord.primitives.Txn.Kind.Nothing;
-import static accord.primitives.TxnId.FastPath.PrivilegedCoordinatorWithDeps;
 
 public interface CommandSummaries
 {
@@ -77,15 +85,61 @@ public interface CommandSummaries
         private static final IsDep[] IS_DEPS = values();
     }
 
+    enum Relevance
+    {
+        /* No need to visit this command */
+        IRRELEVANT(0),
+        /* May need to visit this command, but can make do with TxnId, SaveStatus and Durability */
+        ACTIVE(1),
+        /* May need to visit this command, and requires SupersedingVisitor information */
+        MAYBE_SUPERSEDING(2),
+        MAYBE_BOTH(3),
+        /* May need to visit this command, and requires SupersedingVisitor information */
+        SUPERSEDING(6),
+        BOTH(7),
+        ;
+
+
+        private static final Relevance[] lookup = values();
+        public static final int ENCODED_MASK = 7;
+        public static final int ENCODED_BITS = 3;
+        private final int encoded;
+
+        Relevance(int encoded)
+        {
+            this.encoded = encoded;
+        }
+
+        public boolean is(Relevance relevance)
+        {
+            return (relevance.encoded & encoded) == relevance.encoded;
+        }
+
+        public Relevance or(Relevance that)
+        {
+            return forBits(this.encoded | that.encoded);
+        }
+
+        public static Relevance forOrdinal(int ordinal)
+        {
+            return lookup[ordinal];
+        }
+
+        public static Relevance forBits(int bits)
+        {
+            return forOrdinal(bits < 4 ? bits : 4 + (bits & 1));
+        }
+    }
+
     class Summary extends TxnId
     {
         private static final int SUMMARY_STATUS_MASK = 0x7;
         private static final int IS_DEP_SHIFT = 3;
         private static final int IS_DEP_MASK = 0x7;
         private static final int DURABILITY_SHIFT = 6;
-        private static final int DURABILITY_MASK = (1 << Durability.TOTAL_ENCODING_BITS) - 1;
+        private static final int RELEVANCE_SHIFT = DURABILITY_SHIFT + Durability.ENCODING_BITS;
 
-        final @Nonnull Timestamp executeAt;
+        final @Nullable Timestamp executeAt;
         final int encoded;
         final Unseekables<?> participants;
 
@@ -95,25 +149,33 @@ public interface CommandSummaries
         }
 
         @VisibleForTesting
-        public Summary(@Nonnull TxnId txnId, @Nonnull Timestamp executeAt, @Nonnull SummaryStatus status, @Nonnull Durability durability, IsDep dep, Unseekables<?> participants)
+        public Summary(@Nonnull TxnId txnId, @Nullable Timestamp executeAt, @Nonnull SummaryStatus status, @Nonnull Durability durability, IsDep dep, Relevance relevance, Unseekables<?> participants)
         {
             super(txnId);
             this.participants = participants;
-            this.executeAt = executeAt.equals(txnId) ? this : executeAt;
-            this.encoded = Invariants.nonNull(status).ordinal() | (dep == null ? Integer.MIN_VALUE : (dep.ordinal() << IS_DEP_SHIFT)) | (Invariants.nonNull(durability).encoded() << DURABILITY_SHIFT);
+            this.executeAt = txnId.equals(executeAt) ? this : executeAt;
+            this.encoded = Invariants.nonNull(status).ordinal()
+                           | (dep == null ? Integer.MIN_VALUE : (dep.ordinal() << IS_DEP_SHIFT))
+                           | (Invariants.nonNull(durability).encoded() << DURABILITY_SHIFT)
+                           | (relevance.encoded << RELEVANCE_SHIFT);
         }
 
-        private Summary(@Nonnull TxnId txnId, @Nonnull Timestamp executeAt, int encoded, Unseekables<?> participants)
+        private Summary(@Nonnull TxnId txnId, @Nullable Timestamp executeAt, int encoded, Unseekables<?> participants)
         {
             super(txnId);
             this.participants = participants;
-            this.executeAt = executeAt == txnId || executeAt.equals(txnId) ? this : executeAt;
+            this.executeAt = executeAt == txnId || txnId.equals(executeAt) ? this : executeAt;
             this.encoded = encoded;
         }
 
         public boolean is(IsDep isDep)
         {
             return (encoded >> IS_DEP_SHIFT) == isDep.ordinal();
+        }
+
+        public boolean is(Relevance relevance)
+        {
+            return ((encoded >> RELEVANCE_SHIFT) & relevance.encoded) == relevance.encoded;
         }
 
         public IsDep isDep()
@@ -125,7 +187,12 @@ public interface CommandSummaries
 
         public Durability durability()
         {
-            return Durability.forEncoded((encoded >>> DURABILITY_SHIFT) & DURABILITY_MASK);
+            return Durability.forEncoded((encoded >>> DURABILITY_SHIFT) & Durability.ENCODING_MASK);
+        }
+
+        public Relevance relevance()
+        {
+            return Relevance.forOrdinal((encoded >>> RELEVANCE_SHIFT) & Relevance.ENCODED_MASK);
         }
 
         public boolean is(SummaryStatus summaryStatus)
@@ -137,6 +204,11 @@ public interface CommandSummaries
         {
             int ordinal = encoded & SUMMARY_STATUS_MASK;
             return SummaryStatus.SUMMARY_STATUSES[ordinal];
+        }
+
+        public Unseekables<?> participants()
+        {
+            return participants;
         }
 
         public TxnId plainTxnId()
@@ -157,6 +229,7 @@ public interface CommandSummaries
                    ", executeAt=" + plainExecuteAt() +
                    ", saveStatus=" + status() +
                    ", isDep=" + isDep() +
+                   ", relevance=" + relevance() +
                    '}';
         }
     }
@@ -165,62 +238,76 @@ public interface CommandSummaries
     {
         public interface Factory<L extends SummaryLoader>
         {
-            L create(RedundantBefore redundantBefore, @Nullable MaxDecidedRX maxDecidedRX, TxnId primaryTxnId, Unseekables<?> searchKeysOrRanges, Kinds testKind, TxnId minTxnId, Timestamp maxTxnId, @Nullable TxnId findAsDep);
+            L create(RedundantBefore redundantBefore, @Nullable MaxDecidedRX maxDecidedRX, TxnId primaryTxnId, Unseekables<?> searchKeysOrRanges, Kinds testKind, TxnId minTxnId, Timestamp executeAt, LoadKeysFor loadKeysFor);
         }
 
-        private static final ReducingRangeMap<TxnId> NO_FUTURE_RX = new ReducingRangeMap<>();
+        private static final ReducingRangeMap<TxnId> NO_RX = new ReducingRangeMap<>();
         
         protected final RedundantBefore redundantBefore;
         protected final MaxDecidedRX maxDecidedRX;
-        protected final Unseekables<?> searchKeysOrRanges;
+        protected final Unseekables<?> searchFor;
         // TODO (expected): separate out Kinds we need before/after primaryTxnId/executeAt
         protected final Kinds testKind;
-        protected final TxnId primaryTxnId, findAsDep, minTxnId;
+        protected final LoadKeysFor loadKeysFor;
+        protected final TxnId primaryTxnId, minTxnId;
         protected final DecidedRX decidedRx;
-        protected final Timestamp maxTxnId;
+        protected final Timestamp primaryExecuteAt;
 
-        private ReducingRangeMap<TxnId> minVisitedFutureRX = NO_FUTURE_RX;
-        private TxnId maxRx = TxnId.MAX;
+        private ReducingRangeMap<TxnId> minVisitedFutureRX = NO_RX;
+        private TxnId maxRx = TxnId.MAX; // a cached summary of minVisitedFutureRX to avoid consulting the full collection
 
         // TODO (expected): provide executeAt to PreLoadContext so we can more aggressively filter what we load, esp. by Kind
         public static SummaryLoader loader(RedundantBefore redundantBefore, MaxDecidedRX maxDecidedRX, PreLoadContext context)
         {
-            return loader(redundantBefore, maxDecidedRX, context.primaryTxnId(), context.loadKeysFor(), context.keys());
+            return loader(redundantBefore, maxDecidedRX, context.primaryTxnId(), context.executeAt(), context.loadKeysFor(), context.keys());
         }
 
-        public static SummaryLoader loader(RedundantBefore redundantBefore, MaxDecidedRX maxDecidedRX, TxnId primaryTxnId, LoadKeysFor loadKeysFor, Unseekables<?> keysOrRanges)
+        public static SummaryLoader loader(RedundantBefore redundantBefore, MaxDecidedRX maxDecidedRX, TxnId primaryTxnId, Timestamp executeAt, LoadKeysFor loadKeysFor, Unseekables<?> keysOrRanges)
         {
-            return loader(redundantBefore, maxDecidedRX, primaryTxnId, loadKeysFor, keysOrRanges, SummaryLoader::new);
+            return loader(redundantBefore, maxDecidedRX, primaryTxnId, executeAt, loadKeysFor, keysOrRanges, SummaryLoader::new);
         }
 
         public static <L extends SummaryLoader> L loader(RedundantBefore redundantBefore, MaxDecidedRX maxDecidedRX, PreLoadContext context, Factory<L> factory)
         {
-            return loader(redundantBefore, maxDecidedRX, context.primaryTxnId(), context.loadKeysFor(), context.keys(), factory);
+            return loader(redundantBefore, maxDecidedRX, context.primaryTxnId(), context.executeAt(), context.loadKeysFor(), context.keys(), factory);
         }
 
-        public static <L extends SummaryLoader> L loader(RedundantBefore redundantBefore, MaxDecidedRX maxDecidedRX, TxnId primaryTxnId, LoadKeysFor loadKeysFor, Unseekables<?> keysOrRanges, Factory<L> factory)
+        public static <L extends SummaryLoader> L loader(RedundantBefore redundantBefore, MaxDecidedRX maxDecidedRX, TxnId primaryTxnId, Timestamp executeAt, LoadKeysFor loadKeysFor, Unseekables<?> keysOrRanges, Factory<L> factory)
         {
             Invariants.require(primaryTxnId != null);
             TxnId minTxnId = redundantBefore.min(keysOrRanges, Bounds::gcBefore);
-            Timestamp maxTxnId = loadKeysFor == RECOVERY || !primaryTxnId.isSyncPoint() ? Timestamp.MAX : primaryTxnId;
-            TxnId findAsDep = loadKeysFor == RECOVERY ? primaryTxnId : null;
             Kinds kinds = primaryTxnId.witnesses().or(loadKeysFor == RECOVERY ? primaryTxnId.witnessedBy() : Nothing);
             if (!primaryTxnId.is(Txn.Kind.ExclusiveSyncPoint)) // the main distinction between RX and RV is that RV doesn't filter out decided transactions
                 maxDecidedRX = null;
-            return factory.create(redundantBefore, maxDecidedRX, primaryTxnId, keysOrRanges, kinds, minTxnId, maxTxnId, findAsDep);
+            return factory.create(redundantBefore, maxDecidedRX, primaryTxnId, keysOrRanges, kinds, minTxnId, executeAt, loadKeysFor);
         }
 
-        public SummaryLoader(RedundantBefore redundantBefore, MaxDecidedRX maxDecidedRX, TxnId primaryTxnId, Unseekables<?> searchKeysOrRanges, Kinds testKind, TxnId minTxnId, Timestamp maxTxnId, @Nullable TxnId findAsDep)
+        public SummaryLoader(RedundantBefore redundantBefore, MaxDecidedRX maxDecidedRX, TxnId primaryTxnId, Unseekables<?> searchFor, Kinds testKind, TxnId minTxnId, Timestamp primaryExecuteAt, LoadKeysFor loadKeysFor)
         {
             this.redundantBefore = redundantBefore;
             this.maxDecidedRX = maxDecidedRX;
             this.primaryTxnId = primaryTxnId;
-            this.searchKeysOrRanges = searchKeysOrRanges;
+            this.searchFor = searchFor;
             this.testKind = testKind;
             this.minTxnId = minTxnId;
-            this.maxTxnId = maxTxnId;
-            this.findAsDep = findAsDep;
-            this.decidedRx = forDeps(maxDecidedRX, searchKeysOrRanges, primaryTxnId);
+            this.primaryExecuteAt = primaryExecuteAt;
+            this.loadKeysFor = loadKeysFor;
+            this.decidedRx = forDeps(maxDecidedRX, searchFor, primaryTxnId);
+        }
+
+        public Unseekables<?> participants()
+        {
+            return searchFor;
+        }
+
+        public LoadKeysFor loadKeysFor()
+        {
+            return loadKeysFor;
+        }
+
+        public TxnId primaryTxnId()
+        {
+            return primaryTxnId;
         }
 
         public boolean isRelevant(CommandsForKey cfk)
@@ -254,14 +341,16 @@ public interface CommandSummaries
             return decidedRx == null || decidedRx.includeDecided(last);
         }
 
-        // the caller must manage mutual exclusion for this method, but not to any others
-        public void maybeRecordFutureRx(Summary summary)
+        public boolean shouldRecordFutureRx(TxnId txnId, SummaryStatus status)
         {
-            if (summary.isSyncPoint() && summary.compareTo(primaryTxnId) > 0 && (summary.is(SummaryStatus.STABLE) || summary.is(APPLIED)))
-            {
-                minVisitedFutureRX = ReducingRangeMap.merge(minVisitedFutureRX, ReducingRangeMap.create(summary.participants.toRanges(), summary.plainTxnId()), TxnId::min);
-                maxRx = minVisitedFutureRX.foldlWithDefault(searchKeysOrRanges, TxnId::max, TxnId.MAX, TxnId.NONE);
-            }
+            return txnId.isSyncPoint() && txnId.compareTo(primaryTxnId) > 0 && (status == SummaryStatus.STABLE || status == APPLIED);
+        }
+
+        // the caller must manage mutual exclusion for this method, but not to any others
+        public void recordFutureRx(TxnId txnId, Unseekables<?> participants)
+        {
+            minVisitedFutureRX = ReducingRangeMap.merge(minVisitedFutureRX, ReducingRangeMap.create(participants.toRanges(), txnId), TxnId::min);
+            maxRx = minVisitedFutureRX.foldlWithDefault(searchFor, TxnId::max, TxnId.MAX, TxnId.NONE);
         }
 
         public final Summary ifRelevant(Command cmd)
@@ -284,39 +373,122 @@ public interface CommandSummaries
 
         public final boolean isMaybeRelevant(TxnId txnId)
         {
-            return isMaybeRelevant(txnId, null, null);
+            return maxRelevance(txnId, null, null, null, null) != IRRELEVANT;
         }
 
-        // durability is used as a proxy for durably *decided*
-        public final boolean isMaybeRelevant(TxnId txnId, @Nullable Durability durability, @Nullable Unseekables<?> participants)
+        public final Relevance maxRelevance(TxnId txnId, @Nullable SaveStatus saveStatus, @Nullable Durability durability, @Nullable Timestamp executeAt, @Nullable Unseekables<?> participants)
         {
-            if (!txnId.is(testKind))
-                return false;
+            return relevanceInternal(txnId, saveStatus, durability, executeAt, participants, true);
+        }
 
-            if (txnId.compareTo(minTxnId) < 0 || txnId.compareTo(maxTxnId) > 0)
-                return false;
+        public final Relevance relevance(Command cmd)
+        {
+            return relevance(cmd.txnId(), cmd.saveStatus(), cmd.durability(), cmd.executeAt(), cmd.participants().stillTouches());
+        }
 
-            if (txnId.isSyncPoint())
+        public final Relevance relevance(TxnId txnId, @Nonnull SaveStatus saveStatus, @Nonnull Durability durability, @Nonnull Timestamp executeAt, @Nonnull Unseekables<?> participants)
+        {
+            return relevanceInternal(txnId, saveStatus, durability, executeAt, participants, false);
+        }
+
+        private Relevance relevanceInternal(TxnId txnId, @Nullable SaveStatus saveStatus, @Nullable Durability durability, @Nullable Timestamp executeAt, @Nullable Unseekables<?> participants, boolean permitNull)
+        {
+            if (loadKeysFor == WRITE || !txnId.is(testKind) || (saveStatus != null && saveStatus.compareTo(SaveStatus.TruncatedUnapplied) >= 0))
+                return IRRELEVANT;
+
+            if (!permitNull)
             {
-                if (txnId.compareTo(maxRx) >= 0)
-                    return false;
+                Invariants.requireArgument(durability != null, "durability was expected to be non-null");
+                Invariants.requireArgument(saveStatus != null, "saveStatus was expected to be non-null");
+                Invariants.requireArgument(participants != null, "participants was expected to be non-null");
+                if (executeAt == null)
+                {
+                    if (saveStatus == SaveStatus.NotDefined || saveStatus.status == Status.AcceptedInvalidate)
+                        return IRRELEVANT;
 
-                if (participants != null && txnId.compareTo(minVisitedFutureRX.foldlWithDefault(participants, TxnId::max, TxnId.MAX, TxnId.NONE)) >= 0)
-                    return false;
+                    Invariants.refuseArgument("executeAt was expected to be non-null");
+                }
             }
+
+            if (txnId.compareTo(minTxnId) < 0)
+                return IRRELEVANT;
+
+            Relevance atLeast = IRRELEVANT;
+            if (loadKeysFor == RECOVERY && txnId.witnesses(primaryTxnId))
+            {
+                if (isIgnorableFutureRx(txnId, participants))
+                    return IRRELEVANT;
+
+                atLeast = supersedingRelevance(txnId, saveStatus, executeAt, participants);
+            }
+
+            if (primaryExecuteAt.compareTo(txnId) < 0 || !primaryTxnId.witnesses(txnId))
+                return atLeast;
 
             boolean mayFilterAsDecided = maxDecidedRX != null && (txnId.isSyncPoint() || (durability != null && durability.isDurablyCommitted()));
             if (!mayFilterAsDecided)
-                return true;
+                return atLeast.or(ACTIVE);
 
-            if (decidedRx != null && !decidedRx.includeDecided(txnId))
-                return false;
+            if (decidedRx != null && decidedRx.excludeDecided(txnId))
+                return atLeast;
 
             if (participants == null)
-                return true;
+                return atLeast.or(ACTIVE);
 
             DecidedRX decidedRx = forDeps(maxDecidedRX, participants, primaryTxnId);
-            return decidedRx == null || decidedRx.includeDecided(txnId);
+            return atLeast.or(decidedRx == null || decidedRx.includeDecided(txnId) ? ACTIVE : IRRELEVANT);
+        }
+
+        private Relevance supersedingRelevance(TxnId txnId, @Nullable SaveStatus saveStatus, @Nullable Timestamp executeAt, @Nullable Unseekables<?> participants)
+        {
+            if (txnId.isSyncPoint())
+                executeAt = txnId;
+
+            Relevance ifRelevant = SUPERSEDING;
+            if (saveStatus != null)
+            {
+                switch (saveStatus.known.deps())
+                {
+                    default: throw UnhandledEnum.unknown(saveStatus.known.deps());
+                    case NoDeps: throw UnhandledEnum.invalid(NoDeps);
+                    case DepsUnknown:
+                        // SyncPoint do not (by default) collect additional dependencies in their Accept phase; to support this we must
+                        // wait for any undecided future sync point (prior to the latest decided one after us) to decide itself
+                        // and record its dependencies here. However, we ignore any we have not directly witnessed.
+                        // This does not risk deadlock as there is no fast path to recover for sync points
+                        if (txnId.isSyncPoint() && !saveStatus.is(Status.NotDefined))
+                            break;
+                    case DepsErased:
+                        return IRRELEVANT;
+                    case DepsFromCoordinator:
+                    case DepsProposedFixed:
+                        executeAt = txnId;
+                        break;
+                    case DepsProposed:
+                        if (txnId.compareTo(primaryTxnId) < 0)
+                            ifRelevant = MAYBE_SUPERSEDING;
+                        // cannot assume executeAt is txnId for DepsProposed when not sync point,
+                        // as if the transaction executes after us we may need to wait for the transaction to stabilise its dependencies
+                    case DepsCommitted:
+                    case DepsKnown:
+                }
+            }
+
+            if ((executeAt == null || executeAt.compareTo(primaryTxnId) > 0) && (participants == null || participants.intersects(searchFor)))
+            {
+                // TODO (desired): for pre-filter we can terminate here; only need to continue on construction
+                return ifRelevant;
+            }
+            return IRRELEVANT;
+        }
+
+        public final boolean isIgnorableFutureRx(TxnId txnId, Unseekables<?> participants)
+        {
+            return txnId.isSyncPoint() &&
+                   (txnId.compareTo(maxRx) > 0 ||
+                    (participants != null
+                     && txnId.compareTo(primaryTxnId) > 0
+                     && txnId.compareTo(minVisitedFutureRX.foldlWithDefault(participants, TxnId::max, TxnId.MAX, TxnId.NONE)) > 0));
         }
 
         public final Summary ifRelevant(TxnId txnId, Timestamp executeAt, SaveStatus saveStatus, Durability durability, StoreParticipants participants, @Nullable PartialDeps partialDeps)
@@ -342,87 +514,44 @@ public interface CommandSummaries
 
         public final <P> Summary ifRelevant(TxnId txnId, Timestamp executeAt, SaveStatus saveStatus, Durability durability, Participants<?> touches, @Nullable P deps, TriPredicate<P, TxnId, Unseekables<?>> depTester)
         {
-            SummaryStatus summaryStatus = saveStatus.summary;
-            if (summaryStatus == null)
-                return null;
-
-            if (!txnId.is(testKind))
-                return null;
-
-            if (txnId.compareTo(minTxnId) < 0 || txnId.compareTo(maxTxnId) > 0)
-                return null;
-
-            boolean mayFilterAsDecided = maxDecidedRX != null && (txnId.isSyncPoint() || durability.isDurablyCommitted());
-            if (mayFilterAsDecided && decidedRx != null && decidedRx.excludeDecided(txnId))
-                return null;
-
-            // start in search key domain, since this is what we consult to decide if can be recovered
-            Unseekables<?> intersecting = searchKeysOrRanges.intersecting(touches, Minimal);
-            if (intersecting.isEmpty())
-                return null;
-
-            if (redundantBefore != null)
-            {
-                // TODO (expected): consider whether this is necessary (and document it).
-                Unseekables<?> newIntersecting = redundantBefore.foldlWithBounds(intersecting, (e, accum, start, end) -> {
-                    if (e.gcBefore.compareTo(txnId) <= 0)
-                        return accum;
-                    return accum.without(Ranges.of(start.rangeFactory().newRange(start, end)));
-                }, intersecting, ignore -> false);
-
-                if (newIntersecting.isEmpty())
-                    return null;
-
-                intersecting = newIntersecting;
-            }
-
-            if (mayFilterAsDecided)
-            {
-                DecidedRX decidedRx = forDeps(maxDecidedRX, intersecting, primaryTxnId);
-                if (decidedRx != null && decidedRx.excludeDecided(txnId))
-                    return null;
-            }
-
-            IsDep isDep = null;
-            if (findAsDep != null)
-            {
-                if (deps == null || !isEligibleDep(summaryStatus, findAsDep, txnId, executeAt))
-                {
-                    isDep = IsDep.NOT_ELIGIBLE;
-                }
-                else
-                {
-                    boolean isCoordDeps = summaryStatus.compareTo(ACCEPTED) < 0;
-                    boolean isAnyDep = depTester.test(deps, findAsDep, intersecting);
-                    isDep = isAnyDep ? (isCoordDeps ? IsDep.IS_COORD_DEP     : IsDep.IS_PROPOSED_OR_STABLE_DEP)
-                                     : (isCoordDeps ? IsDep.IS_NOT_COORD_DEP : IsDep.IS_NOT_PROPOSED_OR_STABLE_DEP);
-                }
-            }
-
-            // convert to the domain of the command we're loading
-            intersecting = touches.intersecting(intersecting, Minimal);
-            return construct(txnId, executeAt, summaryStatus, durability, isDep, intersecting);
+            Relevance relevance = relevance(txnId, saveStatus, durability, executeAt, touches);
+            return get(relevance, txnId, executeAt, saveStatus, durability, touches, deps, depTester);
         }
 
-        final boolean isEligibleDep(SummaryStatus status, TxnId findAsDep, TxnId txnId, Timestamp executeAt)
+        public final <P> Summary get(Relevance relevance, Command cmd)
         {
-            switch (status)
+            return get(relevance, cmd.txnId(), cmd.executeAtOrTxnId(), cmd.saveStatus(), cmd.durability(), cmd.participants().stillTouches(), cmd.partialDeps(), SummaryLoader::isDep);
+        }
+
+        public final <P> Summary get(Relevance relevance, TxnId txnId, Timestamp executeAt, SaveStatus saveStatus, Durability durability, Participants<?> touches, @Nullable PartialDeps partialDeps)
+        {
+            return get(relevance, txnId, executeAt, saveStatus, durability, touches, partialDeps, SummaryLoader::isDep);
+        }
+
+        public final <P> Summary get(Relevance relevance, TxnId txnId, Timestamp executeAt, SaveStatus saveStatus, Durability durability, Participants<?> touches, @Nullable P deps, TriPredicate<P, TxnId, Unseekables<?>> depTester)
+        {
+            touches = touches.intersecting(searchFor, Minimal);
+            IsDep isDep = loadKeysFor == RECOVERY ? IsDep.NOT_ELIGIBLE : null;
+            switch (relevance)
             {
-                default: throw new UnhandledEnum(status);
-                case NOT_DIRECTLY_WITNESSED:
-                case INVALIDATED:
-                    return false;
-                case NOTACCEPTED:
-                case PREACCEPTED:
-                    if (!txnId.is(PrivilegedCoordinatorWithDeps))
-                        return false;
-                case ACCEPTED:
-                    return txnId.compareTo(findAsDep) > 0;
-                case COMMITTED:
-                case APPLIED:
-                case STABLE:
-                    return executeAt.compareTo(findAsDep) > 0;
+                default: throw new UnhandledEnum(relevance);
+                case IRRELEVANT: return null;
+                case BOTH:
+                case SUPERSEDING:
+                    if (deps != null)
+                    {
+                        boolean isCoordDeps = saveStatus.summary.compareTo(ACCEPTED) < 0;
+                        boolean isAnyDep = depTester.test(deps, primaryTxnId, touches);
+                        isDep = isAnyDep ? (isCoordDeps ? IsDep.IS_COORD_DEP     : IsDep.IS_PROPOSED_OR_STABLE_DEP)
+                                         : (isCoordDeps ? IsDep.IS_NOT_COORD_DEP : IsDep.IS_NOT_PROPOSED_OR_STABLE_DEP);
+                    }
+                    else Invariants.require(txnId.isSyncPoint() && (saveStatus.summary == PREACCEPTED || saveStatus.summary == NOTACCEPTED));
+                case MAYBE_BOTH:
+                case MAYBE_SUPERSEDING:
+                case ACTIVE:
             }
+            return construct(txnId, executeAt, saveStatus.summary, durability, isDep, relevance, touches);
+
         }
 
         private static boolean isDep(PartialDeps deps, TxnId find, Unseekables<?> intersecting)
@@ -434,13 +563,12 @@ public interface CommandSummaries
 
         }
 
-        protected Summary construct(TxnId txnId, Timestamp executeAt, SummaryStatus summaryStatus, Durability durability, IsDep isDep, Unseekables<?> participants)
+        protected Summary construct(TxnId txnId, Timestamp executeAt, SummaryStatus summaryStatus, Durability durability, IsDep isDep, Relevance relevance, Unseekables<?> participants)
         {
-            return new Summary(txnId, executeAt, summaryStatus, durability, isDep, participants);
+            return new Summary(txnId, executeAt, summaryStatus, durability, isDep, relevance, participants);
         }
     }
     
-    enum TestStartedAt { STARTED_BEFORE, STARTED_AFTER, ANY }
     enum ComputeIsDep
     {
         // don't test deps
@@ -456,7 +584,7 @@ public interface CommandSummaries
         default void visitMaxAppliedHlc(long maxAppliedHlc) {}
     }
 
-    interface AllCommandVisitor
+    interface SupersedingCommandVisitor
     {
         /**
          * Note: Durability is not guaranteed to return anything besides NotDurable; implementation is free to return more information if easily available.
@@ -464,7 +592,7 @@ public interface CommandSummaries
         boolean visit(Unseekable keyOrRange, TxnId txnId, Timestamp executeAt, SummaryStatus status, @Nullable IsDep dep, Durability minDurability);
     }
 
-    boolean visit(Unseekables<?> keysOrRanges, TxnId testTxnId, Kinds testKind, TestStartedAt testStartedAt, Timestamp testStartAtTimestamp, ComputeIsDep computeIsDep, AllCommandVisitor visit);
+    boolean visit(Unseekables<?> keysOrRanges, TxnId testTxnId, Kinds testKind, SupersedingCommandVisitor visit);
 
     /**
      * Visits keys first in ascending order, with equal keys visiting TxnId is ascending order.
@@ -476,33 +604,20 @@ public interface CommandSummaries
     interface ByTxnIdSnapshot extends CommandSummaries
     {
         NavigableMap<Timestamp, Summary> byTxnId();
-        class Helper
-        {
-            static <S extends Summary> NavigableMap<Timestamp, S> slice(TestStartedAt testStartedAt, Timestamp testStartedAtTimestamp, NavigableMap<Timestamp, S> map)
-            {
-                switch (testStartedAt)
-                {
-                    default: throw new UnhandledEnum(testStartedAt);
-                    case STARTED_AFTER: return map.tailMap(testStartedAtTimestamp, false);
-                    case STARTED_BEFORE: return map.headMap(testStartedAtTimestamp, false);
-                    case ANY: return map;
-                }
-            }
-        }
 
         default boolean visit(Unseekables<?> keysOrRanges,
                               TxnId testTxnId,
                               Kinds testKind,
-                              TestStartedAt testStartedAt,
-                              Timestamp testStartedAtTimestamp,
-                              ComputeIsDep computeIsDep,
-                              AllCommandVisitor visit)
+                              SupersedingCommandVisitor visit)
         {
-            NavigableMap<Timestamp, Summary> map = Helper.slice(testStartedAt, testStartedAtTimestamp, byTxnId());
+            NavigableMap<Timestamp, Summary> map = byTxnId();
 
             for (Summary value : map.values())
             {
                 if (!testKind.test(value))
+                    continue;
+
+                if (!value.is(MAYBE_SUPERSEDING))
                     continue;
 
                 Unseekables<?> participants = value.participants;
@@ -510,6 +625,7 @@ public interface CommandSummaries
                 if (!intersecting.isEmpty())
                 {
                     Timestamp executeAt = value.plainExecuteAt();
+                    Invariants.require(executeAt != null);
                     SummaryStatus status = value.status();
                     IsDep dep = value.isDep();
                     for (Unseekable participant : intersecting)
@@ -533,6 +649,9 @@ public interface CommandSummaries
                     continue;
 
                 if (value.is(SummaryStatus.INVALIDATED))
+                    continue;
+
+                if (!value.is(ACTIVE))
                     continue;
 
                 for (Unseekable keyOrRange : value.participants.intersecting(keysOrRanges, Minimal))

--- a/accord-core/src/main/java/accord/local/Commands.java
+++ b/accord-core/src/main/java/accord/local/Commands.java
@@ -1303,9 +1303,9 @@ public class Commands
                     {
                         // TODO (desired): slightly costly to invert a large partialDeps collection
                         participants = waiting.partialDeps().participants(dep.txnId());
-                        Participants<?> stillExecutes = participants.intersecting(waiting.participants().stillExecutes(), Minimal);
+                        Participants<?> waitsOn = participants.intersecting(waiting.participants().stillWaitsOn(), Minimal);
 
-                        depSafe = maybeCleanupRedundantDependency(safeStore, waitingSafe, depSafe, stillExecutes);
+                        depSafe = maybeCleanupRedundantDependency(safeStore, waitingSafe, depSafe, waitsOn);
                         if (depSafe == null)
                             continue;
                     }

--- a/accord-core/src/main/java/accord/local/DurableBefore.java
+++ b/accord-core/src/main/java/accord/local/DurableBefore.java
@@ -42,14 +42,14 @@ public class DurableBefore extends ReducingRangeMap<DurableBefore.Entry>
 {
     public static class SerializerSupport
     {
-        public static DurableBefore create(boolean inclusiveEnds, RoutingKey[] ends, Entry[] values)
+        public static DurableBefore create(RoutingKey[] ends, Entry[] values)
         {
             if (values.length == 0)
             {
                 Invariants.require(ends.length == 1 && ends[0] == null);
                 return DurableBefore.EMPTY;
             }
-            return new DurableBefore(inclusiveEnds, ends, values);
+            return new DurableBefore(ends, values);
         }
     }
 
@@ -135,9 +135,9 @@ public class DurableBefore extends ReducingRangeMap<DurableBefore.Entry>
         this.min = new Entry(TxnId.NONE, TxnId.NONE);
     }
 
-    DurableBefore(boolean inclusiveEnds, RoutingKey[] starts, Entry[] values)
+    DurableBefore(RoutingKey[] starts, Entry[] values)
     {
-        super(inclusiveEnds, starts, values);
+        super(starts, values);
         if (values.length == 0)
         {
             min = new Entry(TxnId.NONE, TxnId.NONE);
@@ -218,15 +218,15 @@ public class DurableBefore extends ReducingRangeMap<DurableBefore.Entry>
 
     static class Builder extends AbstractBoundariesBuilder<RoutingKey, Entry, DurableBefore>
     {
-        protected Builder(boolean inclusiveEnds, int capacity)
+        protected Builder(int capacity)
         {
-            super(inclusiveEnds, capacity);
+            super(capacity);
         }
 
         @Override
         protected DurableBefore buildInternal()
         {
-            return new DurableBefore(inclusiveEnds, starts.toArray(new RoutingKey[0]), values.toArray(new Entry[0]));
+            return new DurableBefore(starts.toArray(new RoutingKey[0]), values.toArray(new Entry[0]));
         }
     }
 

--- a/accord-core/src/main/java/accord/local/MaxConflicts.java
+++ b/accord-core/src/main/java/accord/local/MaxConflicts.java
@@ -33,9 +33,9 @@ public class MaxConflicts extends BTreeReducingRangeMap<Timestamp>
         super();
     }
 
-    private MaxConflicts(boolean inclusiveEnds, Object[] tree)
+    private MaxConflicts(Object[] tree)
     {
-        super(inclusiveEnds, tree);
+        super(tree);
     }
 
     Timestamp get(Routables<?> keysOrRanges)
@@ -53,15 +53,15 @@ public class MaxConflicts extends BTreeReducingRangeMap<Timestamp>
 
     private static class Builder extends AbstractBoundariesBuilder<RoutingKey, Timestamp, MaxConflicts>
     {
-        protected Builder(boolean inclusiveEnds, int capacity)
+        protected Builder(int capacity)
         {
-            super(inclusiveEnds, capacity);
+            super(capacity);
         }
 
         @Override
         protected MaxConflicts buildInternal(Object[] tree)
         {
-            return new MaxConflicts(inclusiveEnds, tree);
+            return new MaxConflicts(tree);
         }
     }
 }

--- a/accord-core/src/main/java/accord/local/MaxDecidedRX.java
+++ b/accord-core/src/main/java/accord/local/MaxDecidedRX.java
@@ -126,9 +126,9 @@ public class MaxDecidedRX extends ReducingRangeMap<MaxDecidedRX.DecidedRX>
         super();
     }
 
-    private MaxDecidedRX(boolean inclusiveEnds, RoutingKey[] starts, DecidedRX[] values)
+    private MaxDecidedRX(RoutingKey[] starts, DecidedRX[] values)
     {
-        super(inclusiveEnds, starts, values);
+        super(starts, values);
     }
 
     DecidedRX min(Routables<?> keysOrRanges)
@@ -196,15 +196,15 @@ public class MaxDecidedRX extends ReducingRangeMap<MaxDecidedRX.DecidedRX>
 
     static class Builder extends AbstractBoundariesBuilder<RoutingKey, DecidedRX, MaxDecidedRX>
     {
-        protected Builder(boolean inclusiveEnds, int capacity)
+        protected Builder(int capacity)
         {
-            super(inclusiveEnds, capacity);
+            super(capacity);
         }
 
         @Override
         protected MaxDecidedRX buildInternal()
         {
-            return new MaxDecidedRX(inclusiveEnds, starts.toArray(new RoutingKey[0]), values.toArray(new DecidedRX[0]));
+            return new MaxDecidedRX(starts.toArray(new RoutingKey[0]), values.toArray(new DecidedRX[0]));
         }
     }
 

--- a/accord-core/src/main/java/accord/local/PreLoadContext.java
+++ b/accord-core/src/main/java/accord/local/PreLoadContext.java
@@ -23,6 +23,7 @@ import accord.local.cfk.CommandsForKey;
 import accord.primitives.AbstractUnseekableKeys;
 import accord.primitives.Routable;
 import accord.primitives.RoutingKeys;
+import accord.primitives.Timestamp;
 import accord.primitives.TxnId;
 
 import accord.primitives.Unseekables;
@@ -41,6 +42,8 @@ import static accord.local.LoadKeysFor.WRITE;
 /**
  * Lists txnids and keys of commands and commands for key that will be needed for an operation. Used
  * to ensure the necessary state is in memory for an operation before it executes.
+ *
+ * TODO (desired): rename to simply Context, or LoadContext
  */
 public interface PreLoadContext
 {
@@ -95,7 +98,10 @@ public interface PreLoadContext
     default Unseekables<?> keys() { return RoutingKeys.EMPTY; }
 
     default LoadKeys loadKeys() { return NONE; }
+
     default LoadKeysFor loadKeysFor() { return WRITE; }
+
+    default Timestamp executeAt() { return primaryTxnId(); }
 
     default boolean isEmpty()
     {

--- a/accord-core/src/main/java/accord/local/RedundantBefore.java
+++ b/accord-core/src/main/java/accord/local/RedundantBefore.java
@@ -93,9 +93,9 @@ public class RedundantBefore extends ReducingRangeMap<RedundantBefore.Bounds>
 
     public static class SerializerSupport
     {
-        public static RedundantBefore create(boolean inclusiveEnds, RoutingKey[] ends, Bounds[] values)
+        public static RedundantBefore create(RoutingKey[] ends, Bounds[] values)
         {
-            return new RedundantBefore(inclusiveEnds, ends, values);
+            return new RedundantBefore(ends, values);
         }
     }
 
@@ -820,9 +820,9 @@ public class RedundantBefore extends ReducingRangeMap<RedundantBefore.Bounds>
         minEndEpoch = Long.MAX_VALUE;
     }
 
-    RedundantBefore(boolean inclusiveEnds, RoutingKey[] starts, Bounds[] values)
+    RedundantBefore(RoutingKey[] starts, Bounds[] values)
     {
-        super(inclusiveEnds, starts, values);
+        super(starts, values);
         staleRanges = extractRanges(values, b -> b.staleUntilAtLeast != null);
         lostRanges = extractRanges(values, Bounds::hasLostOwnership);
         TxnId maxUnready = TxnId.NONE, maxGcBefore = TxnId.NONE, maxShardAppliedBefore = TxnId.NONE;
@@ -914,7 +914,7 @@ public class RedundantBefore extends ReducingRangeMap<RedundantBefore.Bounds>
             return EMPTY;
 
         Bounds bounds = new Bounds(null, startEpoch, endEpoch, new TxnId[] { bound }, new int[] { (int) (status.encoded & ONLY_LE_MASK), (int)status.encoded }, staleUntilAtLeast);
-        Builder builder = new Builder(ranges.get(0).endInclusive(), ranges.size() * 2);
+        Builder builder = new Builder(ranges.size() * 2);
         for (int i = 0 ; i < ranges.size() ; ++i)
         {
             Range cur = ranges.get(i);
@@ -1114,9 +1114,9 @@ public class RedundantBefore extends ReducingRangeMap<RedundantBefore.Bounds>
 
     public static class Builder extends AbstractIntervalBuilder<RoutingKey, Bounds, RedundantBefore>
     {
-        public Builder(boolean inclusiveEnds, int capacity)
+        public Builder(int capacity)
         {
-            super(inclusiveEnds, capacity);
+            super(capacity);
         }
 
         @Override
@@ -1158,7 +1158,7 @@ public class RedundantBefore extends ReducingRangeMap<RedundantBefore.Bounds>
         @Override
         protected RedundantBefore buildInternal()
         {
-            return new RedundantBefore(inclusiveEnds, starts.toArray(new RoutingKey[0]), values.toArray(new Bounds[0]));
+            return new RedundantBefore(starts.toArray(new RoutingKey[0]), values.toArray(new Bounds[0]));
         }
     }
 

--- a/accord-core/src/main/java/accord/local/RejectBefore.java
+++ b/accord-core/src/main/java/accord/local/RejectBefore.java
@@ -33,9 +33,9 @@ public class RejectBefore extends ReducingRangeMap<Timestamp>
 {
     public static class SerializerSupport
     {
-        public static RejectBefore create(boolean inclusiveEnds, RoutingKey[] ends, Timestamp[] values)
+        public static RejectBefore create(RoutingKey[] ends, Timestamp[] values)
         {
-            return new RejectBefore(inclusiveEnds, ends, values);
+            return new RejectBefore(ends, values);
         }
     }
 
@@ -44,9 +44,9 @@ public class RejectBefore extends ReducingRangeMap<Timestamp>
         super();
     }
 
-    protected RejectBefore(boolean inclusiveEnds, RoutingKey[] starts, Timestamp[] values)
+    protected RejectBefore(RoutingKey[] starts, Timestamp[] values)
     {
-        super(inclusiveEnds, starts, values);
+        super(starts, values);
     }
 
     public static RejectBefore add(RejectBefore existing, Ranges ranges, TxnId value)
@@ -83,15 +83,15 @@ public class RejectBefore extends ReducingRangeMap<Timestamp>
 
     static class Builder extends AbstractBoundariesBuilder<RoutingKey, Timestamp, RejectBefore>
     {
-        protected Builder(boolean inclusiveEnds, int capacity)
+        protected Builder(int capacity)
         {
-            super(inclusiveEnds, capacity);
+            super(capacity);
         }
 
         @Override
         protected RejectBefore buildInternal()
         {
-            return new RejectBefore(inclusiveEnds, starts.toArray(new RoutingKey[0]), values.toArray(new Timestamp[0]));
+            return new RejectBefore(starts.toArray(new RoutingKey[0]), values.toArray(new Timestamp[0]));
         }
     }
 }

--- a/accord-core/src/main/java/accord/local/SafeCommandStore.java
+++ b/accord-core/src/main/java/accord/local/SafeCommandStore.java
@@ -281,9 +281,11 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
 
     protected void update(Command prev, Command updated, boolean force)
     {
-        updateMaxConflicts(prev, updated, force);
-        updateCommandsForKey(prev, updated, force);
         updateExclusiveSyncPoint(prev, updated, force);
+        updateMaxConflicts(prev, updated, force);
+        if (updated.txnId().is(Range))
+            updateCommandsForRanges(prev, updated, force);
+        updateCommandsForKey(prev, updated, force);
     }
 
     public void updateExclusiveSyncPoint(Command prev, Command updated, boolean force)
@@ -298,26 +300,26 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
                 listener.update(this, updated);
         }
 
-        SaveStatus oldSaveStatus = prev == null ? SaveStatus.Uninitialised : prev.saveStatus();
+        SaveStatus prevSaveStatus = prev == null ? SaveStatus.Uninitialised : prev.saveStatus();
         SaveStatus newSaveStatus = updated.saveStatus();
 
-        if (newSaveStatus.known.isDefinitionKnown() && (force || !oldSaveStatus.known.isDefinitionKnown()))
+        if (newSaveStatus.known.isDefinitionKnown() && (force || !prevSaveStatus.known.isDefinitionKnown()))
         {
             Ranges ranges = updated.participants().touches().toRanges();
             commandStore().markExclusiveSyncPoint(this, updated.txnId(), ranges);
         }
 
-        if (newSaveStatus.compareTo(Committed) >= 0 && newSaveStatus.compareTo(TruncatedApply) <= 0 && (force || oldSaveStatus.compareTo(Committed) < 0))
+        if (newSaveStatus.compareTo(Committed) >= 0 && newSaveStatus.compareTo(TruncatedApply) <= 0 && (force || prevSaveStatus.compareTo(Committed) < 0))
         {
             Ranges ranges = updated.participants().owns().toRanges();
             commandStore().markExclusiveSyncPointDecided(this, updated.txnId(), ranges);
         }
 
-        if (newSaveStatus == Applied && (force || oldSaveStatus != Applied))
+        if (newSaveStatus == Applied && (force || prevSaveStatus != Applied))
         {
             Ranges ranges = updated.participants().touches().toRanges();
             TxnId txnIdWithFlags = (TxnId)updated.executeAt();
-            commandStore().markExclusiveSyncPointLocallyApplied(this, txnIdWithFlags, ranges);
+            commandStore().markExclusiveSyncPointLocallyApplied(this, txnIdWithFlags, ranges, prevSaveStatus);
         }
 
         if (updated.partialDeps() != null)
@@ -357,36 +359,8 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
         commandStore().updateMaxConflicts(prev, updated, force);
     }
 
-    /**
-     * Methods that implementors can use to capture changes to auxiliary collections:
-     */
-
-    public abstract void upsertRedundantBefore(RedundantBefore addRedundantBefore);
-
-    protected void unsafeSetRedundantBefore(RedundantBefore newRedundantBefore)
+    public void updateCommandsForRanges(Command prev, Command updated, boolean force)
     {
-        commandStore().unsafeSetRedundantBefore(newRedundantBefore);
-    }
-
-    protected void unsafeUpsertRedundantBefore(RedundantBefore addRedundantBefore)
-    {
-        commandStore().unsafeUpsertRedundantBefore(addRedundantBefore);
-        commandStore().updatedRedundantBefore(this, addRedundantBefore);
-    }
-
-    public void setBootstrapBeganAt(NavigableMap<TxnId, Ranges> newBootstrapBeganAt)
-    {
-        commandStore().unsafeSetBootstrapBeganAt(newBootstrapBeganAt);
-    }
-
-    public void setSafeToRead(NavigableMap<Timestamp, Ranges> newSafeToRead)
-    {
-        commandStore().unsafeSetSafeToRead(newSafeToRead);
-    }
-
-    public void setRangesForEpoch(CommandStores.RangesForEpoch rangesForEpoch)
-    {
-        commandStore().unsafeSetRangesForEpoch(rangesForEpoch);
     }
 
     public void updateCommandsForKey(Command prev, Command next, boolean force)
@@ -402,8 +376,6 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
 //        else if (txnId.is(Range) && next.known().deps.hasProposedOrDecidedDeps())
 //            updateUnmanagedCommandsForKey(this, next, REGISTER_DEPS_ONLY);
     }
-
-    abstract protected void persistFieldUpdates();
 
     private static void updateManagedCommandsForKey(SafeCommandStore safeStore, Command prev, Command next, boolean forceNotify)
     {
@@ -516,15 +488,6 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
         }
     }
 
-    private static TxnId maxTxnId(KeyDeps keyDeps, RoutingKey key)
-    {
-        int i = keyDeps.keys().indexOf(key);
-        if (i < 0)
-            return TxnId.NONE;
-        SortedList<TxnId> txnIdsForKey = keyDeps.txnIdsForKeyIndex(i);
-        return txnIdsForKey.get(txnIdsForKey.size() - 1);
-    }
-
     private static void updateUnmanagedCommandsForKey(SafeCommandStore safeStore, Unseekables<?> update, TxnId txnId, UpdateUnmanagedMode mode)
     {
         SafeCommand safeCommand = safeStore.get(txnId);
@@ -583,6 +546,40 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
 
         safeCommand.updateParticipants(safeStore, safeCommand.current().participants().supplement(null, witnessedBy));
     }
+
+    /**
+     * Methods that implementors can use to capture changes to auxiliary collections:
+     */
+
+    public abstract void upsertRedundantBefore(RedundantBefore addRedundantBefore);
+
+    protected void unsafeSetRedundantBefore(RedundantBefore newRedundantBefore)
+    {
+        commandStore().unsafeSetRedundantBefore(newRedundantBefore);
+    }
+
+    protected void unsafeUpsertRedundantBefore(RedundantBefore addRedundantBefore)
+    {
+        commandStore().unsafeUpsertRedundantBefore(addRedundantBefore);
+        commandStore().updatedRedundantBefore(this, addRedundantBefore);
+    }
+
+    public void setBootstrapBeganAt(NavigableMap<TxnId, Ranges> newBootstrapBeganAt)
+    {
+        commandStore().unsafeSetBootstrapBeganAt(newBootstrapBeganAt);
+    }
+
+    public void setSafeToRead(NavigableMap<Timestamp, Ranges> newSafeToRead)
+    {
+        commandStore().unsafeSetSafeToRead(newSafeToRead);
+    }
+
+    public void setRangesForEpoch(CommandStores.RangesForEpoch rangesForEpoch)
+    {
+        commandStore().unsafeSetRangesForEpoch(rangesForEpoch);
+    }
+
+    protected abstract void persistFieldUpdates();
 
     public abstract CommandStore commandStore();
     public abstract DataStore dataStore();

--- a/accord-core/src/main/java/accord/local/cfk/CommandsForKey.java
+++ b/accord-core/src/main/java/accord/local/cfk/CommandsForKey.java
@@ -21,7 +21,6 @@ package accord.local.cfk;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -38,11 +37,9 @@ import accord.local.Command;
 import accord.local.SafeCommand;
 import accord.local.SafeCommandStore;
 import accord.local.CommandSummaries.ActiveCommandVisitor;
-import accord.local.CommandSummaries.AllCommandVisitor;
+import accord.local.CommandSummaries.SupersedingCommandVisitor;
 import accord.local.CommandSummaries.IsDep;
 import accord.local.CommandSummaries.SummaryStatus;
-import accord.local.CommandSummaries.ComputeIsDep;
-import accord.local.CommandSummaries.TestStartedAt;
 import accord.primitives.Deps;
 import accord.primitives.Deps.DepRelationList;
 import accord.primitives.RoutingKeys;
@@ -58,7 +55,6 @@ import accord.primitives.Txn.Kind.Kinds;
 import accord.primitives.TxnId;
 import accord.utils.Invariants;
 import accord.utils.SortedArrays;
-import accord.utils.UnhandledEnum;
 import accord.utils.btree.BTree;
 
 import static accord.api.ProgressLog.BlockedUntil.CanApply;
@@ -97,7 +93,6 @@ import static accord.local.cfk.Pruning.removeRedundantById;
 import static accord.local.cfk.Pruning.prunedBeforeId;
 import static accord.local.cfk.UpdateUnmanagedMode.UPDATE;
 import static accord.local.cfk.Updating.insertOrUpdate;
-import static accord.local.CommandSummaries.ComputeIsDep.IGNORE;
 import static accord.local.cfk.Updating.maybeUpdateMaxAppliedUnreadyWriteById;
 import static accord.primitives.Known.KnownExecuteAt.ApplyAtKnown;
 import static accord.primitives.Routable.Domain.Key;
@@ -1285,7 +1280,7 @@ public class CommandsForKey extends CommandsForKeyUpdate
         TxnInfo result = committedByExecuteAt[i];
         if (untilExecuteAt != null && result.executeAt.compareTo(untilExecuteAt) >= 0)
             return null;
-        return result;
+        return result.plainTxnId();
     }
 
     @VisibleForTesting
@@ -1316,88 +1311,66 @@ public class CommandsForKey extends CommandsForKeyUpdate
      * (either executeAt is before, or txnId is before and command is not committed so deps do not extend to executeAt)
      * <p>
      */
-    public boolean visit(TxnId testTxnId,
-                         Kinds testKind,
-                         TestStartedAt testStartedAt,
-                         Timestamp testStartedAtTimestamp,
-                         ComputeIsDep computeIsDep,
-                         Predicate<SummaryStatus> testStatus,
-                         AllCommandVisitor visitor)
+    public boolean visit(TxnId testTxnId, Kinds testKind, SupersedingCommandVisitor visitor)
     {
-        int start, end, loadingIndex = 0;
+        int loadingIndex = 0;
         // if this is null the TxnId is known in byId
         // otherwise, it must be non-null and represents the transactions (if any) that have requested it be loaded due to being pruned
         TxnId prunedBefore = prunedBefore();
         TxnId[] loadingFor = null;
+        if (Arrays.binarySearch(byId, testTxnId) < 0)
         {
-            int insertPos = Arrays.binarySearch(byId, testStartedAtTimestamp);
-            if (insertPos < 0)
-            {
-                loadingFor = NOT_LOADING_PRUNED;
-                insertPos = -1 - insertPos;
-                if (computeIsDep != IGNORE && testTxnId.compareTo(prunedBefore) < 0)
-                    loadingFor = loadingPrunedFor(loadingPruned, testTxnId, NOT_LOADING_PRUNED);
-            }
-
-            switch (testStartedAt)
-            {
-                default: throw new UnhandledEnum(testStartedAt);
-                case STARTED_BEFORE: start = 0; end = insertPos; break;
-                case STARTED_AFTER: start = insertPos; end = byId.length; break;
-                case ANY: start = 0; end = byId.length;
-            }
+            loadingFor = NOT_LOADING_PRUNED;
+            if (testTxnId.compareTo(prunedBefore) < 0)
+                loadingFor = loadingPrunedFor(loadingPruned, testTxnId, NOT_LOADING_PRUNED);
         }
 
-        for (int i = start; i < end ; ++i)
+        for (int i = 0; i < byId.length ; ++i)
         {
             TxnInfo txn = byId[i];
             if (!txn.is(testKind)) continue;
             SummaryStatus summaryStatus = txn.summaryStatus();
-            if (summaryStatus == null || (testStatus != null && !testStatus.test(summaryStatus))) continue;
+            if (summaryStatus == null) continue;
 
             Timestamp executeAt = txn.executeAt;
-            IsDep dep = null;
-            if (computeIsDep != IGNORE)
+            IsDep dep;
+            if (!txn.hasDeps() || (txn.depsKnownUntilExecuteAt() ? executeAt : txn).compareTo(testTxnId) <= 0)
             {
-                if (!txn.hasDeps() || (summaryStatus == SummaryStatus.ACCEPTED ? txn : executeAt).compareTo(testTxnId) <= 0)
+                dep = NOT_ELIGIBLE;
+            }
+            else
+            {
+                boolean hasAsDep;
+                if (loadingFor == null)
                 {
-                    dep = NOT_ELIGIBLE;
+                    TxnId[] missing = txn.missing();
+                    hasAsDep = missing == NO_TXNIDS || Arrays.binarySearch(txn.missing(), testTxnId) < 0;
+                }
+                else if (loadingFor == NOT_LOADING_PRUNED)
+                {
+                    hasAsDep = false;
                 }
                 else
                 {
-                    boolean hasAsDep;
-                    if (loadingFor == null)
+                    // we could use expontentialSearch and moving index for improved algorithmic complexity,
+                    // but since should be rarely taken path probably not worth code complexity
+                    loadingIndex = SortedArrays.exponentialSearch(loadingFor, loadingIndex, loadingFor.length, txn);
+                    if (loadingIndex >= 0)
                     {
-                        TxnId[] missing = txn.missing();
-                        hasAsDep = missing == NO_TXNIDS || Arrays.binarySearch(txn.missing(), testTxnId) < 0;
-                    }
-                    else if (loadingFor == NOT_LOADING_PRUNED)
-                    {
-                        hasAsDep = false;
+                        hasAsDep = !loadingFor[loadingIndex].is(UNSTABLE);
+                        ++loadingIndex;
                     }
                     else
                     {
-                        // we could use expontentialSearch and moving index for improved algorithmic complexity,
-                        // but since should be rarely taken path probably not worth code complexity
-                        loadingIndex = SortedArrays.exponentialSearch(loadingFor, loadingIndex, loadingFor.length, txn);
-                        if (loadingIndex >= 0)
-                        {
-                            hasAsDep = !loadingFor[loadingIndex].is(UNSTABLE);
-                            ++loadingIndex;
-                        }
-                        else
-                        {
-                            hasAsDep = false;
-                            loadingIndex = -1 - loadingIndex;
-                        }
+                        hasAsDep = false;
+                        loadingIndex = -1 - loadingIndex;
                     }
-
-                    if (txn.compareTo(ACCEPTED) >= 0) dep = hasAsDep ? IS_PROPOSED_OR_STABLE_DEP : IS_NOT_PROPOSED_OR_STABLE_DEP;
-                    else if (txn.is(PrivilegedCoordinatorWithDeps)) dep = hasAsDep ? IS_COORD_DEP : IS_NOT_COORD_DEP;
-                    else dep = NOT_ELIGIBLE;
                 }
-            }
 
+                if (txn.compareTo(ACCEPTED) >= 0) dep = hasAsDep ? IS_PROPOSED_OR_STABLE_DEP : IS_NOT_PROPOSED_OR_STABLE_DEP;
+                else if (txn.is(PrivilegedCoordinatorWithDeps)) dep = hasAsDep ? IS_COORD_DEP : IS_NOT_COORD_DEP;
+                else dep = NOT_ELIGIBLE;
+            }
             if (!visitor.visit(key, txn.plainTxnId(), executeAt, summaryStatus, dep, txn.durability()))
                 return false;
         }

--- a/accord-core/src/main/java/accord/local/durability/DurabilityQueue.java
+++ b/accord-core/src/main/java/accord/local/durability/DurabilityQueue.java
@@ -55,7 +55,9 @@ import accord.utils.SymmetricComparator;
 import accord.utils.async.Cancellable;
 import accord.utils.btree.BTree;
 import accord.utils.btree.IntervalBTree;
+import accord.utils.btree.IntervalBTree.IntervalComparators;
 
+import static accord.api.ProtocolModifiers.RangeSpec.isEndInclusive;
 import static accord.coordinate.ExecuteSyncPoint.coordinateIncluding;
 import static accord.local.durability.DurabilityQueue.Status.ABANDONED;
 import static accord.local.durability.DurabilityQueue.Status.ACTIVE;
@@ -146,7 +148,7 @@ public class DurabilityQueue
         }
     }
 
-    private static final PendingComparators BY_RANGE = new PendingComparators();
+    private static final IntervalComparators<PendingRange> BY_RANGE = new InclusiveEndPendingComparators();
     private static final Comparator<Pending> BY_PRIORITY = (a, b) -> {
         if ((a.status == ACTIVE) != (b.status == ACTIVE))
             return a.status == ACTIVE ? -1 : 1;
@@ -159,7 +161,7 @@ public class DurabilityQueue
         return a.syncPoint.syncId.compareTo(b.syncPoint.syncId);
     };
 
-    private static class PendingComparators implements IntervalBTree.IntervalComparators<PendingRange>
+    private static class InclusiveEndPendingComparators implements IntervalComparators<PendingRange>
     {
         @Override public Comparator<PendingRange> totalOrder()
         {
@@ -310,12 +312,13 @@ public class DurabilityQueue
 
     public DurabilityQueue(Node node)
     {
-        this.adapter = new NodeAdapter(node);
+        this(new NodeAdapter(node));
     }
 
     public DurabilityQueue(Adapter adapter)
     {
         this.adapter = adapter;
+        Invariants.require(isEndInclusive(), "Need to implement range-exclusive IntervalComparators");
     }
 
     void submit(SyncPoint syncPoint, @Nullable DurabilityRequest request)

--- a/accord-core/src/main/java/accord/messages/Accept.java
+++ b/accord-core/src/main/java/accord/messages/Accept.java
@@ -44,10 +44,12 @@ import accord.primitives.Timestamp;
 import accord.primitives.TxnId;
 import accord.topology.Topologies;
 import accord.utils.Invariants;
+import accord.utils.TinyEnumSet;
 import accord.utils.UnhandledEnum;
 import accord.utils.async.Cancellable;
 
 import static accord.api.ProtocolModifiers.Toggles.filterDuplicateDependenciesFromAcceptReply;
+import static accord.api.ProtocolModifiers.Toggles.syncPointsTrackUnstableMediumPathDependencies;
 import static accord.local.Commands.AcceptOutcome.Redundant;
 import static accord.local.Commands.AcceptOutcome.RejectedBallot;
 import static accord.local.Commands.AcceptOutcome.Success;
@@ -63,40 +65,78 @@ public class Accept extends RouteRequest.WithUnsynced<Accept.AcceptReply>
 {
     public static class SerializerSupport
     {
-        public static Accept create(TxnId txnId, Route<?> scope, long waitForEpoch, long minEpoch, Kind kind, Ballot ballot, Timestamp executeAt, PartialDeps partialDeps, boolean isPartialAccept)
+        public static Accept create(TxnId txnId, Route<?> scope, long waitForEpoch, long minEpoch, Kind kind, Ballot ballot, Timestamp executeAt, PartialDeps partialDeps, int acceptFlags)
         {
-            return new Accept(txnId, scope, waitForEpoch, minEpoch, kind, ballot, executeAt, partialDeps, isPartialAccept);
+            return new Accept(txnId, scope, waitForEpoch, minEpoch, kind, ballot, executeAt, partialDeps, acceptFlags);
         }
     }
 
     public enum Kind { SLOW, MEDIUM }
 
+    public enum AcceptFlags
+    {
+        IS_PARTIAL,
+
+        /**
+         * SyncPoints don't need to compute any deps in the Accept phase,
+         * as any dependencies they did not witness in the preaccept phase cannot reach consensus
+         */
+        NO_CALCULATE_DEPS,
+
+        /**
+         * See {@link accord.api.ProtocolModifiers.Toggles#filterDuplicateDependenciesFromAcceptReply()}.
+         */
+        NO_FILTER_DEPS;
+
+        public static int encode(TxnId txnId, boolean isPartial)
+        {
+            return (isPartial ? TinyEnumSet.encode(IS_PARTIAL) : 0)
+                   | (txnId.isSyncPoint() && !syncPointsTrackUnstableMediumPathDependencies() ? TinyEnumSet.encode(NO_CALCULATE_DEPS) : 0)
+                   | (filterDuplicateDependenciesFromAcceptReply() ? 0 : TinyEnumSet.encode(NO_FILTER_DEPS));
+        }
+
+        public static boolean isPartial(int encoded)
+        {
+            return TinyEnumSet.contains(encoded, IS_PARTIAL);
+        }
+
+        public static boolean filterDeps(int encoded)
+        {
+            return !TinyEnumSet.contains(encoded, NO_FILTER_DEPS);
+        }
+
+        public static boolean calculateDeps(int encoded)
+        {
+            return !TinyEnumSet.contains(encoded, NO_CALCULATE_DEPS);
+        }
+    }
+
     public final Kind kind;
     public final Ballot ballot;
     public final Timestamp executeAt;
     private PartialDeps partialDeps;
-    public final boolean isPartialAccept;
+    public final int acceptFlags;
 
     public PartialDeps partialDeps() { return partialDeps; }
 
-    public Accept(Id to, Topologies topologies, Kind kind, Ballot ballot, TxnId txnId, FullRoute<?> route, Timestamp executeAt, Deps deps, boolean isPartialAccept)
+    public Accept(Id to, Topologies topologies, Kind kind, Ballot ballot, TxnId txnId, FullRoute<?> route, Timestamp executeAt, Deps deps, int acceptFlags)
     {
         super(to, topologies, txnId, route);
         this.kind = kind;
         this.ballot = ballot;
         this.executeAt = executeAt;
         this.partialDeps = deps.intersecting(scope);
-        this.isPartialAccept = isPartialAccept;
+        this.acceptFlags = acceptFlags;
     }
 
-    private Accept(TxnId txnId, Route<?> scope, long waitForEpoch, long minEpoch, Kind kind, Ballot ballot, Timestamp executeAt, PartialDeps partialDeps, boolean isPartialAccept)
+    private Accept(TxnId txnId, Route<?> scope, long waitForEpoch, long minEpoch, Kind kind, Ballot ballot, Timestamp executeAt, PartialDeps partialDeps, int acceptFlags)
     {
         super(txnId, scope, waitForEpoch, minEpoch);
         this.kind = kind;
         this.ballot = ballot;
         this.executeAt = executeAt;
         this.partialDeps = partialDeps;
-        this.isPartialAccept = isPartialAccept;
+        this.acceptFlags = acceptFlags;
     }
 
     @Override
@@ -121,7 +161,7 @@ public class Accept extends RouteRequest.WithUnsynced<Accept.AcceptReply>
                 Participants<?> hasDeps = null;
                 Deps deps = null;
 
-                if (command.known().is(DepsKnown) && (isPartialAccept || notOwner))
+                if (command.known().is(DepsKnown) && (isPartialAccept() || notOwner))
                 {
                     deps = command.partialDeps().asFullUnsafe();
                     hasDeps = command.participants().stillTouches();
@@ -131,12 +171,12 @@ public class Accept extends RouteRequest.WithUnsynced<Accept.AcceptReply>
                 if (superseding.compareTo(ballot) <= 0)
                     superseding = null;
 
-                boolean calculateDeps = isPartialAccept;
+                boolean calculateDeps = isPartialAccept() && calculateDeps();
                 if (command.saveStatus() == SaveStatus.Vestigial)
                 {
                     superseding = null;
                     outcome = Success;
-                    calculateDeps = true;
+                    calculateDeps = calculateDeps();
                 }
 
                 if (calculateDeps)
@@ -156,9 +196,12 @@ public class Accept extends RouteRequest.WithUnsynced<Accept.AcceptReply>
                     hasDeps = participants.touches();
                 }
 
-                Participants<?> successful = isPartialAccept ? hasDeps : null;
+                Participants<?> successful = isPartialAccept() ? hasDeps : null;
                 if (notOwner && (outcome == Redundant || (hasDeps != null && hasDeps.containsAll(participants.touches()))))
                     outcome = Success;
+
+                if (deps != null && filterDeps())
+                    deps = deps.without(partialDeps);
                 return new AcceptReply(outcome, superseding, successful, deps, command.executeAtIfKnown());
             }
 
@@ -171,21 +214,44 @@ public class Accept extends RouteRequest.WithUnsynced<Accept.AcceptReply>
             case Success:
                 ExecuteFlags flags;
                 Deps deps;
-                try (DepsCalculator calculator = new DepsCalculator())
+                if (calculateDeps())
                 {
-                    deps = calculator.calculate(safeStore, txnId, participants, minEpoch, executeAt, true);
-                    if (deps == null)
-                        return AcceptReply.inThePast(ballot, participants, safeCommand.current());
-                    flags = calculator.executeFlags(txnId);
+                    try (DepsCalculator calculator = new DepsCalculator())
+                    {
+                        deps = calculator.calculate(safeStore, txnId, participants, minEpoch, executeAt, true);
+                        if (deps == null)
+                            return AcceptReply.inThePast(ballot, participants, safeCommand.current());
+                        flags = calculator.executeFlags(txnId);
+                    }
+
+                    Invariants.require(deps.maxTxnId(txnId).epoch() <= executeAt.epoch());
+                    if (filterDeps())
+                        deps = deps.without(partialDeps);
+                }
+                else
+                {
+                    flags = ExecuteFlags.none();
+                    deps = Deps.NONE;
                 }
 
-                Invariants.require(deps.maxTxnId(txnId).epoch() <= executeAt.epoch());
-                if (filterDuplicateDependenciesFromAcceptReply())
-                    deps = deps.without(partialDeps);
-
-                Participants<?> successful = isPartialAccept ? participants.touches() : null;
+                Participants<?> successful = isPartialAccept() ? participants.touches() : null;
                 return new AcceptReply(successful, deps, flags);
         }
+    }
+
+    private boolean isPartialAccept()
+    {
+        return AcceptFlags.isPartial(acceptFlags);
+    }
+
+    private boolean calculateDeps()
+    {
+        return AcceptFlags.calculateDeps(acceptFlags);
+    }
+
+    private boolean filterDeps()
+    {
+        return AcceptFlags.filterDeps(acceptFlags);
     }
 
     @Override
@@ -218,7 +284,7 @@ public class Accept extends RouteRequest.WithUnsynced<Accept.AcceptReply>
     @Override
     public LoadKeysFor loadKeysFor()
     {
-        return LoadKeysFor.READ_WRITE;
+        return calculateDeps() ? LoadKeysFor.READ_WRITE : LoadKeysFor.WRITE;
     }
 
     @Override
@@ -374,6 +440,12 @@ public class Accept extends RouteRequest.WithUnsynced<Accept.AcceptReply>
         }
     }
 
+    @Override
+    public Timestamp executeAt()
+    {
+        return executeAt;
+    }
+
     public static class NotAccept extends ParticipantsRequest<Participants<?>, AcceptReply>
     {
         public final Status status;
@@ -436,7 +508,7 @@ public class Accept extends RouteRequest.WithUnsynced<Accept.AcceptReply>
         @Override
         public String reason()
         {
-            return status + "{" + txnId + '}';
+            return status.toString();
         }
     }
 }

--- a/accord-core/src/main/java/accord/messages/Await.java
+++ b/accord-core/src/main/java/accord/messages/Await.java
@@ -471,19 +471,6 @@ public class Await extends MapReduceConsumeCommandStores<Participants<?>, Void> 
             return node.commandStores().mapReduceConsume(txnId.epoch(), Long.MAX_VALUE, this);
         }
 
-        @Nullable
-        @Override
-        public TxnId primaryTxnId()
-        {
-            return txnId;
-        }
-
-        @Override
-        public String reason()
-        {
-            return "AwaitComplete{" + newStatus + ',' + txnId + '}';
-        }
-
         @Override
         protected void acceptInternal(Reply reply, Throwable failure)
         {

--- a/accord-core/src/main/java/accord/messages/BeginInvalidation.java
+++ b/accord-core/src/main/java/accord/messages/BeginInvalidation.java
@@ -109,21 +109,9 @@ public class BeginInvalidation extends ParticipantsRequest<Participants<?>, Begi
     }
 
     @Override
-    public long waitForEpoch()
-    {
-        return txnId.epoch();
-    }
-
-    @Override
     public MessageType type()
     {
         return BEGIN_INVALIDATE_REQ;
-    }
-
-    @Override
-    public String reason()
-    {
-        return "Invalidate{" + txnId + '}';
     }
 
     @Override

--- a/accord-core/src/main/java/accord/messages/BeginRecovery.java
+++ b/accord-core/src/main/java/accord/messages/BeginRecovery.java
@@ -48,18 +48,16 @@ import accord.utils.TinyEnumSet;
 import accord.utils.UnhandledEnum;
 import accord.utils.async.Cancellable;
 
-import static accord.local.CommandSummaries.ComputeIsDep.EITHER;
 import static accord.local.CommandSummaries.SummaryStatus.APPLIED;
 import static accord.local.CommandSummaries.SummaryStatus.NOT_DIRECTLY_WITNESSED;
 import static accord.local.CommandSummaries.SummaryStatus.ACCEPTED;
 import static accord.local.CommandSummaries.SummaryStatus.STABLE;
-import static accord.local.CommandSummaries.TestStartedAt.ANY;
 import static accord.messages.BeginRecovery.RecoverReply.Kind.Ok;
 import static accord.messages.BeginRecovery.RecoverReply.Kind.Reject;
 import static accord.messages.BeginRecovery.RecoverReply.Kind.Retired;
 import static accord.messages.BeginRecovery.RecoverReply.Kind.Truncated;
-import static accord.messages.BeginRecovery.RecoveryFlags.FAST_PATH_DECIDED;
-import static accord.messages.BeginRecovery.RecoveryFlags.FORCE_RECOVER_FAST_PATH;
+import static accord.messages.BeginRecovery.RecoveryFlags.forceRecoverFastPath;
+import static accord.messages.BeginRecovery.RecoveryFlags.isFastPathDecided;
 import static accord.messages.MessageType.StandardMessage.BEGIN_RECOVER_REQ;
 import static accord.messages.MessageType.StandardMessage.BEGIN_RECOVER_RSP;
 import static accord.primitives.Known.KnownDeps.DepsUnknown;
@@ -82,7 +80,24 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
 
     public enum RecoveryFlags
     {
-        FAST_PATH_DECIDED, FORCE_RECOVER_FAST_PATH
+        FAST_PATH_DECIDED,
+        FORCE_RECOVER_FAST_PATH,
+        NO_CALCULATE_DEPS;
+
+        public static boolean isFastPathDecided(int encoded)
+        {
+            return TinyEnumSet.contains(encoded, FAST_PATH_DECIDED);
+        }
+
+        public static boolean forceRecoverFastPath(int encoded)
+        {
+            return TinyEnumSet.contains(encoded, FORCE_RECOVER_FAST_PATH);
+        }
+
+        public static boolean calculateDeps(int encoded)
+        {
+            return !TinyEnumSet.contains(encoded, NO_CALCULATE_DEPS);
+        }
     }
 
     public final PartialTxn partialTxn;
@@ -139,7 +154,7 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
         LatestDeps deps; {
             PartialDeps coordinatedDeps = command.partialDeps();
             Deps localDeps = null;
-            if (!command.known().deps().hasCommittedOrDecidedDeps())
+            if (!command.known().deps().hasCommittedOrDecidedDeps() && calculateDeps())
             {
                 localDeps = DepsCalculator.calculateDeps(safeStore, txnId, participants, minEpoch, txnId, false);
             }
@@ -168,11 +183,11 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
         {
             try (Visitor visitor = new Visitor())
             {
-                safeStore.visit(participants.owns(), txnId, txnId.witnessedBy(), ANY, txnId, EITHER, visitor);
+                safeStore.visit(participants.owns(), txnId, txnId.witnessedBy(), visitor);
                 supersedingRejects = visitor.supersedingRejects;
-                earlierNoWait = visitor.earlierNoWait == null ? Deps.NONE : visitor.earlierNoWait.build();
-                earlierWait = visitor.earlierWait == null ? Deps.NONE : visitor.earlierWait.build();
-                laterCoordRejects = visitor.laterCoordRejects == null ? Deps.NONE : visitor.laterCoordRejects.build();
+                earlierNoWait = visitor.simpleNoWait == null ? Deps.NONE : visitor.simpleNoWait.build();
+                earlierWait = visitor.simpleWait == null ? Deps.NONE : visitor.simpleWait.build();
+                laterCoordRejects = visitor.supersedingCoordRejects == null ? Deps.NONE : visitor.supersedingCoordRejects.build();
             }
         }
 
@@ -188,9 +203,14 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
 
     private boolean recoverFastPath()
     {
-        if (TinyEnumSet.contains(flags, FORCE_RECOVER_FAST_PATH))
+        if (forceRecoverFastPath(flags))
             return true;
-        return !txnId.isSyncPoint() && !TinyEnumSet.contains(flags, FAST_PATH_DECIDED);
+        return txnId.hasFastPath() && !isFastPathDecided(flags);
+    }
+
+    private boolean calculateDeps()
+    {
+        return RecoveryFlags.calculateDeps(flags);
     }
 
     static boolean acceptsFastPath(TxnId txnId, StoreParticipants participants, SaveStatus saveStatus, @Nullable Timestamp executeAt)
@@ -224,10 +244,10 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
         if (!ok1.status.hasBeen(PreAccepted)) throw new IllegalStateException();
 
         LatestDeps deps = LatestDeps.merge(ok1.deps, ok2.deps);
-        Deps earlierNoWait = ok1.earlierNoWait.with(ok2.earlierNoWait);
-        Deps earlierWait = ok1.earlierWait.with(ok2.earlierWait)
-                                          .without(earlierNoWait);
-        Deps laterNoVote = ok1.laterCoordRejects.with(ok2.laterCoordRejects);
+        Deps earlierNoWait = ok1.simpleNoWait.with(ok2.simpleNoWait);
+        Deps earlierWait = ok1.simpleWait.with(ok2.simpleWait)
+                                         .without(earlierNoWait);
+        Deps laterNoVote = ok1.supersedingCoordRejects.with(ok2.supersedingCoordRejects);
         Timestamp timestamp = ok1.status == PreAccepted ? Timestamp.max(ok1.executeAt, ok2.executeAt) : ok1.executeAt;
 
         return new RecoverOk(
@@ -251,19 +271,15 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
     {
         if (recoverFastPath())
             return LoadKeysFor.RECOVERY;
-        return LoadKeysFor.READ_WRITE;
+        if (calculateDeps())
+            return LoadKeysFor.READ_WRITE;
+        return LoadKeysFor.WRITE;
     }
 
     @Override
     public MessageType type()
     {
         return BEGIN_RECOVER_REQ;
-    }
-
-    @Override
-    public String reason()
-    {
-        return "Recover{" + txnId + '}';
     }
 
     @Override
@@ -276,10 +292,10 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
                '}';
     }
 
-    class Visitor implements CommandSummaries.AllCommandVisitor, AutoCloseable
+    class Visitor implements CommandSummaries.SupersedingCommandVisitor, AutoCloseable
     {
-        Deps.Builder earlierWait, earlierNoWait;
-        Deps.Builder laterCoordRejects;
+        Deps.Builder simpleWait, simpleNoWait;
+        Deps.Builder supersedingCoordRejects;
         boolean supersedingRejects;
 
         @Override
@@ -315,7 +331,7 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
                             if (status != ACCEPTED)
                                 break;
                         case PREACCEPTED:
-                            ensureEarlierWait().add(keyOrRange, testTxnId);
+                            ensureSimpleWait().add(keyOrRange, testTxnId);
                         case NOTACCEPTED:
                         case INVALIDATED:
                     }
@@ -326,7 +342,7 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
                     default: throw new UnhandledEnum(dep);
                     case IS_PROPOSED_OR_STABLE_DEP:
                         if (status == STABLE || status == APPLIED)
-                            ensureEarlierNoWait().add(keyOrRange, testTxnId);
+                            ensureSimpleNoWait().add(keyOrRange, testTxnId);
                         break;
 
                     case IS_NOT_PROPOSED_OR_STABLE_DEP:
@@ -344,12 +360,12 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
                         {
                             case INVALIDATED:
                                 // TODO (desired): optionally exclude these and other normally-unnecessary entries on e.g. first recovery attempt
-                                ensureEarlierNoWait().add(keyOrRange, testTxnId);
+                                ensureSimpleNoWait().add(keyOrRange, testTxnId);
                                 break;
 
                             case ACCEPTED:
                                 if (testExecuteAt.compareTo(txnId) > 0)
-                                    ensureEarlierWait().add(keyOrRange, testTxnId);
+                                    ensureSimpleWait().add(keyOrRange, testTxnId);
                                 break;
 
                             case PREACCEPTED:
@@ -359,7 +375,7 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
                                 // (that is, if either transaction use the optimisation, we must wait for the earlier transaction)
                                 // TODO (desired): compute against shard whether this is a necessary wait condition - for many quorum configurations it isn't
                                 if (testTxnId.hasPrivilegedCoordinator() || txnId.hasPrivilegedCoordinator())
-                                    ensureEarlierWait().add(keyOrRange, testTxnId);
+                                    ensureSimpleWait().add(keyOrRange, testTxnId);
                         }
                 }
             }
@@ -389,7 +405,12 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
                     case IS_NOT_COORD_DEP:
                         Invariants.requireArgument(testTxnId.is(PrivilegedCoordinatorWithDeps));
                         // TODO (expected): if we are the original coordinator and we know we cannot fast path commit then we should not include this in the reply
-                        ensureLaterCoordRejects().add(keyOrRange, testTxnId);
+                        ensureSupersedingCoordRejects().add(keyOrRange, testTxnId);
+                }
+                if (testTxnId.isSyncPoint())
+                {
+                    if (status.compareTo(ACCEPTED) < 0) ensureSimpleWait().add(keyOrRange, testTxnId);
+                    else ensureSimpleNoWait().add(keyOrRange, testTxnId);
                 }
             }
 
@@ -402,44 +423,44 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
             return false;
         }
 
-        private Deps.Builder ensureEarlierNoWait()
+        private Deps.Builder ensureSimpleNoWait()
         {
-            if (earlierNoWait == null)
-                earlierNoWait = new Deps.Builder(true);
-            return earlierNoWait;
+            if (simpleNoWait == null)
+                simpleNoWait = new Deps.Builder(true);
+            return simpleNoWait;
         }
 
-        private Deps.Builder ensureEarlierWait()
+        private Deps.Builder ensureSimpleWait()
         {
-            if (earlierWait == null)
-                earlierWait = new Deps.Builder(true);
-            return earlierWait;
+            if (simpleWait == null)
+                simpleWait = new Deps.Builder(true);
+            return simpleWait;
         }
 
-        private Deps.Builder ensureLaterCoordRejects()
+        private Deps.Builder ensureSupersedingCoordRejects()
         {
-            if (laterCoordRejects == null)
-                laterCoordRejects = new Deps.Builder(true);
-            return laterCoordRejects;
+            if (supersedingCoordRejects == null)
+                supersedingCoordRejects = new Deps.Builder(true);
+            return supersedingCoordRejects;
         }
 
         @Override
         public void close()
         {
-            if (earlierNoWait != null)
+            if (simpleNoWait != null)
             {
-                earlierNoWait.close();
-                earlierNoWait = null;
+                simpleNoWait.close();
+                simpleNoWait = null;
             }
-            if (earlierWait != null)
+            if (simpleWait != null)
             {
-                earlierWait.close();
-                earlierWait = null;
+                simpleWait.close();
+                simpleWait = null;
             }
-            if (laterCoordRejects != null)
+            if (supersedingCoordRejects != null)
             {
-                laterCoordRejects.close();
-                laterCoordRejects = null;
+                supersedingCoordRejects.close();
+                supersedingCoordRejects = null;
             }
         }
     }
@@ -465,8 +486,13 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
         public final Ballot accepted;
         public final Timestamp executeAt;
         public final LatestDeps deps;
-        public final Deps earlierWait, earlierNoWait;
-        public final Deps laterCoordRejects;
+        // either preceding transactions or a potentially-superseding sync point (with no intervening decided sync point);
+        // these transactions cannot be blocked by our decision, so we can simply wait for their decision,
+        // and if they execute after us determine if they reject our execution
+        public final Deps simpleWait, simpleNoWait;
+        // superseding transactions where the coordinator had not witnessed us, and so they may reject our execution;
+        // these transactions may await our decision, so we must treat them differently to ensure there is no deadlock
+        public final Deps supersedingCoordRejects;
         public final boolean selfAcceptsFastPath;
         public final @Nullable Participants<?> coordinatorAcceptsFastPath;
         public final boolean supersedingRejects;
@@ -474,7 +500,7 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
         public final Result result;
 
         public RecoverOk(TxnId txnId, Status status, Ballot accepted, Timestamp executeAt, LatestDeps deps,
-                         Deps earlierWait, Deps earlierNoWait, Deps laterCoordRejects,
+                         Deps simpleWait, Deps simpleNoWait, Deps supersedingCoordRejects,
                          boolean selfAcceptsFastPath, Participants<?> coordinatorAcceptsFastPath, boolean supersedingRejects, Writes writes, Result result)
         {
             this.txnId = txnId;
@@ -482,9 +508,9 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
             this.executeAt = executeAt;
             this.status = status;
             this.deps = deps;
-            this.earlierWait = earlierWait;
-            this.earlierNoWait = earlierNoWait;
-            this.laterCoordRejects = laterCoordRejects;
+            this.simpleWait = simpleWait;
+            this.simpleNoWait = simpleNoWait;
+            this.supersedingCoordRejects = supersedingCoordRejects;
             this.selfAcceptsFastPath = selfAcceptsFastPath;
             this.coordinatorAcceptsFastPath = coordinatorAcceptsFastPath;
             this.supersedingRejects = supersedingRejects;
@@ -512,9 +538,9 @@ public class BeginRecovery extends RouteRequest.WithUnsynced<BeginRecovery.Recov
                    ", accepted:" + accepted +
                    ", executeAt:" + executeAt +
                    ", deps:" + deps +
-                   ", earlierWait:" + earlierWait +
-                   ", earlierNoWait:" + earlierNoWait +
-                   ", laterCoordRejects:" + laterCoordRejects +
+                   ", simpleWait:" + simpleWait +
+                   ", simpleNoWait:" + simpleNoWait +
+                   ", laterCoordRejects:" + supersedingCoordRejects +
                    ", selfAcceptsFastPath:" + selfAcceptsFastPath +
                    (txnId.hasPrivilegedCoordinator() ? ", coordinatorFastPath:" + selfAcceptsFastPath : "") +
                    ", supersedingRejects:" + supersedingRejects +

--- a/accord-core/src/main/java/accord/messages/Commit.java
+++ b/accord-core/src/main/java/accord/messages/Commit.java
@@ -363,21 +363,9 @@ public class Commit extends RouteRequest.WithUnsynced<CommitOrReadNack>
         }
 
         @Override
-        public TxnId primaryTxnId()
-        {
-            return txnId;
-        }
-
-        @Override
         public String reason()
         {
-            return "Commit Invalidate";
-        }
-
-        @Override
-        public long waitForEpoch()
-        {
-            return waitForEpoch;
+            return "CommitInvalidate";
         }
 
         @Override

--- a/accord-core/src/main/java/accord/messages/GetMaxConflict.java
+++ b/accord-core/src/main/java/accord/messages/GetMaxConflict.java
@@ -96,12 +96,6 @@ public class GetMaxConflict extends RouteRequest.WithUnsynced<GetMaxConflict.Get
         return null;
     }
 
-    @Override
-    public String reason()
-    {
-        return toString();
-    }
-
     public static class GetMaxConflictOk implements Reply
     {
         public final Timestamp maxConflict;

--- a/accord-core/src/main/java/accord/messages/NoWaitRequest.java
+++ b/accord-core/src/main/java/accord/messages/NoWaitRequest.java
@@ -221,6 +221,6 @@ public abstract class NoWaitRequest<P extends Participants<?>, R extends Reply> 
     @Override
     public String reason()
     {
-        return getClass().getSimpleName() + (txnId == null ? "" : "{" + txnId + '}');
+        return getClass().getSimpleName();
     }
 }

--- a/accord-core/src/main/java/accord/messages/ParticipantsRequest.java
+++ b/accord-core/src/main/java/accord/messages/ParticipantsRequest.java
@@ -64,7 +64,7 @@ public abstract class ParticipantsRequest<P extends Participants<?>, R extends R
      * safe to do so.
      */
     @Override
-    public long waitForEpoch()
+    public final long waitForEpoch()
     {
         return waitForEpoch;
     }

--- a/accord-core/src/main/java/accord/messages/ReadData.java
+++ b/accord-core/src/main/java/accord/messages/ReadData.java
@@ -201,6 +201,7 @@ public abstract class ReadData extends MapReduceConsumeCommandStores<Participant
         return partialTxn;
     }
 
+    @Override
     public final @Nullable Timestamp executeAt()
     {
         return executeAt;

--- a/accord-core/src/main/java/accord/primitives/AbstractRanges.java
+++ b/accord-core/src/main/java/accord/primitives/AbstractRanges.java
@@ -733,6 +733,15 @@ public abstract class AbstractRanges implements Iterable<Range>, Routables<Range
         return Arrays.equals(this.ranges, ((AbstractRanges) that).ranges);
     }
 
+    public boolean hasSameRanges(Object that)
+    {
+        if (this == that)
+            return true;
+        if (!(that instanceof AbstractRanges))
+            return false;
+        return Arrays.equals(this.ranges, ((AbstractRanges) that).ranges);
+    }
+
     @Override
     public Iterator<Range> iterator()
     {

--- a/accord-core/src/main/java/accord/primitives/KeyDeps.java
+++ b/accord-core/src/main/java/accord/primitives/KeyDeps.java
@@ -31,6 +31,7 @@ import accord.utils.LargeBitSet;
 import accord.utils.SortedArrays.SortedArrayList;
 import accord.utils.SymmetricComparator;
 import accord.utils.TriFunction;
+import accord.utils.UnhandledEnum;
 
 import java.util.*;
 import java.util.function.BiConsumer;
@@ -42,6 +43,8 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
+import static accord.api.ProtocolModifiers.RangeSpec.isEndInclusive;
+import static accord.api.ProtocolModifiers.RangeSpec.isStartExclusive;
 import static accord.primitives.RoutingKeys.toRoutingKeys;
 import static accord.primitives.Timestamp.Flag.UNSTABLE;
 import static accord.primitives.TxnId.NO_TXNIDS;
@@ -562,11 +565,11 @@ public class KeyDeps implements Iterable<Map.Entry<RoutingKey, TxnId>>, KeyOrRan
         keysToTxnIds();
         int startKeyIndex = keys.indexOf(range.start());
         if (startKeyIndex < 0) startKeyIndex = -1 - startKeyIndex;
-        else if (!range.startInclusive()) ++startKeyIndex;
+        else if (isStartExclusive()) ++startKeyIndex;
 
         int endKeyIndex = keys.indexOf(range.end());
         if (endKeyIndex < 0) endKeyIndex = -1 - startKeyIndex;
-        else if (range.endInclusive()) ++endKeyIndex;
+        else if (isEndInclusive()) ++endKeyIndex;
 
         if (endKeyIndex <= startKeyIndex)
             return orElse;
@@ -592,11 +595,11 @@ public class KeyDeps implements Iterable<Map.Entry<RoutingKey, TxnId>>, KeyOrRan
         keysToTxnIds();
         int startKeyIndex = keys.indexOf(range.start());
         if (startKeyIndex < 0) startKeyIndex = -1 - startKeyIndex;
-        else if (!range.startInclusive()) ++startKeyIndex;
+        else if (isStartExclusive()) ++startKeyIndex;
 
         int endKeyIndex = keys.indexOf(range.end());
         if (endKeyIndex < 0) endKeyIndex = -1 - startKeyIndex;
-        else if (range.endInclusive()) ++endKeyIndex;
+        else if (isEndInclusive()) ++endKeyIndex;
 
         if (endKeyIndex <= startKeyIndex)
             return orElse;
@@ -630,46 +633,75 @@ public class KeyDeps implements Iterable<Map.Entry<RoutingKey, TxnId>>, KeyOrRan
         }
     }
 
-    public <P1, P2> void forEach(Ranges ranges, int inclIdx, int exclIdx, P1 p1, P2 p2, IndexedBiConsumer<P1, P2> forEach)
+    public <P1, P2> void forEach(Unseekables<?> unseekables, P1 p1, P2 p2, IndexedBiConsumer<P1, P2> forEach)
+    {
+        Routable.Domain domain = unseekables.domain();
+        switch (domain)
+        {
+            default: throw new UnhandledEnum(domain);
+            case Key: forEach((AbstractUnseekableKeys) unseekables, p1, p2, forEach); break;
+            case Range: forEach((AbstractRanges) unseekables, p1, p2, forEach); break;
+        }
+    }
+    public <P1, P2> void forEach(AbstractUnseekableKeys keys, P1 p1, P2 p2, IndexedBiConsumer<P1, P2> forEach)
+    {
+        if (keys.isEmpty())
+            return;
+
+        int[] keysToTxnIds = keysToTxnIds();
+        int searchFromIndex = -1;
+
+        for (int i = 0; i < keys.size() ; ++i)
+        {
+            int keyIndex = searchFromIndex < 0 ? this.keys.indexOf(keys.get(i))
+                                               : this.keys.findNext(searchFromIndex, keys.get(i), FAST);
+
+            if (keyIndex < 0) searchFromIndex = -1 - keyIndex;
+            else
+            {
+                int index = startOffset(keyIndex);
+                int end = endOffset(keyIndex);
+                while (index < end)
+                {
+                    int txnIdx = keysToTxnIds[index++];
+                    forEach.accept(p1, p2, txnIdx);
+                }
+                searchFromIndex = keyIndex + 1;
+            }
+        }
+    }
+
+    public <P1, P2> void forEach(AbstractRanges ranges, P1 p1, P2 p2, IndexedBiConsumer<P1, P2> forEach)
     {
         for (int i = 0; i < ranges.size(); ++i)
-            forEach(ranges.get(i), inclIdx, exclIdx, p1, p2, forEach);
+            forEach(ranges.get(i), p1, p2, forEach);
     }
 
-    public <P1, P2> void forEach(Range range, P1 p1, P2 p2, IndexedBiConsumer<P1, P2> forEach)
+    public <P1, P2> int forEach(Range range, P1 p1, P2 p2, IndexedBiConsumer<P1, P2> forEach)
     {
-        forEach(range, 0, keys.size(), p1, p2, forEach);
+        return forEach(range, forEach, p1, p2, IndexedBiConsumer::accept);
     }
 
-    public <P1, P2> void forEach(Range range, int inclKeyIdx, int exclKeyIdx, P1 p1, P2 p2, IndexedBiConsumer<P1, P2> forEach)
-    {
-        forEach(range, inclKeyIdx, exclKeyIdx, forEach, p1, p2, IndexedBiConsumer::accept);
-    }
-
-    public <P1, P2, P3> void forEach(Range range, P1 p1, P2 p2, P3 p3, IndexedTriConsumer<P1, P2, P3> forEach)
-    {
-        forEach(range, 0, keys.size(), p1, p2, p3, forEach);
-    }
-
-    public <P1, P2, P3> void forEach(Range range, int inclKeyIdx, int exclKeyIdx, P1 p1, P2 p2, P3 p3, IndexedTriConsumer<P1, P2, P3> forEach)
+    public <P1, P2, P3> int forEach(Range range, P1 p1, P2 p2, P3 p3, IndexedTriConsumer<P1, P2, P3> forEach)
     {
         int[] keysToTxnIds = keysToTxnIds();
         int start = keys.indexOf(range.start());
         if (start < 0) start = -1 - start;
-        else if (!range.startInclusive()) ++start;
+        else if (isStartExclusive()) ++start;
         start = startOffset(start);
 
         int end = keys.indexOf(range.end());
         if (end < 0) end = -1 - end;
-        else if (range.endInclusive()) ++end;
+        else if (isEndInclusive()) ++end;
         end = startOffset(end);
 
         while (start < end)
         {
             int txnIdx = keysToTxnIds[start++];
-            if (txnIdx >= inclKeyIdx && txnIdx < exclKeyIdx)
-                forEach.accept(p1, p2, p3, txnIdx);
+            forEach.accept(p1, p2, p3, txnIdx);
         }
+
+        return end;
     }
 
     public <P1, V> V foldEachKey(int txnIdx, P1 p1, V accumulate, TriFunction<P1, RoutingKey, V, V> fold)
@@ -741,11 +773,11 @@ public class KeyDeps implements Iterable<Map.Entry<RoutingKey, TxnId>>, KeyOrRan
     {
         int startIndex = keys.indexOf(range.start());
         if (startIndex < 0) startIndex = -1 - startIndex;
-        else if (!range.startInclusive()) ++startIndex;
+        else if (isStartExclusive()) ++startIndex;
 
         int endIndex = keys.indexOf(range.end());
         if (endIndex < 0) endIndex = -1 - endIndex;
-        else if (range.endInclusive()) ++endIndex;
+        else if (isEndInclusive()) ++endIndex;
 
         if (startIndex == endIndex)
             return DepRelationList.EMPTY;

--- a/accord-core/src/main/java/accord/primitives/KnownMap.java
+++ b/accord-core/src/main/java/accord/primitives/KnownMap.java
@@ -27,6 +27,8 @@ import javax.annotation.Nullable;
 import accord.api.RoutingKey;
 import accord.utils.ReducingRangeMap;
 
+import static accord.api.ProtocolModifiers.RangeSpec.isEndInclusive;
+import static accord.api.ProtocolModifiers.RangeSpec.isStartInclusive;
 import static accord.primitives.Known.Definition.DefinitionErased;
 import static accord.primitives.Known.Definition.DefinitionKnown;
 import static accord.primitives.Known.KnownDeps.DepsErased;
@@ -126,9 +128,9 @@ public class KnownMap extends ReducingRangeMap<KnownMap.MinAndMaxKnown>
 
     public static class SerializerSupport
     {
-        public static KnownMap create(boolean inclusiveEnds, RoutingKey[] ends, MinAndMaxKnown[] values)
+        public static KnownMap create(RoutingKey[] ends, MinAndMaxKnown[] values)
         {
-            return new KnownMap(inclusiveEnds, ends, values);
+            return new KnownMap(ends, values);
         }
     }
 
@@ -141,14 +143,14 @@ public class KnownMap extends ReducingRangeMap<KnownMap.MinAndMaxKnown>
         this.validForAll = Known.Nothing;
     }
 
-    public KnownMap(boolean inclusiveEnds, RoutingKey[] starts, MinAndMaxKnown[] values)
+    public KnownMap(RoutingKey[] starts, MinAndMaxKnown[] values)
     {
-        this(inclusiveEnds, starts, values, Known.Nothing);
+        this(starts, values, Known.Nothing);
     }
 
-    private KnownMap(boolean inclusiveEnds, RoutingKey[] starts, MinAndMaxKnown[] values, Known validForAll)
+    private KnownMap(RoutingKey[] starts, MinAndMaxKnown[] values, Known validForAll)
     {
-        super(inclusiveEnds, starts, values);
+        super(starts, values);
         this.validForAll = validForAll;
     }
 
@@ -199,7 +201,7 @@ public class KnownMap extends ReducingRangeMap<KnownMap.MinAndMaxKnown>
         }
 
         if (i == size())
-            return new KnownMap(inclusiveEnds(), starts, values, validForAll);
+            return new KnownMap(starts, values, validForAll);
 
         RoutingKey[] newStarts = new RoutingKey[size() + 1];
         MinAndMaxKnown[] newValues = new MinAndMaxKnown[size()];
@@ -222,7 +224,7 @@ public class KnownMap extends ReducingRangeMap<KnownMap.MinAndMaxKnown>
             newValues = Arrays.copyOf(newValues, count);
             newStarts = Arrays.copyOf(newStarts, count + 1);
         }
-        return new KnownMap(inclusiveEnds(), newStarts, newValues, validForAll);
+        return new KnownMap(newStarts, newValues, validForAll);
     }
 
     public boolean hasAnyFullyTruncated(Routables<?> routables)
@@ -303,7 +305,7 @@ public class KnownMap extends ReducingRangeMap<KnownMap.MinAndMaxKnown>
                         return prev.slice(-1 - i, prev.size());
 
                     if (prev.domain() == Routable.Domain.Key)
-                        return prev.slice(i + (inclusiveEnds() ? 1 : 0), prev.size());
+                        return prev.slice(i + (isEndInclusive() ? 1 : 0), prev.size());
 
                     Range r = prev.get(i).asRange();
                     prev = prev.slice(i, prev.size());
@@ -317,7 +319,7 @@ public class KnownMap extends ReducingRangeMap<KnownMap.MinAndMaxKnown>
                         return prev.slice(0, -1 - i);
 
                     if (prev.domain() == Routable.Domain.Key)
-                        return prev.slice(0, i + (inclusiveStarts() ? 0 : 1));
+                        return prev.slice(0, i + (isStartInclusive() ? 0 : 1));
 
                     Range r = prev.get(i).asRange();
                     prev = prev.slice(0, i);
@@ -331,15 +333,15 @@ public class KnownMap extends ReducingRangeMap<KnownMap.MinAndMaxKnown>
 
     public static class Builder extends AbstractBoundariesBuilder<RoutingKey, MinAndMaxKnown, KnownMap>
     {
-        public Builder(boolean inclusiveEnds, int capacity)
+        public Builder(int capacity)
         {
-            super(inclusiveEnds, capacity);
+            super(capacity);
         }
 
         @Override
         protected KnownMap buildInternal()
         {
-            return new KnownMap(inclusiveEnds, starts.toArray(new RoutingKey[0]), values.toArray(new MinAndMaxKnown[0]));
+            return new KnownMap(starts.toArray(new RoutingKey[0]), values.toArray(new MinAndMaxKnown[0]));
         }
     }
 }

--- a/accord-core/src/main/java/accord/primitives/LatestDeps.java
+++ b/accord-core/src/main/java/accord/primitives/LatestDeps.java
@@ -60,9 +60,9 @@ public class LatestDeps extends ReducingRangeMap<LatestDeps.LatestEntry>
 
     public static class SerializerSupport
     {
-        public static LatestDeps create(boolean inclusiveEnds, RoutingKey[] starts, LatestEntry[] values)
+        public static LatestDeps create(RoutingKey[] starts, LatestEntry[] values)
         {
-            return new LatestDeps(inclusiveEnds, starts, values);
+            return new LatestDeps(starts, values);
         }
     }
 
@@ -287,12 +287,12 @@ public class LatestDeps extends ReducingRangeMap<LatestDeps.LatestEntry>
 
     private LatestDeps()
     {
-        super(false, RoutingKeys.EMPTY_KEYS_ARRAY, new LatestEntry[0]);
+        super(RoutingKeys.EMPTY_KEYS_ARRAY, new LatestEntry[0]);
     }
 
-    private LatestDeps(boolean inclusiveEnds, RoutingKey[] starts, LatestEntry[] values)
+    private LatestDeps(RoutingKey[] starts, LatestEntry[] values)
     {
-        super(inclusiveEnds, starts, values);
+        super(starts, values);
     }
 
     public Deps merge()
@@ -310,7 +310,7 @@ public class LatestDeps extends ReducingRangeMap<LatestDeps.LatestEntry>
         if (participants.isEmpty())
             return new LatestDeps();
 
-        Builder builder = new Builder(participants.get(0).asRange().endInclusive(), participants.size() * 2);
+        Builder builder = new Builder(participants.size() * 2);
         for (int i = 0 ; i < participants.size() ; ++i)
         {
             Range cur = participants.get(i).asRange();
@@ -330,9 +330,9 @@ public class LatestDeps extends ReducingRangeMap<LatestDeps.LatestEntry>
 
     static class Builder extends AbstractIntervalBuilder<RoutingKey, LatestEntry, LatestDeps>
     {
-        protected Builder(boolean inclusiveEnds, int capacity)
+        protected Builder(int capacity)
         {
-            super(inclusiveEnds, capacity);
+            super(capacity);
         }
 
         @Override
@@ -350,7 +350,7 @@ public class LatestDeps extends ReducingRangeMap<LatestDeps.LatestEntry>
         @Override
         protected LatestDeps buildInternal()
         {
-            return new LatestDeps(inclusiveEnds, starts.toArray(new RoutingKey[0]), values.toArray(new LatestEntry[0]));
+            return new LatestDeps(starts.toArray(new RoutingKey[0]), values.toArray(new LatestEntry[0]));
         }
     }
 
@@ -409,12 +409,12 @@ public class LatestDeps extends ReducingRangeMap<LatestDeps.LatestEntry>
 
         private Merge(LatestDeps convert)
         {
-            super(convert.inclusiveEnds(), convert.starts, convert(convert.values));
+            super(convert.starts, convert(convert.values));
         }
 
-        private Merge(boolean inclusiveEnds, RoutingKey[] starts, MergeEntry[] values)
+        private Merge(RoutingKey[] starts, MergeEntry[] values)
         {
-            super(inclusiveEnds, starts, values);
+            super(starts, values);
         }
 
         static Merge merge(Merge a, Merge b)
@@ -588,9 +588,9 @@ public class LatestDeps extends ReducingRangeMap<LatestDeps.LatestEntry>
 
         static class MergeBuilder extends AbstractIntervalBuilder<RoutingKey, MergeEntry, Merge>
         {
-            protected MergeBuilder(boolean inclusiveEnds, int capacity)
+            protected MergeBuilder(int capacity)
             {
-                super(inclusiveEnds, capacity);
+                super(capacity);
             }
 
             @Override
@@ -629,7 +629,7 @@ public class LatestDeps extends ReducingRangeMap<LatestDeps.LatestEntry>
             @Override
             protected Merge buildInternal()
             {
-                return new Merge(inclusiveEnds, starts.toArray(new RoutingKey[0]), values.toArray(new MergeEntry[0]));
+                return new Merge(starts.toArray(new RoutingKey[0]), values.toArray(new MergeEntry[0]));
             }
         }
     }

--- a/accord-core/src/main/java/accord/primitives/Range.java
+++ b/accord-core/src/main/java/accord/primitives/Range.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 
 import javax.annotation.Nullable;
 
+import static accord.api.ProtocolModifiers.RangeSpec.END_INCLUSIVE;
 import static accord.utils.SortedArrays.Search.CEIL;
 import static accord.utils.SortedArrays.Search.FAST;
 
@@ -41,11 +42,13 @@ public abstract class Range implements Comparable<RoutableKey>, Unseekable, Seek
         public EndInclusive(RoutingKey start, RoutingKey end)
         {
             super(start, end);
+            Invariants.require(END_INCLUSIVE);
         }
 
         public EndInclusive(RoutingKey start, RoutingKey end, AntiRangeMarker antiRange)
         {
             super(start, end, antiRange);
+            Invariants.require(END_INCLUSIVE);
         }
 
         @Override
@@ -96,11 +99,13 @@ public abstract class Range implements Comparable<RoutableKey>, Unseekable, Seek
         public StartInclusive(RoutingKey start, RoutingKey end)
         {
             super(start, end);
+            Invariants.require(!END_INCLUSIVE);
         }
 
         public StartInclusive(RoutingKey start, RoutingKey end, AntiRangeMarker antiRange)
         {
             super(start, end, antiRange);
+            Invariants.require(!END_INCLUSIVE);
         }
 
         @Override
@@ -148,68 +153,8 @@ public abstract class Range implements Comparable<RoutableKey>, Unseekable, Seek
 
     public static Range range(RoutingKey start, RoutingKey end, boolean startInclusive, boolean endInclusive)
     {
-        return new Range(start, end) {
-
-            @Override
-            public boolean startInclusive()
-            {
-                return startInclusive;
-            }
-
-            @Override
-            public boolean endInclusive()
-            {
-                return endInclusive;
-            }
-
-            @Override
-            public Range newRange(RoutingKey start, RoutingKey end)
-            {
-                throw new UnsupportedOperationException("subRange");
-            }
-
-            @Override
-            public int compareTo(RoutableKey key)
-            {
-                if (startInclusive)
-                {
-                    if (key.compareTo(start()) < 0)
-                        return 1;
-                }
-                else
-                {
-                    if (key.compareTo(start()) <= 0)
-                        return 1;
-                }
-                if (endInclusive)
-                {
-                    if (key.compareTo(end()) > 0)
-                        return -1;
-                }
-                else
-                {
-                    if (key.compareTo(end()) >= 0)
-                        return -1;
-                }
-                return 0;
-            }
-
-            @Override
-            public int compareStartTo(RoutableKey key)
-            {
-                int c = start().compareTo(key);
-                if (c == 0 && !startInclusive) c = 1;
-                return c;
-            }
-
-            @Override
-            public int compareEndTo(RoutableKey key)
-            {
-                int c = end().compareTo(key);
-                if (c == 0 && !endInclusive) c = -1;
-                return c;
-            }
-        };
+        Invariants.require(startInclusive != endInclusive);
+        return startInclusive ? new StartInclusive(start, end) : new EndInclusive(start, end);
     }
 
     // used to construct an unsafe Range used only for representing an absence of information. Imposes weaker invariants.
@@ -223,16 +168,13 @@ public abstract class Range implements Comparable<RoutableKey>, Unseekable, Seek
         // TODO (expected): should we at least relax to permit an empty Range?
         Invariants.requireArgument(start.compareTo(end) < 0, "%s >= %s", start, end);
         Invariants.requireArgument(Objects.equals(start.prefix(), end.prefix()), "Range bounds must share their prefix: %s vs %s", start, end);
-        Invariants.require(startInclusive() != endInclusive(), "Range must have one side inclusive, and the other exclusive. Range of different types should not be mixed.");
         this.start = start;
         this.end = end;
     }
 
     private Range(RoutingKey start, RoutingKey end, AntiRangeMarker antiRange)
     {
-        // TODO (expected): should we at least relax to permit an empty Range?
         Invariants.requireArgument(start.compareTo(end) < 0, "%s >= %s", start, end);
-        Invariants.require(startInclusive() != endInclusive(), "Range must have one side inclusive, and the other exclusive. Range of different types should not be mixed.");
         this.start = start;
         this.end = end;
     }

--- a/accord-core/src/main/java/accord/primitives/SaveStatus.java
+++ b/accord-core/src/main/java/accord/primitives/SaveStatus.java
@@ -30,8 +30,10 @@ import accord.primitives.Known.KnownExecuteAt;
 import accord.primitives.Known.KnownRoute;
 import accord.primitives.Known.Outcome;
 import accord.primitives.Status.Phase;
+import accord.utils.BitUtils;
 
 import static accord.local.CommandSummaries.SummaryStatus.ACCEPTED;
+import static accord.local.CommandSummaries.SummaryStatus.APPLIED;
 import static accord.primitives.Known.PrivilegedVote.NoVote;
 import static accord.primitives.Known.PrivilegedVote.VotePreAccept;
 import static accord.primitives.Known.KnownDeps.DepsFromCoordinator;
@@ -107,8 +109,8 @@ public enum SaveStatus
     Applied                         (Status.Applied,                                                                                                 LocalExecution.Applied),
     // TruncatedApplyWithOutcomeAndDeps exists to support re-populating CommandsForKey on replay with any dependencies needed for computing recovery superseding-rejects decisions
     // TODO (expected): test replay
-    TruncatedApplyWithOutcome       (Status.Truncated,              FullRoute,  DefinitionErased,   ApplyAtKnown,       DepsErased,         Apply,   CleaningUp),
-    TruncatedApply                  (Status.Truncated,              FullRoute,  DefinitionErased,   ApplyAtKnown,       DepsErased,         WasApply,CleaningUp),
+    TruncatedApplyWithOutcome       (Status.Truncated,   APPLIED,   FullRoute,  DefinitionErased,   ApplyAtKnown,       DepsErased,         Apply,   CleaningUp),
+    TruncatedApply                  (Status.Truncated,   APPLIED,   FullRoute,  DefinitionErased,   ApplyAtKnown,       DepsErased,         WasApply,CleaningUp),
     TruncatedUnapplied              (Status.Truncated,              MaybeRoute, DefinitionErased,   ExecuteAtKnown,     DepsErased,         WasApply,CleaningUp),
     // Vestigial means the command cannot be completed and is either pre-bootstrap, did not commit, or did not participate in this shard's epoch
     // TODO (expected): should Vestigial NOT be a Truncated status? We should really only use Known or KnownMap to make decisions, so we don't interpret Truncated as implying a decision, e.g. in Invalidate (as of this commit)
@@ -167,6 +169,8 @@ public enum SaveStatus
     }
 
     private static final SaveStatus[] lookup = values();
+    public static final int ENCODING_BITS = BitUtils.numberOfBitsToRepresent(lookup.length);
+    public static final int ENCODING_MASK = (1 << ENCODING_BITS) - 1;
 
     public final Status status;
     public final Phase phase;

--- a/accord-core/src/main/java/accord/primitives/Status.java
+++ b/accord-core/src/main/java/accord/primitives/Status.java
@@ -137,7 +137,8 @@ public enum Status
         private static final int SHARDS_SHIFT = 3;
         private static final int PHASE_SHIFT = 1;
         private static final int PHASE_MASK = 0x3;
-        public static final int TOTAL_ENCODING_BITS = 6;
+        public static final int ENCODING_BITS = 6;
+        public static final int ENCODING_MASK = (1 << ENCODING_BITS) - 1;
         private static final Durability[] lookup = values();
 
         public static final Durability NotDurable = get(HasDecision.None, HasOutcome.None, HasOutcome.None, false);

--- a/accord-core/src/main/java/accord/primitives/Timestamp.java
+++ b/accord-core/src/main/java/accord/primitives/Timestamp.java
@@ -18,6 +18,9 @@
 
 package accord.primitives;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import accord.local.Node.Id;
 import accord.utils.Invariants;
 import javax.annotation.Nonnull;
@@ -26,6 +29,7 @@ import static accord.primitives.Timestamp.Flag.HLC_BOUND;
 import static accord.primitives.Timestamp.Flag.REJECTED;
 import static accord.primitives.Timestamp.Flag.SHARD_BOUND;
 import static accord.primitives.Timestamp.Flag.UNSTABLE;
+import static accord.utils.Invariants.illegalArgument;
 
 /**
  * TxnId flag bits:
@@ -102,7 +106,7 @@ public class Timestamp implements Comparable<Timestamp>, EpochSupplier
     public static final int KIND_AND_DOMAIN_FLAGS = 0x00000000_0000000F;
     public static final long MAX_EPOCH = (1L << 48) - 1;
     private static final long HLC_INCR = 1L << 16;
-    static final long MAX_FLAGS = HLC_INCR - 1;
+    static final int MAX_FLAGS = (int) (HLC_INCR - 1);
 
     public static Timestamp fromBits(long msb, long lsb, Id node)
     {
@@ -121,12 +125,22 @@ public class Timestamp implements Comparable<Timestamp>, EpochSupplier
 
     public static Timestamp maxForEpoch(long epoch)
     {
-        return new Timestamp(epochMsb(epoch) | 0x7fff, Long.MAX_VALUE, Id.MAX);
+        return maxForEpoch(epoch, Timestamp::fromBits);
+    }
+
+    public static <T extends Timestamp> T maxForEpoch(long epoch, RawFactory<T> factory)
+    {
+        return factory.create(epochMsb(epoch) | 0x7fff, Long.MAX_VALUE, Id.MAX);
     }
 
     public static Timestamp minForEpoch(long epoch)
     {
-        return new Timestamp(epochMsb(epoch), 0, Id.NONE);
+        return minForEpoch(epoch, Timestamp::fromBits);
+    }
+
+    public static <T extends Timestamp> T minForEpoch(long epoch, RawFactory<T> factory)
+    {
+        return factory.create(epochMsb(epoch), 0, Id.NONE);
     }
 
     public final long msb;
@@ -295,11 +309,27 @@ public class Timestamp implements Comparable<Timestamp>, EpochSupplier
         return new Timestamp(msb, lsb, node);
     }
 
+    public Timestamp logicalPrev(Id node)
+    {
+        long lsb = this.lsb - HLC_INCR;
+        long msb = this.msb;
+        if (lowHlc(this.lsb) == 0)
+            --msb; // overflow of lsb
+        return new Timestamp(msb, lsb, node);
+    }
+
     public Timestamp next()
     {
-        if (node.id < Long.MAX_VALUE)
+        if (node.id < Integer.MAX_VALUE)
             return new Timestamp(msb, lsb, new Id(node.id + 1));
         return logicalNext(Id.NONE);
+    }
+
+    public Timestamp prev()
+    {
+        if (node.id > 0)
+            return new Timestamp(msb, lsb, new Id(node.id - 1));
+        return logicalPrev(Id.MAX);
     }
 
     @Override
@@ -430,6 +460,17 @@ public class Timestamp implements Comparable<Timestamp>, EpochSupplier
     }
 
     /**
+     * The resulting timestamp will have max(a.hlc,b.hlc) and max(a.epoch, b.epoch)
+     */
+    public static <T extends Timestamp> T mergeMax(T a, T b, ValueFactory<T> factory)
+    {
+        // Note: it is not safe to take the highest HLC while retaining the current node;
+        //       however, it is safe to take the highest epoch, as the originating node will always advance the hlc()
+        return a.compareToWithoutEpoch(b) >= 0 ? withEpochAtLeast(b.epoch(), a, factory)
+                                               : withEpochAtLeast(a.epoch(), b, factory);
+    }
+
+    /**
      * The resulting timestamp will have min(a.hlc,b.hlc) and min(a.epoch, b.epoch)
      */
     public static <T extends Timestamp> T mergeMin(T a, T b, ValueFactory<T> factory)
@@ -526,18 +567,53 @@ public class Timestamp implements Comparable<Timestamp>, EpochSupplier
         return "[" + epoch() + ',' + hlc + (hlc == uniqueHlc ? "" : "+" + (uniqueHlc - hlc)) + ',' + flags() + ',' + node + ']';
     }
 
-    public static Timestamp fromString(String string)
+    private static final Pattern PARSE = Pattern.compile("\\[(?<epoch>[0-9]+),(?<hlc>[0-9]+)(\\+(?<uniqueHlc>[0-9]+>))?,(?<flags>[0-9]+)(?<kind>\\([KR][REWXV]\\))?,(?<node>[0-9]+)]");
+    public static Timestamp parse(String timestampString)
     {
-        String[] split = string.replaceFirst("\\[", "").replaceFirst("\\]", "").split(",");
-        assert split.length == 4;
-        int indexOfUniqueHlc = split[2].indexOf('+');
-        int flags = Integer.parseInt(indexOfUniqueHlc < 0 ? split[2] : split[2].substring(0, indexOfUniqueHlc));
-        Timestamp result = Timestamp.fromValues(Long.parseLong(split[0]),
-                                                Long.parseLong(split[1]),
-                                                flags,
-                                                new Id(Integer.parseInt(split[3])));
-        if (indexOfUniqueHlc < 0)
-            return result;
-        return new TimestampWithUniqueHlc(result, Integer.parseInt(split[2].substring(indexOfUniqueHlc + 1)));
+        Matcher m = PARSE.matcher(timestampString);
+        if (!m.matches())
+            throw illegalArgument("Invalid Timestamp string: " + timestampString);
+        return fromMatcher(timestampString, m, true);
+    }
+
+    public static Timestamp tryParse(String timestampString)
+    {
+        Matcher m = PARSE.matcher(timestampString);
+        if (!m.matches())
+            return null;
+        return fromMatcher(timestampString, m, false);
+    }
+
+    private static Timestamp fromMatcher(String timestampString, Matcher m, boolean failIfInvalid)
+    {
+        String uniqueHlc = m.group("uniqueHlc");
+        String kind = m.group("kind");
+        if (uniqueHlc != null && kind != null)
+            return failOrNull(timestampString, failIfInvalid);
+
+        long epoch = Long.parseLong(m.group("epoch"));
+        long hlc = Long.parseLong(m.group("hlc"));
+        int flags = Integer.parseInt(m.group("flags"));
+        if (flags > 0xffff)
+            return failOrNull(timestampString, failIfInvalid);
+
+        Id node = new Id(Integer.parseInt(m.group("node")));
+        if (uniqueHlc != null)
+            return new TimestampWithUniqueHlc(epoch, hlc, Long.parseLong(uniqueHlc), flags, node);
+
+        if (kind != null)
+        {
+            // TODO (expected): validate kind vs flags
+            return TxnId.fromValues(epoch, hlc, flags, node);
+        }
+
+        return fromValues(epoch, hlc, flags, node);
+    }
+
+    private static <T extends Timestamp> T failOrNull(String timestampString, boolean fail)
+    {
+        if (fail)
+            throw illegalArgument("Invalid Timestamp string: " + timestampString);
+        return null;
     }
 }

--- a/accord-core/src/main/java/accord/primitives/TxnId.java
+++ b/accord-core/src/main/java/accord/primitives/TxnId.java
@@ -319,6 +319,11 @@ public class TxnId extends Timestamp
         return Kind.isVisible(kindOrdinal(flagsUnmasked()));
     }
 
+    public final boolean hasFastPath()
+    {
+        return !isSyncPoint();
+    }
+
     public final boolean isSyncPoint()
     {
         return Kind.isSyncPoint(kindOrdinal(flagsUnmasked()));
@@ -497,12 +502,12 @@ public class TxnId extends Timestamp
 
     public static TxnId maxForEpoch(long epoch)
     {
-        return new TxnId(epochMsb(epoch) | 0x7fff, Long.MAX_VALUE, Id.MAX);
+        return maxForEpoch(epoch, TxnId::fromBits);
     }
 
     public static TxnId minForEpoch(long epoch)
     {
-        return new TxnId(epochMsb(epoch), 0, Id.NONE);
+        return minForEpoch(epoch, TxnId::fromBits);
     }
 
     public static TxnId noneIfNull(TxnId id)
@@ -515,13 +520,20 @@ public class TxnId extends Timestamp
         return id == null ? MAX : id;
     }
 
+    public static TxnId atLeast(Timestamp timestamp)
+    {
+        if (timestamp.flags() != 0)
+            timestamp = timestamp.next();
+        return new TxnId(timestamp, 0, Read, Domain.Key, Any);
+    }
+
     private static final Pattern PARSE = Pattern.compile("\\[(?<epoch>[0-9]+),(?<hlc>[0-9]+),(?<flags>[0-9]+)\\([KR][REWXV]\\),(?<node>[0-9]+)]");
     public static TxnId parse(String txnIdString)
     {
         Matcher m = PARSE.matcher(txnIdString);
         if (!m.matches())
             throw illegalArgument("Invalid TxnId string: " + txnIdString);
-        return fromValues(Long.parseLong(m.group("epoch")), Long.parseLong(m.group("hlc")), Integer.parseInt(m.group("flags")), new Id(Integer.parseInt(m.group("node"))));
+        return fromMatcher(txnIdString, m, true);
     }
 
     public static TxnId tryParse(String txnIdString)
@@ -529,7 +541,27 @@ public class TxnId extends Timestamp
         Matcher m = PARSE.matcher(txnIdString);
         if (!m.matches())
             return null;
-        return fromValues(Long.parseLong(m.group("epoch")), Long.parseLong(m.group("hlc")), Integer.parseInt(m.group("flags")), new Id(Integer.parseInt(m.group("node"))));
+        return fromMatcher(txnIdString, m, false);
+    }
+
+    private static TxnId fromMatcher(String txnIdString, Matcher m, boolean failIfInvalid)
+    {
+        long epoch = Long.parseLong(m.group("epoch"));
+        long hlc = Long.parseLong(m.group("hlc"));
+        int flags = Integer.parseInt(m.group("flags"));
+        if (flags > 0xffff)
+            return failOrNull(txnIdString, failIfInvalid);
+
+        Id node = new Id(Integer.parseInt(m.group("node")));
+        // TODO (expected): validate kind vs flags
+        return TxnId.fromValues(epoch, hlc, flags, node);
+    }
+
+    private static <T extends Timestamp> T failOrNull(String timestampString, boolean fail)
+    {
+        if (fail)
+            throw illegalArgument("Invalid TxnId string: " + timestampString);
+        return null;
     }
 
     public static boolean equalsStrict(TxnId[] a, TxnId[] b)

--- a/accord-core/src/main/java/accord/topology/Topology.java
+++ b/accord-core/src/main/java/accord/topology/Topology.java
@@ -55,6 +55,7 @@ import accord.utils.Utils;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.IntArrayList;
 
+import static accord.api.ProtocolModifiers.RangeSpec.isEndInclusive;
 import static accord.utils.Invariants.illegalArgument;
 import static accord.utils.SortedArrays.Search.FAST;
 import static accord.utils.SortedArrays.Search.FLOOR;
@@ -600,7 +601,7 @@ public class Topology
             Range r = subsetOfRanges.get(bi);
             ai = as.findNext(ai, r.end(), FAST);
             if (ai < 0) ai = -1 - ai;
-            else if (r.endInclusive()) ++ai;
+            else if (isEndInclusive()) ++ai;
             ++bi;
         }
 

--- a/accord-core/src/main/java/accord/utils/BTreeReducingIntervalMap.java
+++ b/accord-core/src/main/java/accord/utils/BTreeReducingIntervalMap.java
@@ -31,6 +31,8 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static accord.api.ProtocolModifiers.RangeSpec.isEndInclusive;
+import static accord.api.ProtocolModifiers.RangeSpec.isStartInclusive;
 import static accord.utils.Invariants.*;
 import static com.google.common.collect.Iterators.filter;
 import static com.google.common.collect.Iterators.transform;
@@ -49,33 +51,16 @@ import static com.google.common.collect.Iterators.transform;
  */
 public class BTreeReducingIntervalMap<K extends Comparable<? super K>, V>
 {
-    protected final boolean inclusiveEnds;
     protected final Object[] tree;
 
     public BTreeReducingIntervalMap()
     {
-        this(false);
+        this(BTree.empty());
     }
 
-    public BTreeReducingIntervalMap(boolean inclusiveEnds)
+    protected BTreeReducingIntervalMap(Object[] tree)
     {
-        this(inclusiveEnds, BTree.empty());
-    }
-
-    protected BTreeReducingIntervalMap(boolean inclusiveEnds, Object[] tree)
-    {
-        this.inclusiveEnds = inclusiveEnds;
         this.tree = tree;
-    }
-
-    public boolean inclusiveEnds()
-    {
-        return inclusiveEnds;
-    }
-
-    public final boolean inclusiveStarts()
-    {
-        return !inclusiveEnds;
     }
 
     public boolean isEmpty()
@@ -94,7 +79,7 @@ public class BTreeReducingIntervalMap<K extends Comparable<? super K>, V>
         int idx = BTree.findIndex(tree, EntryComparator.instance(), key);
 
         if (idx < 0) idx = -2 - idx;
-        else if (inclusiveEnds) --idx;
+        else if (isEndInclusive()) --idx;
 
         return idx < 0 || idx >= size()
              ? null
@@ -164,11 +149,11 @@ public class BTreeReducingIntervalMap<K extends Comparable<? super K>, V>
             if (!isFirst)
                 builder.append(", ");
 
-            builder.append(inclusiveStarts() ? '[' : '(')
+            builder.append(isStartInclusive() ? '[' : '(')
                    .append(iter.start())
                    .append(',')
                    .append(iter.end())
-                   .append(inclusiveEnds() ? ']' : ')')
+                   .append(isEndInclusive() ? ']' : ')')
                    .append('=')
                    .append(iter.value());
 
@@ -184,13 +169,13 @@ public class BTreeReducingIntervalMap<K extends Comparable<? super K>, V>
         if (o == null || getClass() != o.getClass()) return false;
         @SuppressWarnings("unchecked")
         BTreeReducingIntervalMap<K, V> that = (BTreeReducingIntervalMap<K, V>) o;
-        return this.inclusiveEnds == that.inclusiveEnds && BTree.equals(this.tree, that.tree);
+        return BTree.equals(this.tree, that.tree);
     }
 
     @Override
     public int hashCode()
     {
-        return Boolean.hashCode(inclusiveEnds) + 31 * BTree.hashCode(tree);
+        return 31 * BTree.hashCode(tree);
     }
 
     public static class EntryComparator<K extends Comparable<? super K>, V> implements AsymmetricComparator<K, Entry<K, V>>
@@ -281,8 +266,7 @@ public class BTreeReducingIntervalMap<K extends Comparable<? super K>, V>
         if (historyRight == null || historyRight.isEmpty())
             return historyLeft;
 
-        boolean inclusiveEnds = inclusiveEnds(historyLeft.inclusiveEnds, !historyLeft.isEmpty(), historyRight.inclusiveEnds, !historyRight.isEmpty());
-        AbstractIntervalBuilder<K, V, M> builder = factory.create(inclusiveEnds, historyLeft.size() + historyRight.size());
+        AbstractIntervalBuilder<K, V, M> builder = factory.create(historyLeft.size() + historyRight.size());
 
         WithBoundsIterator<K, V> left = historyLeft.withBoundsIterator();
         WithBoundsIterator<K, V> right = historyRight.withBoundsIterator();
@@ -359,8 +343,7 @@ public class BTreeReducingIntervalMap<K extends Comparable<? super K>, V>
         if (historyRight == null || historyRight.isEmpty())
             return historyLeft;
 
-        boolean inclusiveEnds = inclusiveEnds(historyLeft.inclusiveEnds, !historyLeft.isEmpty(), historyRight.inclusiveEnds, !historyRight.isEmpty());
-        AbstractBoundariesBuilder<K, V, M> builder = factory.create(inclusiveEnds, historyLeft.size() + historyRight.size());
+        AbstractBoundariesBuilder<K, V, M> builder = factory.create(historyLeft.size() + historyRight.size());
 
         WithBoundsIterator<K, V> left = historyLeft.withBoundsIterator();
         WithBoundsIterator<K, V> right = historyRight.withBoundsIterator();
@@ -463,19 +446,16 @@ public class BTreeReducingIntervalMap<K extends Comparable<? super K>, V>
 
     public interface BoundariesBuilderFactory<K extends Comparable<? super K>, V, M extends BTreeReducingIntervalMap<K, V>>
     {
-        AbstractBoundariesBuilder<K, V, M> create(boolean inclusiveEnds, int capacity);
+        AbstractBoundariesBuilder<K, V, M> create(int capacity);
     }
 
     public static abstract class AbstractBoundariesBuilder<K extends Comparable<? super K>, V, M extends BTreeReducingIntervalMap<K, V>>
     {
-        protected final boolean inclusiveEnds;
-
         private final BTree.Builder<Entry<K, V>> treeBuilder;
         private final TinyKVBuffer<K, V> buffer;
 
-        protected AbstractBoundariesBuilder(boolean inclusiveEnds, int capacity)
+        protected AbstractBoundariesBuilder(int capacity)
         {
-            this.inclusiveEnds = inclusiveEnds;
             this.treeBuilder = BTree.builder(Comparator.naturalOrder(), capacity);
             this.buffer = new TinyKVBuffer<>();
         }
@@ -550,20 +530,18 @@ public class BTreeReducingIntervalMap<K extends Comparable<? super K>, V>
 
     public interface IntervalBuilderFactory<K extends Comparable<? super K>, V, M extends BTreeReducingIntervalMap<K, V>>
     {
-        AbstractIntervalBuilder<K, V, M> create(boolean inclusiveEnds, int capacity);
+        AbstractIntervalBuilder<K, V, M> create(int capacity);
     }
 
     public static abstract class AbstractIntervalBuilder<K extends Comparable<? super K>, V, M>
     {
-        protected final boolean inclusiveEnds;
         private final BTree.Builder<Entry<K, V>> treeBuilder;
         private final TinyKVBuffer<K, V> buffer;
 
         private K prevEnd;
 
-        protected AbstractIntervalBuilder(boolean inclusiveEnds, int capacity)
+        protected AbstractIntervalBuilder(int capacity)
         {
-            this.inclusiveEnds = inclusiveEnds;
             this.treeBuilder = BTree.builder(Comparator.naturalOrder(), capacity);
             this.buffer = new TinyKVBuffer<>();
         }

--- a/accord-core/src/main/java/accord/utils/BTreeReducingRangeMap.java
+++ b/accord-core/src/main/java/accord/utils/BTreeReducingRangeMap.java
@@ -28,8 +28,10 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static accord.api.ProtocolModifiers.RangeSpec.isEndInclusive;
 import static accord.utils.SortedArrays.Search.FAST;
 
 public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKey, V>
@@ -39,9 +41,9 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
         super();
     }
 
-    protected BTreeReducingRangeMap(boolean inclusiveEnds, Object[] tree)
+    protected BTreeReducingRangeMap(Object[] tree)
     {
-        super(inclusiveEnds, tree);
+        super(tree);
     }
 
     public V foldl(Routables<?> routables, BiFunction<V, V, V> fold, V accumulator)
@@ -74,20 +76,20 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
 
         int i = keys.find(startAt(0), FAST);
         if (i < 0) i = -1 - i;
-        else if (inclusiveEnds) ++i;
+        else if (isEndInclusive()) ++i;
 
         while (i < keysSize)
         {
             int idx = findIndex(keys.get(i));
             if (idx < 0) idx = -2 - idx;
-            else if (inclusiveEnds) --idx;
+            else if (isEndInclusive()) --idx;
 
             if (idx >= treeSize - 1)
                 return accumulator;
 
             int nexti = keys.findNext(i, startAt(idx + 1), FAST);
             if (nexti < 0) nexti = -1 -nexti;
-            else if (inclusiveEnds) ++nexti;
+            else if (isEndInclusive()) ++nexti;
 
             Entry<RoutingKey, V> entry = entryAt(idx);
             if (i != nexti && entry.hasValue() && entry.value() != null)
@@ -112,7 +114,7 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
         RoutingKey start = startAt(0);
         int i = ranges.find(start, FAST);
         if (i < 0) i = -1 - i;
-        else if (inclusiveEnds && ranges.get(i).end().equals(start)) ++i;
+        else if (isEndInclusive() && ranges.get(i).end().equals(start)) ++i;
 
         while (i < rangesSize)
         {
@@ -150,7 +152,7 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
             RoutingKey nextStart = startAt(endPos + 1);
             i = ranges.findNext(i, nextStart, FAST);
             if (i < 0) i = -1 - i;
-            else if (inclusiveEnds && ranges.get(i).end().equals(nextStart)) ++i;
+            else if (isEndInclusive() && ranges.get(i).end().equals(nextStart)) ++i;
         }
 
         return accumulator;
@@ -195,7 +197,7 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
     {
         Invariants.requireArgument(value != null, "value is null");
 
-        AbstractBoundariesBuilder<RoutingKey, V, M> builder = factory.create(ranges.get(0).endInclusive(), ranges.size() * 2);
+        AbstractBoundariesBuilder<RoutingKey, V, M> builder = factory.create(ranges.size() * 2);
         for (Range cur : ranges)
         {
             builder.append(cur.start(), value, (a, b) -> { throw new IllegalStateException(); });
@@ -209,7 +211,7 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
     {
         Invariants.requireArgument(value != null, "value is null");
 
-        AbstractBoundariesBuilder<RoutingKey, V, M> builder = factory.create(keys.get(0).asRange().endInclusive(), keys.size() * 2);
+        AbstractBoundariesBuilder<RoutingKey, V, M> builder = factory.create(keys.size() * 2);
         for (int i = 0 ; i < keys.size() ; ++i)
         {
             Range range = keys.get(i).asRange();
@@ -228,7 +230,7 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
         AbstractBoundariesBuilder<RoutingKey, V, M> builder;
         {
             Range range = prev.asRange();
-            builder = factory.create(prev.asRange().endInclusive(), keys.size() * 2);
+            builder = factory.create(keys.size() * 2);
             builder.append(range.start(), value, (a, b) -> { throw new IllegalStateException(); });
             builder.append(range.end(), null, (a, b) -> { throw new IllegalStateException(); });
         }
@@ -268,7 +270,7 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
      */
     public static <M extends BTreeReducingRangeMap<V>, V> M update(
         M map, Unseekables<?> keysOrRanges, V value, BiFunction<V, V, V> valueResolver,
-        BiFunction<Boolean, Object[], M> factory, BoundariesBuilderFactory<RoutingKey, V, M> builderFactory)
+        Function<Object[], M> factory, BoundariesBuilderFactory<RoutingKey, V, M> builderFactory)
     {
         if (keysOrRanges.isEmpty())
             return map;
@@ -276,14 +278,11 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
         if (map.isEmpty())
             return create(keysOrRanges, value, builderFactory);
 
-        if (map.inclusiveEnds() != keysOrRanges.get(0).toUnseekable().asRange().endInclusive())
-            throw new IllegalStateException("Mismatching bound inclusivity/exclusivity - can't be updated");
-
         return update(map, keysOrRanges, value, valueResolver, factory);
     }
 
     private static <M extends BTreeReducingRangeMap<V>, V> M update(
-            M map, Unseekables<?> keysOrRanges, V value, BiFunction<V, V, V> valueResolver, BiFunction<Boolean, Object[], M> factory)
+            M map, Unseekables<?> keysOrRanges, V value, BiFunction<V, V, V> valueResolver, Function<Object[], M> factory)
     {
         Accumulator<V> acc = accumulator();
 
@@ -382,7 +381,7 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
         Object[] updated = acc.apply(map.tree); acc.reuse();
         return map.tree == updated
              ? map
-             : factory.apply(map.inclusiveEnds(), updated);
+             : factory.apply(updated);
     }
 
     private static final ThreadLocal<Accumulator<?>> accumulator = ThreadLocal.withInitial(Accumulator::new);
@@ -482,15 +481,15 @@ public class BTreeReducingRangeMap<V> extends BTreeReducingIntervalMap<RoutingKe
 
     static class Builder<V> extends AbstractBoundariesBuilder<RoutingKey, V, BTreeReducingRangeMap<V>>
     {
-        protected Builder(boolean inclusiveEnds, int capacity)
+        protected Builder(int capacity)
         {
-            super(inclusiveEnds, capacity);
+            super(capacity);
         }
 
         @Override
         protected BTreeReducingRangeMap<V> buildInternal(Object[] tree)
         {
-            return new BTreeReducingRangeMap<>(inclusiveEnds, tree);
+            return new BTreeReducingRangeMap<>(tree);
         }
     }
 

--- a/accord-core/src/main/java/accord/utils/IntrusiveLinkedList.java
+++ b/accord-core/src/main/java/accord/utils/IntrusiveLinkedList.java
@@ -29,10 +29,10 @@ import static java.util.Spliterators.spliteratorUnknownSize;
  * A simple intrusive double-linked list for maintaining a list of tasks,
  * useful for invalidating queued ordered tasks
  *
- * TODO (low priority): COPIED FROM CASSANDRA
+ * TODO (low priority): COPIED FROM CASSANDRA (TEST CLASSES). NOW USED IN CASSANDRA IMPL VIA HERE... SHOULD CLEANUP.
  */
 
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"unchecked", "unused"})
 public class IntrusiveLinkedList<O extends IntrusiveLinkedListNode> extends IntrusiveLinkedListNode implements Iterable<O>
 {
     public IntrusiveLinkedList()

--- a/accord-core/src/main/java/accord/utils/IntrusiveStack.java
+++ b/accord-core/src/main/java/accord/utils/IntrusiveStack.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.utils;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import net.nicoulaj.compilecommand.annotations.Inline;
+
+/**
+ * An efficient stack/list that is expected to be ordinarily either empty or close to, and for which
+ * we need concurrent insertions and do not need to support removal - i.e. the list is semi immutable.
+ *
+ * This is an intrusive stack, and for simplicity we treat all
+ *
+ * TODO (desired): COPIED FROM CASSANDRA - SHARE WITH COMMON SUBMODULE
+ *
+ * @param <T>
+ */
+public class IntrusiveStack<T extends IntrusiveStack<T>> implements Iterable<T>
+{
+    static class Itr<T extends IntrusiveStack<T>> implements Iterator<T>
+    {
+        private T next;
+
+        Itr(T next)
+        {
+            this.next = next;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return next != null;
+        }
+
+        @Override
+        public T next()
+        {
+            T result = next;
+            next = result.next;
+            return result;
+        }
+    }
+
+    T next;
+
+    @Inline
+    protected static <O, T extends IntrusiveStack<T>> T getAndPush(AtomicReferenceFieldUpdater<? super O, T> headUpdater, O owner, T prepend)
+    {
+        return getAndPush(headUpdater, owner, prepend, (prev, next) -> {
+            next.next = prev;
+            return next;
+        });
+    }
+
+    protected static <O, T extends IntrusiveStack<T>> T getAndPush(AtomicReferenceFieldUpdater<O, T> headUpdater, O owner, T prepend, BiFunction<T, T, T> combine)
+    {
+        while (true)
+        {
+            T head = headUpdater.get(owner);
+            T newHead = combine.apply(head, prepend);
+            if (headUpdater.compareAndSet(owner, head, newHead))
+                return head;
+        }
+    }
+
+    protected static <O, T extends IntrusiveStack<T>> T pushAndGet(AtomicReferenceFieldUpdater<O, T> headUpdater, O owner, T prepend, BiFunction<T, T, T> combine)
+    {
+        while (true)
+        {
+            T head = headUpdater.get(owner);
+            T newHead = combine.apply(head, prepend);
+            if (head == newHead || headUpdater.compareAndSet(owner, head, newHead))
+                return newHead;
+        }
+    }
+
+    protected interface Setter<O, T>
+    {
+        public boolean compareAndSet(O owner, T expect, T update);
+    }
+
+    @Inline
+    protected static <O, T extends IntrusiveStack<T>> T getAndPush(Function<O, T> getter, Setter<O, T> setter, O owner, T prepend)
+    {
+        return getAndPush(getter, setter, owner, prepend, (prev, next) -> {
+            next.next = prev;
+            return next;
+        });
+    }
+
+    protected static <O, T extends IntrusiveStack<T>> T getAndPush(Function<O, T> getter, Setter<O, T> setter, O owner, T prepend, BiFunction<T, T, T> combine)
+    {
+        while (true)
+        {
+            T head = getter.apply(owner);
+            if (setter.compareAndSet(owner, head, combine.apply(head, prepend)))
+                return head;
+        }
+    }
+
+    protected static <O, T extends IntrusiveStack<T>> void pushExclusive(AtomicReferenceFieldUpdater<O, T> headUpdater, O owner, T prepend, BiFunction<T, T, T> combine)
+    {
+        T head = headUpdater.get(owner);
+        headUpdater.lazySet(owner, combine.apply(head, prepend));
+    }
+
+    protected static <T extends IntrusiveStack<T>, O> void pushExclusive(AtomicReferenceFieldUpdater<O, T> headUpdater, O owner, T prepend)
+    {
+        prepend.next = headUpdater.get(owner);
+        headUpdater.lazySet(owner, prepend);
+    }
+
+    protected static <T extends IntrusiveStack<T>> T pushExclusive(T head, T prepend)
+    {
+        prepend.next = head;
+        return prepend;
+    }
+
+    protected static <T extends IntrusiveStack<T>, O> Iterable<T> iterable(AtomicReferenceFieldUpdater<O, T> headUpdater, O owner)
+    {
+        return iterable(headUpdater.get(owner));
+    }
+
+    protected static <T extends IntrusiveStack<T>> Iterable<T> iterable(T list)
+    {
+        return list == null ? () -> iterator(null) : list;
+    }
+
+    protected static <T extends IntrusiveStack<T>> Iterator<T> iterator(T list)
+    {
+        return new Itr<>(list);
+    }
+
+    protected static int size(IntrusiveStack<?> list)
+    {
+        int size = 0;
+        while (list != null)
+        {
+            ++size;
+            list = list.next;
+        }
+        return size;
+    }
+
+    protected static boolean isSize(int size, IntrusiveStack<?> list)
+    {
+        while (list != null && --size >= 0)
+            list = list.next;
+        return list == null && size == 0;
+    }
+
+    // requires exclusive ownership (incl. with readers)
+    protected T reverse()
+    {
+        return reverse((T) this);
+    }
+
+    // requires exclusive ownership (incl. with readers)
+    protected static <T extends IntrusiveStack<T>> T reverse(T list)
+    {
+        T prev = null;
+        T cur = list;
+        while (cur != null)
+        {
+            T next = cur.next;
+            cur.next = prev;
+            prev = cur;
+            cur = next;
+        }
+        return prev;
+    }
+
+    @Override
+    public void forEach(Consumer<? super T> forEach)
+    {
+        forEach((T)this, forEach);
+    }
+
+    public <P, V> V foldl(TriFunction<? super T, P, ? super V, ? extends V> foldl, P param, V accumulator)
+    {
+        T list = (T) this;
+        while (list != null)
+        {
+            accumulator = foldl.apply(list, param, accumulator);
+            list = list.next;
+        }
+        return accumulator;
+    }
+
+    protected static <T extends IntrusiveStack<T>> void forEach(T list, Consumer<? super T> forEach)
+    {
+        forEach(list, Function.identity(), forEach);
+    }
+
+    protected static <T extends IntrusiveStack<T>, P> void forEach(T list, BiConsumer<P, ? super T> forEach, P param)
+    {
+        forEach(list, Function.identity(), forEach, param);
+    }
+
+    protected static <T extends IntrusiveStack<T>, V> void forEach(T list, Function<? super T, ? extends V> getter, Consumer<? super V> forEach)
+    {
+        forEach(list, getter, Consumer::accept, forEach);
+    }
+
+    protected static <P, T extends IntrusiveStack<T>, V> void forEach(T list, Function<? super T, ? extends V> getter, BiConsumer<? super P, ? super V> forEach, P param)
+    {
+        while (list != null)
+        {
+            forEach.accept(param, getter.apply(list));
+            list = list.next;
+        }
+    }
+
+    @Override
+    public Iterator<T> iterator()
+    {
+        return new Itr<>((T) this);
+    }
+}

--- a/accord-core/src/main/java/accord/utils/Invariants.java
+++ b/accord-core/src/main/java/accord/utils/Invariants.java
@@ -386,6 +386,11 @@ public class Invariants
         return input;
     }
 
+    public static void refuseArgument(String msg)
+    {
+        throw illegalArgument(msg);
+    }
+
     public static void requireArgument(boolean condition)
     {
         if (!condition)

--- a/accord-core/src/main/java/accord/utils/ReducingIntervalMap.java
+++ b/accord-core/src/main/java/accord/utils/ReducingIntervalMap.java
@@ -31,6 +31,9 @@ import javax.annotation.Nullable;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import static accord.api.ProtocolModifiers.RangeSpec.isEndInclusive;
+import static accord.api.ProtocolModifiers.RangeSpec.isStartExclusive;
+import static accord.api.ProtocolModifiers.RangeSpec.isStartInclusive;
 import static accord.utils.Invariants.illegalState;
 
 /**
@@ -51,30 +54,21 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
     @SuppressWarnings("rawtypes")
     public static final Comparable[] NO_OBJECTS = new Comparable[0];
 
-    // for simplicity at construction, we permit this to be overridden by the first insertion
-    protected final boolean inclusiveEnds;
     // starts is 1 longer than values, so that starts[0] == start of values[0]
     protected final K[] starts;
     protected final V[] values;
 
+    @SuppressWarnings("unchecked")
     public ReducingIntervalMap()
     {
-        this(false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public ReducingIntervalMap(boolean inclusiveEnds)
-    {
-        this.inclusiveEnds = inclusiveEnds;
         this.starts = (K[]) NO_OBJECTS;
         this.values = (V[]) NO_OBJECTS;
     }
 
     @VisibleForTesting
-    ReducingIntervalMap(boolean inclusiveEnds, K[] starts, V[] values)
+    ReducingIntervalMap(K[] starts, V[] values)
     {
         Invariants.requireArgument(starts.length == values.length + 1 || (starts.length + values.length) == 0);
-        this.inclusiveEnds = inclusiveEnds;
         this.starts = starts;
         this.values = values;
     }
@@ -142,7 +136,7 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
     {
         return IntStream.range(0, values.length)
                         .filter(i -> include.test(values[i]))
-                        .mapToObj(i -> (inclusiveStarts() ? "[" : "(") + starts[i] + "," + starts[i + 1] + (inclusiveEnds ? "]" : ")") + "=" + values[i])
+                        .mapToObj(i -> (isStartInclusive() ? "[" : "(") + starts[i] + "," + starts[i + 1] + (isEndInclusive() ? "]" : ")") + "=" + values[i])
                         .collect(Collectors.joining(", ", "{", "}"));
     }
 
@@ -152,17 +146,12 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ReducingIntervalMap that = (ReducingIntervalMap) o;
-        return inclusiveEnds == that.inclusiveEnds && Arrays.equals(starts, that.starts) && Arrays.equals(values, that.values);
+        return Arrays.equals(starts, that.starts) && Arrays.equals(values, that.values);
     }
 
     public int hashCode()
     {
         return Arrays.hashCode(values);
-    }
-
-    public boolean inclusiveEnds()
-    {
-        return inclusiveEnds;
     }
 
     public V get(K key)
@@ -200,13 +189,8 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
     {
         int idx = Arrays.binarySearch(starts, key);
         if (idx < 0) idx = -2 - idx;
-        else if (inclusiveEnds) --idx;
+        else if (isEndInclusive()) --idx;
         return idx;
-    }
-
-    protected final boolean inclusiveStarts()
-    {
-        return !inclusiveEnds;
     }
 
     public int size()
@@ -234,8 +218,7 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
         if (historyRight == null || historyRight.values.length == 0)
             return historyLeft;
 
-        boolean inclusiveEnds = inclusiveEnds(historyLeft.inclusiveEnds, historyLeft.size() > 0, historyRight.inclusiveEnds, historyRight.size() > 0);
-        IntervalBuilder<K, V, M> builder = factory.create(inclusiveEnds, historyLeft.size() + historyRight.size());
+        IntervalBuilder<K, V, M> builder = factory.create(historyLeft.size() + historyRight.size());
 
         ReducingIntervalMap<K, V>.RangeIterator left = historyLeft.rangeIterator();
         ReducingIntervalMap<K, V>.RangeIterator right = historyRight.rangeIterator();
@@ -307,8 +290,7 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
         if (historyRight == null || historyRight.values.length == 0)
             return historyLeft;
 
-        boolean inclusiveEnds = inclusiveEnds(historyLeft.inclusiveEnds, historyLeft.size() > 0, historyRight.inclusiveEnds, historyRight.size() > 0);
-        AbstractBoundariesBuilder<K, V, M> builder = factory.create(inclusiveEnds, historyLeft.size() + historyRight.size());
+        AbstractBoundariesBuilder<K, V, M> builder = factory.create(historyLeft.size() + historyRight.size());
 
         ReducingIntervalMap<K, V>.RangeIterator left = historyLeft.rangeIterator();
         ReducingIntervalMap<K, V>.RangeIterator right = historyRight.rangeIterator();
@@ -396,11 +378,11 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
     {
         int from = Arrays.binarySearch(starts, start);
         if (from < 0) from = Math.max(0, -2 - from);
-        else if (!inclusiveStarts()) ++from;
+        else if (isStartExclusive()) ++from;
 
         int to = Arrays.binarySearch(starts, end);
         if (to < 0) to = -1 - to;
-        else if (inclusiveStarts()) ++to;
+        else if (isStartInclusive()) ++to;
         return new RangeIterator(from, to);
     }
 
@@ -448,18 +430,16 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
 
     protected interface BuilderFactory<K extends Comparable<? super K>, V, M extends ReducingIntervalMap<K, V>>
     {
-        AbstractBoundariesBuilder<K, V, M> create(boolean inclusiveEnds, int capacity);
+        AbstractBoundariesBuilder<K, V, M> create(int capacity);
     }
 
     protected static abstract class AbstractBoundariesBuilder<K extends Comparable<? super K>, V, M extends ReducingIntervalMap<K, V>>
     {
-        protected final boolean inclusiveEnds;
         protected final List<K> starts;
         protected final List<V> values;
         private K safeToAdd;
-        protected AbstractBoundariesBuilder(boolean inclusiveEnds, int estimatedCapacity)
+        protected AbstractBoundariesBuilder(int estimatedCapacity)
         {
-            this.inclusiveEnds = inclusiveEnds;
             this.starts = new ArrayList<>(estimatedCapacity);
             this.values = new ArrayList<>(estimatedCapacity + 1);
         }
@@ -564,7 +544,7 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
 
     protected interface IntervalBuilderFactory<K extends Comparable<? super K>, V, M extends ReducingIntervalMap<K, V>>
     {
-        IntervalBuilder<K, V, M> create(boolean inclusiveEnds, int capacity);
+        IntervalBuilder<K, V, M> create(int capacity);
     }
 
     protected static abstract class IntervalBuilder<K extends Comparable<? super K>, V, M>
@@ -581,14 +561,12 @@ public class ReducingIntervalMap<K extends Comparable<? super K>, V>
 
     protected static abstract class AbstractIntervalBuilder<K extends Comparable<? super K>, V, M> extends IntervalBuilder<K, V, M>
     {
-        protected final boolean inclusiveEnds;
         protected final List<K> starts;
         protected final List<V> values;
 
         private K prevEnd;
-        protected AbstractIntervalBuilder(boolean inclusiveEnds, int capacity)
+        protected AbstractIntervalBuilder(int capacity)
         {
-            this.inclusiveEnds = inclusiveEnds;
             this.starts = new ArrayList<>(capacity);
             this.values = new ArrayList<>(capacity + 1);
         }

--- a/accord-core/src/main/java/accord/utils/ReducingRangeMap.java
+++ b/accord-core/src/main/java/accord/utils/ReducingRangeMap.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
 
+import static accord.api.ProtocolModifiers.RangeSpec.isEndInclusive;
 import static accord.utils.SortedArrays.Search.FAST;
 import static accord.utils.SortedArrays.exponentialSearch;
 
@@ -38,20 +39,20 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
 
     public static class SerializerSupport
     {
-        public static <V> ReducingRangeMap<V> create(boolean inclusiveEnds, RoutingKey[] starts, V[] values)
+        public static <V> ReducingRangeMap<V> create(RoutingKey[] starts, V[] values)
         {
-            return new ReducingRangeMap<>(inclusiveEnds, starts, values);
+            return new ReducingRangeMap<>(starts, values);
         }
     }
 
     public ReducingRangeMap()
     {
-        super(false, RoutingKeys.EMPTY_KEYS_ARRAY, (V[])NO_OBJECTS);
+        super(RoutingKeys.EMPTY_KEYS_ARRAY, (V[])NO_OBJECTS);
     }
 
-    protected ReducingRangeMap(boolean inclusiveEnds, RoutingKey[] starts, V[] values)
+    protected ReducingRangeMap(RoutingKey[] starts, V[] values)
     {
-        super(inclusiveEnds, starts, values);
+        super(starts, values);
     }
 
     public <V2> V2 foldl(Routables<?> routables, BiFunction<V, V2, V2> fold, V2 accumulator)
@@ -136,21 +137,21 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
 
         int i = 0, j = keys.find(starts[0], FAST);
         if (j < 0) j = -1 - j;
-        else if (inclusiveEnds) ++j;
+        else if (isEndInclusive()) ++j;
 
         while (j < keys.size())
         {
             // TODO (desired): first search should be binarySearch
             i = exponentialSearch(starts, i, starts.length, keys.get(j));
             if (i < 0) i = -2 - i;
-            else if (inclusiveEnds) --i;
+            else if (isEndInclusive()) --i;
 
             if (i >= values.length)
                 return accumulator;
 
             int nextj = keys.findNext(j, starts[i + 1], FAST);
             if (nextj < 0) nextj = -1 -nextj;
-            else if (inclusiveEnds) ++nextj;
+            else if (isEndInclusive()) ++nextj;
 
             if (j != nextj && values[i] != null)
             {
@@ -187,7 +188,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
 
         int j = ranges.find(starts[0], FAST);
         if (j < 0) j = -1 - j;
-        else if (inclusiveEnds && ranges.get(j).end().equals(starts[0])) ++j;
+        else if (isEndInclusive() && ranges.get(j).end().equals(starts[0])) ++j;
 
         int i = 0;
         while (j < ranges.size())
@@ -195,7 +196,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
             // TODO (desired): first search should be binarySearch
             int nexti = exponentialSearch(starts, i, starts.length, ranges.get(j).start());
             if (nexti < 0) i = Math.max(i, -2 - nexti);
-            else if (nexti > i && inclusiveEnds) i = nexti - 1;
+            else if (nexti > i && isEndInclusive()) i = nexti - 1;
             else i = nexti;
 
             if (i >= values.length)
@@ -209,7 +210,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
             else
             {
                 toj = nextj + 1;
-                if (inclusiveEnds && ranges.get(nextj).end().equals(starts[i + 1]))
+                if (isEndInclusive() && ranges.get(nextj).end().equals(starts[i + 1]))
                     ++nextj;
             }
 
@@ -243,7 +244,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
 
         int i = 0, j = keys.find(starts[0], FAST);
         if (j < 0) j = -1 - j;
-        else if (inclusiveEnds) ++j;
+        else if (isEndInclusive()) ++j;
 
         if (j > 0)
             accumulator = fold.apply(defaultValue, accumulator, p1, p2, 0, j, 0);
@@ -253,14 +254,14 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
             // TODO (desired): first search should be binarySearch
             i = exponentialSearch(starts, i, starts.length, keys.get(j));
             if (i < 0) i = -2 - i;
-            else if (inclusiveEnds) --i;
+            else if (isEndInclusive()) --i;
 
             if (i >= values.length)
                 return fold.apply(defaultValue, accumulator, p1, p2, j, keys.size(), i);
 
             int nextj = keys.findNext(j, starts[i + 1], FAST);
             if (nextj < 0) nextj = -1 -nextj;
-            else if (inclusiveEnds) ++nextj;
+            else if (isEndInclusive()) ++nextj;
 
             if (j != nextj)
             {
@@ -288,7 +289,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
 
         int j = ranges.find(starts[0], FAST);
         if (j < 0) j = -1 - j;
-        else if (inclusiveEnds && ranges.get(j).end().equals(starts[0])) ++j;
+        else if (isEndInclusive() && ranges.get(j).end().equals(starts[0])) ++j;
 
         if (j > 0 || starts[0].compareTo(ranges.get(0).start()) > 0)
             accumulator = fold.apply(defaultValue, accumulator, p1, p2, 0, j, 0);
@@ -299,7 +300,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
             // TODO (desired): first search should be binarySearch
             int nexti = exponentialSearch(starts, i, starts.length, ranges.get(j).start());
             if (nexti < 0) i = Math.max(i, -2 - nexti);
-            else if (nexti > i && inclusiveEnds) i = nexti - 1;
+            else if (nexti > i && isEndInclusive()) i = nexti - 1;
             else i = nexti;
 
             if (i >= values.length)
@@ -313,7 +314,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
             else
             {
                 toj = nextj + 1;
-                if (inclusiveEnds && ranges.get(nextj).end().equals(starts[i + 1]))
+                if (isEndInclusive() && ranges.get(nextj).end().equals(starts[i + 1]))
                     ++nextj;
             }
 
@@ -338,7 +339,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
     {
         int idx = Arrays.binarySearch(starts, key);
         if (idx < 0) idx = -2 - idx;
-        else if (inclusiveEnds) --idx;
+        else if (isEndInclusive()) --idx;
         return idx;
     }
 
@@ -363,7 +364,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
 
     public static <V> ReducingRangeMap<V> create(Range range, V value)
     {
-        return new ReducingRangeMap<>(range.endInclusive(), new RoutingKey[] { range.start(), range.end() }, (V[])new Object[] { value });
+        return new ReducingRangeMap<>(new RoutingKey[] { range.start(), range.end() }, (V[])new Object[] { value });
     }
 
     protected static <V, M extends ReducingRangeMap<V>> M create(Unseekables<?> keysOrRanges, V value, BuilderFactory<RoutingKey, V, M> builder)
@@ -391,7 +392,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         if (value == null)
             throw new IllegalArgumentException("value is null");
 
-        AbstractBoundariesBuilder<RoutingKey, V, M> builder = factory.create(ranges.get(0).endInclusive(), ranges.size() * 2);
+        AbstractBoundariesBuilder<RoutingKey, V, M> builder = factory.create(ranges.size() * 2);
         for (Range cur : ranges)
         {
             builder.appendNoOverlap(cur.start(), value);
@@ -406,7 +407,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         if (value == null)
             throw new IllegalArgumentException("value is null");
 
-        AbstractBoundariesBuilder<RoutingKey, V, M> builder = factory.create(keys.get(0).asRange().endInclusive(), keys.size() * 2);
+        AbstractBoundariesBuilder<RoutingKey, V, M> builder = factory.create(keys.size() * 2);
         for (int i = 0 ; i < keys.size() ; ++i)
         {
             Range range = keys.get(i).asRange();
@@ -426,7 +427,7 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         AbstractBoundariesBuilder<RoutingKey, V, M> builder;
         {
             Range range = prev.asRange();
-            builder = factory.create(prev.asRange().endInclusive(), keys.size() * 2);
+            builder = factory.create(keys.size() * 2);
             builder.appendNoOverlap(range.start(), value);
             builder.appendNoOverlap(range.end(), null);
         }
@@ -464,16 +465,16 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
 
     public static class Builder<V> extends AbstractBoundariesBuilder<RoutingKey, V, ReducingRangeMap<V>>
     {
-        public Builder(boolean inclusiveEnds, int capacity)
+        public Builder(int capacity)
         {
-            super(inclusiveEnds, capacity);
+            super(capacity);
         }
 
         @SuppressWarnings("unchecked")
         @Override
         protected ReducingRangeMap<V> buildInternal()
         {
-            return new ReducingRangeMap<>(inclusiveEnds, starts.toArray(new RoutingKey[0]), (V[])values.toArray(new Object[0]));
+            return new ReducingRangeMap<>(starts.toArray(new RoutingKey[0]), (V[])values.toArray(new Object[0]));
         }
     }
 
@@ -496,6 +497,6 @@ public class ReducingRangeMap<V> extends ReducingIntervalMap<RoutingKey, V>
         V2[] output = allocator.apply(values.length);
         for (int i = 0 ; i < values.length ; ++i)
             output[i] = map.apply(values[i]);
-        return new ReducingRangeMap<>(inclusiveEnds, starts, output);
+        return new ReducingRangeMap<>(starts, output);
     }
 }

--- a/accord-core/src/main/java/accord/utils/SemiSyncCollection.java
+++ b/accord-core/src/main/java/accord/utils/SemiSyncCollection.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.utils;
+
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+public abstract class SemiSyncCollection<V, E, ES> extends SemiSyncValue<V, SemiSyncCollection.Edit<E>>
+{
+    protected static class Edit<E> extends SemiSyncValue.Edit<Edit<E>>
+    {
+        public final Object group;
+        public final E with;
+        public final E replace;
+
+        public Edit(Object group, E with, E replace)
+        {
+            this.group = group;
+            this.with = with;
+            this.replace = replace;
+        }
+
+        @Nonnull
+        @Override
+        protected Object group()
+        {
+            return group;
+        }
+
+        @Override
+        protected Edit<E> merge(Edit<E> next)
+        {
+            return new Edit<>(next.group, next.with, replace);
+        }
+    }
+
+    protected abstract ES merge(List<E> es);
+    protected abstract V applyOne(V value, E add, E remove);
+    protected abstract V applyMultiple(V value, ES add, ES remove);
+
+    protected V merge(V value, Edit<E> edit)
+    {
+        return applyOne(value, edit.with, edit.replace);
+    }
+
+    protected V merge(V value, Collection<Edit<E>> edits)
+    {
+        ES add, remove;
+        try (ArrayBuffers.BufferList<E> adds = new ArrayBuffers.BufferList<>();
+             ArrayBuffers.BufferList<E> removes = new ArrayBuffers.BufferList<>())
+        {
+            for (Edit<E> edit : edits)
+            {
+                if (edit.with != null)
+                    adds.add(edit.with);
+                if (edit.replace != null)
+                    removes.add(edit.replace);
+            }
+            add = merge(adds);
+            remove = merge(removes);
+        }
+        return applyMultiple(value, add, remove);
+    }
+
+    protected SemiSyncCollection(V initialValue)
+    {
+        super(initialValue);
+    }
+}

--- a/accord-core/src/main/java/accord/utils/SemiSyncIntervalTree.java
+++ b/accord-core/src/main/java/accord/utils/SemiSyncIntervalTree.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.utils;
+
+import java.util.List;
+
+import accord.utils.btree.IntervalBTree;
+
+public abstract class SemiSyncIntervalTree<E> extends SemiSyncCollection<Object[], E, Object[]>
+{
+    final IntervalBTree.IntervalComparators<?> comparators;
+
+    protected SemiSyncIntervalTree(IntervalBTree.IntervalComparators<?> comparators)
+    {
+        super(IntervalBTree.empty());
+        this.comparators = comparators;
+    }
+
+    protected abstract Object[] tree(E edit);
+
+    protected void pushEdit(Object group, E add, E remove)
+    {
+        pushEdit(new Edit<>(group, add, remove));
+    }
+
+    protected Object[] merge(List<E> es)
+    {
+        if (es.isEmpty())
+            return IntervalBTree.empty();
+        Object[] v = tree(es.get(0));
+        for (int i = 1; i < es.size() ; ++i)
+            v = IntervalBTree.update(v, tree(es.get(i)), comparators);
+        return v;
+    }
+
+    protected Object[] applyOne(Object[] value, E add, E remove)
+    {
+        return applyMultiple(value, add == null ? null : tree(add), remove == null ? null : tree(remove));
+    }
+
+    protected Object[] applyMultiple(Object[] value, Object[] add, Object[] remove)
+    {
+        Object[] result = value;
+        if (remove != null)
+            result = IntervalBTree.subtract(value, remove, comparators);
+        if (add != null)
+            return IntervalBTree.update(result, add, comparators);
+        return result;
+    }
+}

--- a/accord-core/src/main/java/accord/utils/SemiSyncValue.java
+++ b/accord-core/src/main/java/accord/utils/SemiSyncValue.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.utils;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.annotation.Nonnull;
+
+/**
+ * A value that may be updated asynchronously. Edits to the value are queued, and when prompted by the implementation
+ * an attempt is made to exclusively drain any pending edits. Before reading the value any pending edits are
+ * drained synchronously.
+ *
+ * Depending on the underlying collection once a read has been served it may be possible to update a collection
+ * before the read is complete (i.e. if the collection is immutable/copy-on-write). It is up to the implementation
+ * or user to ensure any mutual exclusivity required for correctness otherwise.
+ */
+public abstract class SemiSyncValue<V, E extends SemiSyncValue.Edit<E>> implements Runnable
+{
+    protected static abstract class Edit<E extends Edit<E>> extends IntrusiveStack<E>
+    {
+        static <E extends Edit<E>> boolean push(E edit, SemiSyncValue<?, E> owner)
+        {
+            return null == IntrusiveStack.getAndPush(pendingEditsUpdater, (SemiSyncValue)owner, (Edit)edit);
+        }
+
+        // may be some constant; if multiple pending edits, group them by this identity before applying
+        protected abstract @Nonnull Object group();
+
+        // merge two Edits for the same group
+        protected abstract E merge(E next);
+    }
+
+    protected V value;
+    protected volatile E pendingEdits;
+    private final ReentrantLock drainPendingEditsLock = new ReentrantLock();
+    private static final AtomicReferenceFieldUpdater<SemiSyncValue, Edit> pendingEditsUpdater = AtomicReferenceFieldUpdater.newUpdater(SemiSyncValue.class, Edit.class, "pendingEdits");
+
+    /**
+     * We have added an edit onto an empty queue; the implementation may request an immediate or asynchronous flush if helpful
+     */
+    protected void onNewEdits() {}
+
+    /**
+     * We have completed a drain and found more edits pending; the implementation may request an immediate or asynchronous flush if helpful
+     */
+    protected void onRemainingEdits() {}
+
+    protected abstract V merge(V value, E edit);
+
+    protected V merge(V value, Collection<E> edits)
+    {
+        for (E edit : edits)
+            value = merge(value, edit);
+        return value;
+    }
+
+    protected SemiSyncValue(V initialValue)
+    {
+        this.value = initialValue;
+    }
+
+    protected void pushEdit(E edit)
+    {
+        if (Edit.push(edit, this))
+            onNewEdits();
+    }
+
+    @Override
+    public void run()
+    {
+        tryDrainPendingEdits();
+    }
+
+    protected V get()
+    {
+        return drainPendingEdits();
+    }
+
+    protected boolean tryDrainPendingEdits()
+    {
+        if (!tryLock())
+            return false;
+
+        try
+        {
+            drainPendingEditsExclusive();
+            return true;
+        }
+        finally
+        {
+            unlock();
+        }
+    }
+
+    protected V drainPendingEdits()
+    {
+        lock();
+        try
+        {
+            drainPendingEditsExclusive();
+            return value;
+        }
+        finally
+        {
+            unlock();
+        }
+    }
+
+    protected void drainPendingEditsExclusive()
+    {
+        E edits = (E) pendingEditsUpdater.getAndSet(this, null);
+        if (edits == null)
+            return;
+
+        edits = edits.reverse();
+        Map<Object, E> editMap = null;
+        E pending = edits;
+        Object pendingKey = pending.group();
+        for (E next = edits.next; next != null ; next = next.next)
+        {
+            Object nextKey = next.group();
+            if (!pendingKey.equals(nextKey))
+            {
+                if (editMap == null) editMap = new HashMap<>();
+                editMap.merge(pendingKey, pending, Edit::merge);
+                pending = next;
+                pendingKey = nextKey;
+            }
+            else
+            {
+                pending = pending.merge(next);
+            }
+        }
+
+        if (editMap == null)
+        {
+            value = merge(value, pending);
+        }
+        else
+        {
+            editMap.merge(pendingKey, pending, Edit::merge);
+            value = merge(value, editMap.values());
+        }
+    }
+
+    protected final void lock()
+    {
+        drainPendingEditsLock.lock();
+    }
+
+    protected final boolean tryLock()
+    {
+        return drainPendingEditsLock.tryLock();
+    }
+
+    protected final void unlock()
+    {
+        drainPendingEditsLock.unlock();
+        postUnlock();
+    }
+
+    private void postUnlock()
+    {
+        if (pendingEdits != null && !drainPendingEditsLock.isHeldByCurrentThread())
+            onRemainingEdits();
+    }
+}

--- a/accord-core/src/main/java/accord/utils/btree/BTree.java
+++ b/accord-core/src/main/java/accord/utils/btree/BTree.java
@@ -3378,6 +3378,7 @@ public class BTree
             {
                 branch.count = 0;
                 branch.hasRightChild = false;
+                branch.clearSourceNode();
                 clearBranchBuffer(branch.buffer);
                 if (branch.savedBuffer != null && branch.savedBuffer[0] != null)
                     Arrays.fill(branch.savedBuffer, null); // by definition full, if non-empty
@@ -3385,6 +3386,15 @@ public class BTree
                 branch = branch.parent;
             }
             Invariants.require(branch == null || (branch.count == 0 && !branch.hasRightChild));
+            if (Invariants.isParanoid() && branch != null)
+            {
+                while (branch != null)
+                {
+                    Invariants.require(!branch.inUse);
+                    Invariants.require(branch.sourceNode == null);
+                    branch = branch.parent;
+                }
+            }
         }
 
         /**

--- a/accord-core/src/main/java/accord/utils/btree/IntervalBTree.java
+++ b/accord-core/src/main/java/accord/utils/btree/IntervalBTree.java
@@ -98,12 +98,12 @@ public class IntervalBTree
     /**
      * Apply the accumulation function over all intersecting intervals in the tree
      */
-    public static <Find, Interval, P1, P2, V> V accumulate(Object[] btree, WithIntervalComparators<Find, Interval> comparators, Find find, QuadFunction<P1, P2, Interval, V, V> function, P1 p1, P2 p2, V accumulate)
+    public static <Find, Interval, P1, P2, V> V accumulate(Object[] btree, WithIntervalComparators<? super Find, ? super Interval> comparators, Find find, QuadFunction<P1, P2, Interval, V, V> function, P1 p1, P2 p2, V accumulate)
     {
         if (isLeaf(btree))
         {
-            AsymmetricComparator<Find, Interval> startWithEnd = comparators.startWithEndSeeker();
-            AsymmetricComparator<Find, Interval> endWithStart = comparators.endWithStartSeeker();
+            AsymmetricComparator<? super Find, ? super Interval> startWithEnd = comparators.startWithEndSeeker();
+            AsymmetricComparator<? super Find, ? super Interval> endWithStart = comparators.endWithStartSeeker();
             int keyEnd = getLeafKeyEnd(btree);
             for (int i = 0; i < keyEnd; ++i)
             {
@@ -171,10 +171,10 @@ public class IntervalBTree
         return accumulate;
     }
 
-    private static <Find, Interval, P1, P2, V> V accumulateMaxOnly(int ifChildBefore, int ifKeyBefore, Object[] btree, WithIntervalComparators<Find, Interval> comparators, Find find, QuadFunction<P1, P2, Interval, V, V> function, P1 p1, P2 p2, V accumulate)
+    private static <Find, Interval, P1, P2, V> V accumulateMaxOnly(int ifChildBefore, int ifKeyBefore, Object[] btree, WithIntervalComparators<? super Find, ? super Interval> comparators, Find find, QuadFunction<P1, P2, Interval, V, V> function, P1 p1, P2 p2, V accumulate)
     {
-        AsymmetricComparator<Find, Interval> startWithEnd = comparators.startWithEndSeeker();
-        AsymmetricComparator<Find, Interval> endWithStart = comparators.endWithStartSeeker();
+        AsymmetricComparator<? super Find, ? super Interval> startWithEnd = comparators.startWithEndSeeker();
+        AsymmetricComparator<? super Find, ? super Interval> endWithStart = comparators.endWithStartSeeker();
         if (isLeaf(btree))
         {
             Invariants.require(ifChildBefore == Integer.MAX_VALUE);
@@ -607,7 +607,7 @@ public class IntervalBTree
     /**
      * Build a tree of unknown size, in order.
      */
-    public static <V> FastIntervalTreeBuilder<V> fastBuilder(IntervalComparators<V> comparators)
+    public static <V> FastIntervalTreeBuilder<V> fastBuilder(IntervalComparators<? super V> comparators)
     {
         TinyThreadLocalPool.TinyPool<FastIntervalTreeBuilder<?>> pool = FastIntervalTreeBuilder.POOL.get();
         FastIntervalTreeBuilder<V> builder = (FastIntervalTreeBuilder<V>) pool.poll();

--- a/accord-core/src/test/java/accord/impl/LocalListenersTest.java
+++ b/accord-core/src/test/java/accord/impl/LocalListenersTest.java
@@ -19,6 +19,7 @@
 package accord.impl;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -39,12 +40,15 @@ import accord.api.LocalListeners;
 import accord.api.LocalListeners.ComplexListener;
 import accord.api.RemoteListeners.NoOpRemoteListeners;
 import accord.local.Command;
+import accord.local.Node;
 import accord.local.SafeCommand;
 import accord.local.SafeCommandStore;
+import accord.primitives.Routable;
 import accord.primitives.SaveStatus;
 import accord.primitives.Status.Durability;
 import accord.local.StoreParticipants;
 import accord.primitives.Ballot;
+import accord.primitives.Txn;
 import accord.primitives.TxnId;
 import accord.utils.AccordGens;
 import accord.utils.Invariants;
@@ -433,6 +437,49 @@ public class LocalListenersTest
         }
     }
 
+    @Test
+    public void testTxnListeners()
+    {
+        DefaultLocalListeners listeners = new DefaultLocalListeners(new RemoteListenersTest.TestCommandStore(1), new DefaultRemoteListeners((DefaultRemoteListeners.NotifySink) null), null);
+        TxnId txnId1 = new TxnId(1, 1, Txn.Kind.Write, Routable.Domain.Key, new Node.Id(1));
+        TxnId txnId2 = new TxnId(1, 2, Txn.Kind.Write, Routable.Domain.Key, new Node.Id(1));
+        TxnId txnId3 = new TxnId(1, 3, Txn.Kind.Write, Routable.Domain.Key, new Node.Id(1));
+        TxnId txnId4 = new TxnId(1, 4, Txn.Kind.Write, Routable.Domain.Key, new Node.Id(1));
+        listeners.register(txnId1, SaveStatus.Applied, txnId2);
+        listeners.register(txnId1, SaveStatus.Applied, txnId3);
+        listeners.register(txnId1, SaveStatus.Applying, txnId2);
+        listeners.register(txnId2, SaveStatus.Applied, txnId3);
+        listeners.register(txnId2, SaveStatus.Applied, txnId4);
+        TreeMap<TxnId, TreeMap<SaveStatus, List<TxnId>>> actual = new TreeMap<>();
+        listeners.txnListeners().forEach(l -> {
+            actual.computeIfAbsent(l.waitingOn, ignore -> new TreeMap<>())
+                  .computeIfAbsent(l.awaitingStatus, ignore -> new ArrayList<>())
+                  .add(l.waiter);
+        });
+        TreeMap<TxnId, TreeMap<SaveStatus, List<TxnId>>> expected = new TreeMap<>();
+        expected.computeIfAbsent(txnId1, ignore -> new TreeMap<>())
+                .put(SaveStatus.Applying, Arrays.asList(txnId2));
+        expected.computeIfAbsent(txnId1, ignore -> new TreeMap<>())
+                .put(SaveStatus.Applied, Arrays.asList(txnId2, txnId3));
+        expected.computeIfAbsent(txnId2, ignore -> new TreeMap<>())
+                .put(SaveStatus.Applied, Arrays.asList(txnId3, txnId4));
+        Assertions.assertEquals(expected, actual);
+    }
 
-
+    @Test
+    public void testComplexListeners()
+    {
+        DefaultLocalListeners listeners = new DefaultLocalListeners(new RemoteListenersTest.TestCommandStore(1), new DefaultRemoteListeners((DefaultRemoteListeners.NotifySink) null), null);
+        TxnId txnId1 = new TxnId(1, 1, Txn.Kind.Write, Routable.Domain.Key, new Node.Id(1));
+        ComplexListener listener1 = (safeStore, safeCommand) -> false;
+        ComplexListener listener2 = (safeStore, safeCommand) -> false;
+        listeners.register(txnId1, listener1);
+        listeners.register(txnId1, listener2);
+        List<ComplexListener> waiters = new ArrayList<>();
+        listeners.complexListeners().forEach(l -> {
+            Assertions.assertEquals(txnId1, l.waitingOn());
+            waiters.add(l.waiting());
+        });
+        Assertions.assertEquals(Arrays.asList(listener1, listener2), waiters);
+    }
 }

--- a/accord-core/src/test/java/accord/impl/RemoteListenersTest.java
+++ b/accord-core/src/test/java/accord/impl/RemoteListenersTest.java
@@ -46,7 +46,6 @@ import accord.api.RoutingKey;
 import accord.impl.LocalListenersTest.TestSafeCommand;
 import accord.local.CommandStore;
 import accord.local.CommandStores;
-import accord.local.CommandSummaries;
 import accord.local.Node;
 import accord.local.NodeCommandStoreService;
 import accord.local.PreLoadContext;
@@ -411,7 +410,7 @@ public class RemoteListenersTest
         }
 
         @Override protected void ensureDurable(Ranges ranges, RedundantBefore onCommandStoreDurable) {}
-        @Override public boolean inStore() { return false; }
+        @Override public boolean inStore() { return true; }
         @Override public AsyncChain<Void> chain(PreLoadContext context, Consumer<? super SafeCommandStore> consumer) { return null; }
         @Override public <T> AsyncChain<T> chain(PreLoadContext context, Function<? super SafeCommandStore, T> apply) { return null; }
         @Override public void shutdown() {}
@@ -446,7 +445,7 @@ public class RemoteListenersTest
         }
 
         @Override public <P1, P2> void visit(Unseekables<?> keys, @Nullable Timestamp withLowerTxnId, Txn.Kind.Kinds kinds, ActiveCommandVisitor<P1, P2> visit, P1 p1, P2 p2) { }
-        @Override public boolean visit(Unseekables<?> keys, TxnId testTxnId, Txn.Kind.Kinds testKind, CommandSummaries.TestStartedAt testStartedAt, Timestamp testStartedAtTimestamp, ComputeIsDep computeIsDep, AllCommandVisitor visit) { return true; }
+        @Override public boolean visit(Unseekables<?> keys, TxnId testTxnId, Txn.Kind.Kinds testKind, SupersedingCommandVisitor visit) { return true; }
         @Override public DataStore dataStore() { return null; }
         @Override public Agent agent() { return null; }
         @Override public ProgressLog progressLog() { return null; }

--- a/accord-core/src/test/java/accord/impl/basic/DelayedCommandStores.java
+++ b/accord-core/src/test/java/accord/impl/basic/DelayedCommandStores.java
@@ -31,6 +31,8 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.ImmutableSortedMap;
 
 import accord.api.Agent;
@@ -40,10 +42,10 @@ import accord.api.LocalListeners;
 import accord.api.ProgressLog;
 import accord.api.RoutingKey;
 import accord.impl.InMemoryCommandStore;
+import accord.impl.InMemoryCommandStore.CommandsForRangeLoad;
 import accord.impl.InMemoryCommandStores;
 import accord.impl.InMemorySafeCommand;
 import accord.impl.InMemorySafeCommandsForKey;
-import accord.impl.PrefixedIntHashKey;
 import accord.impl.basic.TaskExecutorService.Task;
 import accord.local.Command;
 import accord.local.CommandStore;
@@ -54,12 +56,10 @@ import accord.local.RedundantBefore;
 import accord.local.SafeCommandStore;
 import accord.local.ShardDistributor;
 import accord.local.cfk.CommandsForKey;
-import accord.primitives.Range;
 import accord.primitives.Ranges;
 import accord.primitives.RoutableKey;
 import accord.primitives.Timestamp;
 import accord.primitives.TxnId;
-import accord.topology.Topology;
 import accord.utils.Invariants;
 import accord.utils.RandomSource;
 import accord.utils.async.AsyncChain;
@@ -144,17 +144,6 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
         super.loadSnapshot(nextSnapshot);
     }
 
-    private static boolean contains(Topology previous, int searchPrefix)
-    {
-        for (Range range : previous.ranges())
-        {
-            int prefix = ((PrefixedIntHashKey) range.start()).prefix;
-            if (prefix == searchPrefix)
-                return true;
-        }
-        return false;
-    }
-
     public static class DelayedCommandStore extends InMemoryCommandStore
     {
         public class DelayedTask<T> extends Task<T>
@@ -167,6 +156,16 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
             private DelayedTask(Callable<T> call, Pending origin)
             {
                 super(call, origin);
+            }
+
+            private DelayedTask(Callable<T> fn, @Nullable Cancellable ifCancelled)
+            {
+                super(fn, ifCancelled);
+            }
+
+            private DelayedTask(Callable<T> fn, Pending origin, @Nullable Cancellable ifCancelled)
+            {
+                super(fn, origin, ifCancelled);
             }
 
             public DelayedCommandStore owner()
@@ -305,13 +304,13 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
         @Override
         public AsyncChain<Void> chain(PreLoadContext context, Consumer<? super SafeCommandStore> consumer)
         {
-            return submit(newTask(context, i -> { consumer.accept(i); return null; }));
+            return chain(context, i -> { consumer.accept(i); return null; });
         }
 
         @Override
         public <T> AsyncChain<T> chain(PreLoadContext context, Function<? super SafeCommandStore, T> function)
         {
-            return submit(newTask(context, function));
+            return submit(newTask(context, cfrLoad(context), function));
         }
 
         @Override
@@ -338,12 +337,12 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
                 runNextTask();
         }
 
-        private <T> DelayedTask<T> newTask(PreLoadContext context, Function<? super SafeCommandStore, T> function)
+        private <T> DelayedTask<T> newTask(PreLoadContext context, @Nullable CommandsForRangeLoad cfrLoad, Function<? super SafeCommandStore, T> function)
         {
             Pending origin = Pending.Global.activeOrigin();
             if (RecurringPendingRunnable.isRecurring(origin) && context.primaryTxnId() != null && !context.primaryTxnId().isSystemTxn())
                 origin = null;
-            return new DelayedTask<>(() -> executeInContext(this, context, function), origin);
+            return new DelayedTask<>(() -> executeInContext(this, context, cfrLoad, function), origin, cfrLoad);
         }
 
         private <T> AsyncChain<T> submit(DelayedTask<T> task)
@@ -403,9 +402,9 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
         }
 
         @Override
-        protected InMemorySafeStore createSafeStore(PreLoadContext context, RangesForEpoch ranges, Map<TxnId, InMemorySafeCommand> commands, Map<RoutableKey, InMemorySafeCommandsForKey> commandsForKeys)
+        protected InMemorySafeStore createSafeStore(PreLoadContext context, CommandsForRangeLoad cfrLoad, Map<TxnId, InMemorySafeCommand> commands, Map<RoutableKey, InMemorySafeCommandsForKey> commandsForKeys)
         {
-            return new DelayedSafeStore(this, ranges, context, commands, commandsForKeys, cacheLoading);
+            return new DelayedSafeStore(this, context, cfrLoad, commands, commandsForKeys, cacheLoading);
         }
     }
 
@@ -416,13 +415,13 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
         private final CacheLoading cacheLoading;
 
         public DelayedSafeStore(DelayedCommandStore commandStore,
-                                RangesForEpoch ranges,
                                 PreLoadContext context,
+                                CommandsForRangeLoad cfrLoad,
                                 Map<TxnId, InMemorySafeCommand> commands,
                                 Map<RoutableKey, InMemorySafeCommandsForKey> commandsForKey,
                                 CacheLoading cacheLoading)
         {
-            super(commandStore, ranges, context, commands, commandsForKey);
+            super(commandStore, context, cfrLoad, commands, commandsForKey);
             this.commandStore = commandStore;
             this.cacheLoading = cacheLoading;
             ++counter;

--- a/accord-core/src/test/java/accord/impl/basic/TaskExecutorService.java
+++ b/accord-core/src/test/java/accord/impl/basic/TaskExecutorService.java
@@ -28,23 +28,38 @@ import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import javax.annotation.Nullable;
+
 import accord.api.AsyncExecutor;
 import accord.utils.async.AsyncResults;
+import accord.utils.async.Cancellable;
 
 public abstract class TaskExecutorService extends AbstractExecutorService implements AsyncExecutor
 {
     static abstract class Task<T> extends AsyncResults.RunnableResult<T> implements Pending, RunnableFuture<T>
     {
         final Pending origin;
+        final @Nullable Cancellable ifCancelled;
+
         public Task(Callable<T> fn)
         {
-            this(fn, Pending.Global.activeOrigin());
+            this(fn, (Cancellable) null);
+        }
+        public Task(Callable<T> fn, @Nullable Cancellable ifCancelled)
+        {
+            this(fn, Pending.Global.activeOrigin(), ifCancelled);
         }
 
         public Task(Callable<T> fn, Pending origin)
         {
+            this(fn, origin, null);
+        }
+
+        public Task(Callable<T> fn, Pending origin, @Nullable Cancellable ifCancelled)
+        {
             super(fn);
             this.origin = origin == null ? this : origin;
+            this.ifCancelled = ifCancelled;
         }
 
         public Pending origin()

--- a/accord-core/src/test/java/accord/local/ImmutableCommandTest.java
+++ b/accord-core/src/test/java/accord/local/ImmutableCommandTest.java
@@ -134,7 +134,7 @@ public class ImmutableCommandTest
         }
 
         commands.execute(() -> {
-            SafeCommandStore safeStore = commands.beginOperation(PreLoadContext.contextFor(txnId, "Test"));
+            SafeCommandStore safeStore = commands.beginOperation(PreLoadContext.contextFor(txnId, "Test"), null);
             try
             {
                 StoreParticipants participants = StoreParticipants.update(safeStore, ROUTE, txnId.epoch(), txnId, txnId.epoch());

--- a/accord-core/src/test/java/accord/local/cfk/CommandsForKeyTest.java
+++ b/accord-core/src/test/java/accord/local/cfk/CommandsForKeyTest.java
@@ -848,7 +848,7 @@ public class CommandsForKeyTest
         }
 
         @Override
-        public boolean visit(Unseekables<?> keysOrRanges, TxnId testTxnId, Txn.Kind.Kinds testKind, TestStartedAt testStartedAt, Timestamp testStartAtTimestamp, ComputeIsDep computeIsDep, AllCommandVisitor visit)
+        public boolean visit(Unseekables<?> keysOrRanges, TxnId testTxnId, Txn.Kind.Kinds testKind, SupersedingCommandVisitor visit)
         {
             return false;
         }

--- a/accord-core/src/test/java/accord/local/durability/DurabilityQueueTest.java
+++ b/accord-core/src/test/java/accord/local/durability/DurabilityQueueTest.java
@@ -324,7 +324,7 @@ public class DurabilityQueueTest
         private ReducingRangeMap<DurabilityLevel> result(SortedArrayList<Node.Id> including, Topology topology, MinimalSyncPoint syncPoint)
         {
             SyncLocal syncLocal = including.contains(self) ? Self : NoLocal;
-            ReducingRangeMap.Builder<DurabilityLevel> builder = new ReducingRangeMap.Builder<>(syncPoint.route.get(0).endInclusive(), topology.size());
+            ReducingRangeMap.Builder<DurabilityLevel> builder = new ReducingRangeMap.Builder<>(topology.size());
             for (Shard shard : topology.shards())
             {
                 SortedArrayList<Node.Id> shardIncluding = shard.nodes.intersecting(including);

--- a/accord-core/src/test/java/accord/utils/AccordGens.java
+++ b/accord-core/src/test/java/accord/utils/AccordGens.java
@@ -637,7 +637,7 @@ public class AccordGens
         return rs -> {
             Ranges ranges = rangesGen.next(rs);
             if (ranges.isEmpty()) return RedundantBefore.EMPTY;
-            RedundantBefore.Builder builder = new RedundantBefore.Builder(ranges.get(0).endInclusive(), ranges.size());
+            RedundantBefore.Builder builder = new RedundantBefore.Builder(ranges.size());
             ranges.forEach(r -> builder.append(r.start(), r.end(), entryGen.apply(rs, r)));
             return builder.build();
         };

--- a/accord-core/src/test/java/accord/utils/BTreeReducingRangeMapTest.java
+++ b/accord-core/src/test/java/accord/utils/BTreeReducingRangeMapTest.java
@@ -120,7 +120,7 @@ public class BTreeReducingRangeMapTest
         for (int i = 1 ; i < length ; ++i)
             builder.append(points[i - 1].left, points[i].right);
         builder.append(points[length - 1].left);
-        return builder.build(BTreeReducingRangeMap::new);
+        return builder.build((inclusiveEnds, tree) -> new BTreeReducingRangeMap<Timestamp>(tree));
     }
 
     static
@@ -314,9 +314,9 @@ public class BTreeReducingRangeMapTest
 
         static class IntervalBuilder extends BTreeReducingIntervalMap.AbstractIntervalBuilder<RoutingKey, Timestamp, BTreeReducingRangeMap<Timestamp>>
         {
-            protected IntervalBuilder(boolean inclusiveEnds, int capacity)
+            protected IntervalBuilder(int capacity)
             {
-                super(inclusiveEnds, capacity);
+                super(capacity);
             }
 
             @Override
@@ -340,7 +340,7 @@ public class BTreeReducingRangeMapTest
             @Override
             protected BTreeReducingRangeMap<Timestamp> buildInternal(Object[] tree)
             {
-                return new BTreeReducingRangeMap<>(inclusiveEnds, tree);
+                return new BTreeReducingRangeMap<>(tree);
             }
         }
 

--- a/accord-core/src/test/java/accord/utils/ReducingRangeMapTest.java
+++ b/accord-core/src/test/java/accord/utils/ReducingRangeMapTest.java
@@ -126,7 +126,7 @@ public class ReducingRangeMapTest
             timestamps[i - 1] = points[i].right;
         }
         routingKeys[length - 1] = points[length - 1].left;
-        return new ReducingRangeMap<>(true, routingKeys, timestamps);
+        return new ReducingRangeMap<>(routingKeys, timestamps);
     }
 
     static
@@ -319,9 +319,9 @@ public class ReducingRangeMapTest
 
         static class IntervalBuilder extends ReducingIntervalMap.AbstractIntervalBuilder<RoutingKey, Timestamp, ReducingRangeMap<Timestamp>>
         {
-            protected IntervalBuilder(boolean inclusiveEnds, int capacity)
+            protected IntervalBuilder(int capacity)
             {
-                super(inclusiveEnds, capacity);
+                super(capacity);
             }
 
             @Override
@@ -345,7 +345,7 @@ public class ReducingRangeMapTest
             @Override
             protected ReducingRangeMap<Timestamp> buildInternal()
             {
-                return new ReducingRangeMap<>(inclusiveEnds, starts.toArray(new RoutingKey[0]), values.toArray(new Timestamp[0]));
+                return new ReducingRangeMap<>(starts.toArray(new RoutingKey[0]), values.toArray(new Timestamp[0]));
             }
         }
 


### PR DESCRIPTION
InMemoryRangeIndex: Cassandra's secondary range index integration appears to be faulty in some way, producing sync points that have missing dependencies. Introduce a burn-test integrated in-memory implementation we can be more efficiently confident in.
Also:
     - SemiSyncValue
     - Simulate CFR loading/listening
     - KeyDeps.forEach
     - Timestamp.tryParse
Fix:
     - Minor burn test edge case when cancelling bootstrap and resuming
     - NotifyWaitingOn stillExecutes->stillWaitsOn
     - Privileged fast path commit failure should not send stable message
     - DefaultLocalListeners iterators do not handle multiple waiters on the same transaction correctly
Improve:
     - Don't compute Deps for SyncPoint Accept or Recover phase
     - Catchup should report bounds to progress log