### PR TITLE
CASSANDRA-21183 Safely regain ranges that were previously owned by a node

### DIFF
--- a/accord-core/src/main/java/accord/local/CommandStore.java
+++ b/accord-core/src/main/java/accord/local/CommandStore.java
@@ -187,7 +187,7 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
      * But they may still be ordered for other key ranges they participate in.
      */
     private NavigableMap<Timestamp, Ranges> safeToRead = emptySafeToRead();
-    private Ranges retiredRanges =  Ranges.EMPTY;
+    private Ranges regainedRanges =  Ranges.EMPTY;
     private final Set<Bootstrap> bootstraps = Collections.synchronizedSet(new DeterministicIdentitySet<>());
     @Nullable private RejectBefore rejectBefore;
 
@@ -406,8 +406,8 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
         {
             for (Map.Entry<Timestamp, Ranges> entry : newSafeToRead.entrySet())
             {
-                Ranges rangeExcluded = entry.getValue().without(this.retiredRanges);
-                logger.info("{} is excluded from newSafeToRead because it is in the retired range", rangeExcluded);
+                Ranges rangeExcluded = entry.getValue().without(this.regainedRanges);
+                logger.info("{} is excluded from newSafeToRead because it is in the regained ranges", rangeExcluded);
             }
         }
 
@@ -415,9 +415,9 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
         this.safeToRead = newSafeToRead;
     }
 
-    final void unsafeAddToRetiredRanges(Ranges newRetiredRange)
+    final void unsafeAddToRegainedRanges(Ranges newRegainedRanges)
     {
-        this.retiredRanges = newRetiredRange.union(MERGE_ADJACENT, this.retiredRanges);
+        this.regainedRanges = newRegainedRanges.union(MERGE_ADJACENT, this.regainedRanges);
     }
 
     protected final void unsafeClearSafeToRead()
@@ -1196,10 +1196,10 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
         }
     }
 
-    final void markAsRetired(Ranges ranges)
+    final void markAsRegained(Ranges ranges)
     {
-        execute((Empty) () -> "Mark Range As Retired", safeStore -> {
-            safeStore.addToRetiredRanges(ranges);
+        execute((Empty) () -> "Mark Range As Regained", safeStore -> {
+            safeStore.addToRegainedRanges(ranges);
         }, agent);
     }
 

--- a/accord-core/src/main/java/accord/local/CommandStore.java
+++ b/accord-core/src/main/java/accord/local/CommandStore.java
@@ -402,10 +402,13 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
      */
     final void unsafeSetSafeToRead(NavigableMap<Timestamp, Ranges> newSafeToRead)
     {
-        for (Map.Entry<Timestamp, Ranges> entry : newSafeToRead.entrySet())
+        if (newSafeToRead != null)
         {
-            Ranges rangeExcluded = entry.getValue().without(this.retiredRanges);
-            logger.info("{} is excluded from newSafeToRead because it is in the retired range", rangeExcluded);
+            for (Map.Entry<Timestamp, Ranges> entry : newSafeToRead.entrySet())
+            {
+                Ranges rangeExcluded = entry.getValue().without(this.retiredRanges);
+                logger.info("{} is excluded from newSafeToRead because it is in the retired range", rangeExcluded);
+            }
         }
 
         node.updateStamp();

--- a/accord-core/src/main/java/accord/local/CommandStore.java
+++ b/accord-core/src/main/java/accord/local/CommandStore.java
@@ -187,6 +187,7 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
      * But they may still be ordered for other key ranges they participate in.
      */
     private NavigableMap<Timestamp, Ranges> safeToRead = emptySafeToRead();
+    private Ranges retiredRanges =  Ranges.EMPTY;
     private final Set<Bootstrap> bootstraps = Collections.synchronizedSet(new DeterministicIdentitySet<>());
     @Nullable private RejectBefore rejectBefore;
 
@@ -401,8 +402,19 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
      */
     final void unsafeSetSafeToRead(NavigableMap<Timestamp, Ranges> newSafeToRead)
     {
+        for (Map.Entry<Timestamp, Ranges> entry : newSafeToRead.entrySet())
+        {
+            Ranges rangeExcluded = entry.getValue().without(this.retiredRanges);
+            logger.info("{} is excluded from newSafeToRead because it is in the retired range", rangeExcluded);
+        }
+
         node.updateStamp();
         this.safeToRead = newSafeToRead;
+    }
+
+    final void unsafeAddToRetiredRanges(Ranges newRetiredRange)
+    {
+        this.retiredRanges = newRetiredRange.union(MERGE_ADJACENT, this.retiredRanges);
     }
 
     protected final void unsafeClearSafeToRead()
@@ -1179,6 +1191,13 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
                 safeStore.setSafeToRead(purgeHistory(safeToRead, ranges));
             }, agent);
         }
+    }
+
+    final void markAsRetired(Ranges ranges)
+    {
+        execute((Empty) () -> "Mark Range As Retired", safeStore -> {
+            safeStore.addToRetiredRanges(ranges);
+        }, agent);
     }
 
     public final DataStore unsafeGetDataStore()

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -634,7 +634,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
             for (int i = 0; i < shards.length; i++)
             {
-                for (int j = i+1; j < shards.length; j++)
+                for (int j = i; j < shards.length; j++)
                 {
                     if (!shards[i].ranges().all().slice(shards[j].ranges().all(), Minimal).isEmpty())
                     {

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -629,16 +629,17 @@ public abstract class CommandStores implements AsyncExecutorFactory
             lookupByRange = SearchableRangeList.build(ranges);
 
             overlappingCommandStores = new HashMap<>();
-            for (ShardHolder shard : shards)
+            for (int i = 0; i < shards.length; i++)
+                overlappingCommandStores.put(i, new LargeBitSet(shards.length));
+
+            for (int i = 0; i < shards.length; i++)
             {
-                overlappingCommandStores.put(shard.store.id, new LargeBitSet(shards.length));
-                for (Map.Entry<Integer, LargeBitSet> entry : overlappingCommandStores.entrySet())
+                for (int j = i+1; j < shards.length; j++)
                 {
-                    Integer id = entry.getKey();
-                    if (!shard.ranges().all().overlapping(shards[byId.get(id)].ranges.all()).isEmpty())
+                    if (!shards[i].ranges().all().overlapping(shards[j].ranges().all()).isEmpty())
                     {
-                        overlappingCommandStores.get(shard.store.id).set(id);
-                        entry.getValue().set(shard.store.id);
+                        overlappingCommandStores.get(i).set(j);
+                        overlappingCommandStores.get(j).set(i);
                     }
                 }
             }
@@ -973,7 +974,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (bitSet.get(i))
                 {
-                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).unsafeGetRangesForEpoch().all());
+                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.shards[i].ranges().all());
 
                     if (!range.overlapping(touchedKeys).isEmpty())
                         throw illegalState("We should not query the same range from two different command stores.");

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -965,6 +965,13 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
 
+        Invariants.require(checkQueryDisjointRangesAcrossCommandStores(snapshot, bitSet, mapReduceConsume.keys().toRanges()));
+
+        return chain == null ? AsyncChains.success(null) : chain;
+    }
+
+    public boolean checkQueryDisjointRangesAcrossCommandStores(Snapshot snapshot, LargeBitSet commandStoresSeen, Ranges queryRange)
+    {
         // Check that we are not querying two command stores for the same range
         for (Map.Entry<Integer, LargeBitSet> entry : snapshot.overlappingCommandStores.entrySet())
         {
@@ -972,19 +979,19 @@ public abstract class CommandStores implements AsyncExecutorFactory
             LargeBitSet overlappingCommandStores = entry.getValue();
             for (int i = overlappingCommandStores.firstSetBit(); i >= 0 ; i = overlappingCommandStores.nextSetBit(i + 1, -1))
             {
-                if (bitSet.get(i))
+                if (commandStoresSeen.get(i))
                 {
-                    Ranges touchedKeys = mapReduceConsume.keys().toRanges().slice(snapshot.shards[i].ranges().all(), Minimal);
+                    Ranges touchedKeys = queryRange.slice(snapshot.shards[i].ranges().all(), Minimal);
 
                     if (!range.slice(touchedKeys, Minimal).isEmpty())
-                        throw illegalState("We should not query the same range from two different command stores.");
+                        return false;
 
                     range = range.with(touchedKeys.toRanges());
                 }
             }
         }
 
-        return chain == null ? AsyncChains.success(null) : chain;
+        return true;
     }
 
     public <O> O mapReduceUnsafe(StoreSelector selector, Function<CommandStore, O> map, BiFunction<O, O, O> reduce, O accumulator)

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -110,9 +110,9 @@ public abstract class CommandStores implements AsyncExecutorFactory
             @Override
             public StoreSelector refine(TxnId txnId, @Nullable Timestamp executeAt, Participants<?> participants)
             {
-                return snapshot -> StoreFinder.find(snapshot, participants)
+                return snapshot -> new StoreIterator(StoreFinder.find(snapshot, participants)
                                               .filter(snapshot, participants, txnId.epoch(), (executeAt != null ? executeAt : txnId).epoch())
-                                              .iterator(snapshot);
+                                              .iterator(snapshot), txnId.epoch());
             }
         }
 
@@ -125,7 +125,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
     public interface StoreSelector extends LatentStoreSelector
     {
         default StoreSelector refine(TxnId txnId, @Nullable Timestamp executeAt, Participants<?> participants) { return this; }
-        Iterator<CommandStore> select(Snapshot snapshot);
+        StoreIterator select(Snapshot snapshot);
     }
 
     public static class IncludingSpecificStoreSelector implements StoreSelector
@@ -144,14 +144,35 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 StoreFinder finder = StoreFinder.find(snapshot, participants)
                                                 .filter(snapshot, participants, txnId.epoch(), (executeAt != null ? executeAt : txnId).epoch());
                 finder.set(snapshot.byId.get(storeId));
-                return finder.iterator(snapshot);
+                return new StoreIterator(finder.iterator(snapshot), txnId.epoch());
             };
         }
 
         @Override
-        public Iterator<CommandStore> select(Snapshot snapshot)
+        public StoreIterator select(Snapshot snapshot)
         {
-            return Collections.singletonList(snapshot.byId(storeId)).iterator();
+            return new StoreIterator(Collections.singletonList(snapshot.byId(storeId)).iterator(), null);
+        }
+    }
+
+    public static class StoreIterator
+    {
+        public final Iterator<CommandStore> StoreIterator;
+        public final Long minEpoch;
+
+        public StoreIterator(Iterator<CommandStore> StoreIterator, @Nullable Long minEpoch)
+        {
+            this.StoreIterator = StoreIterator;
+            this.minEpoch = minEpoch;
+        }
+
+        public Iterator<CommandStore> getStoreIterator()
+        {
+            return StoreIterator;
+        }
+
+        public Long getMinEpoch() {
+            return minEpoch;
         }
     }
 
@@ -176,7 +197,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             return snapshot -> {
                 StoreFinder finder = StoreFinder.find(snapshot, unseekables);
                 finder.filter(snapshot, unseekables, minEpoch, maxEpoch);
-                return finder.iterator(snapshot);
+                return new StoreIterator(finder.iterator(snapshot), minEpoch);
             };
         }
 
@@ -878,7 +899,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
     public AsyncChain<Void> forAll(String reason, Consumer<SafeCommandStore> forEach)
     {
-        return mapReduce(snapshot -> Stream.of(snapshot.shards).map(shard -> shard.store).iterator(), new MapReduceCommandStores<>(RoutingKeys.EMPTY)
+        return mapReduce(snapshot -> new StoreIterator(Stream.of(snapshot.shards).map(shard -> shard.store).iterator(), null), new MapReduceCommandStores<>(RoutingKeys.EMPTY)
         {
             @Override public Void reduce(Void o1, Void o2) { return null; }
             @Override public TxnId primaryTxnId() { return null; }
@@ -947,13 +968,14 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
     public <O> AsyncChain<O> mapReduce(IntStream commandStoreIds, MapReduceCommandStores<?, O> mapReduce)
     {
-        return mapReduce(snapshot -> commandStoreIds.mapToObj(snapshot::byId).iterator(), mapReduce);
+        return mapReduce(snapshot -> new StoreIterator(commandStoreIds.mapToObj(snapshot::byId).iterator(), null), mapReduce);
     }
 
     public <O> AsyncChain<O> mapReduce(StoreSelector selector, MapReduceCommandStores<?, O> mapReduceConsume)
     {
         Snapshot snapshot = current;
-        Iterator<CommandStore> stores = selector.select(snapshot);
+        StoreIterator StoreIterator = selector.select(snapshot);
+        Iterator<CommandStore> stores = StoreIterator.getStoreIterator();
         AsyncChain<O> chain = null;
         LargeBitSet bitSet = new LargeBitSet(snapshot.shards.length);
         while (stores.hasNext())
@@ -965,12 +987,13 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
 
-        Invariants.require(checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges()));
+        if (checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
+            throw new IllegalStateException();
 
         return chain == null ? AsyncChains.success(null) : chain;
     }
 
-    public static boolean checkQueryDisjointRangesAcrossCommandStores(Map<Integer, LargeBitSet> overlappingCommandStores, ShardHolder[] shards, LargeBitSet commandStoresSeen, Ranges queryRange)
+    public static boolean checkQueryDisjointRangesAcrossCommandStores(Map<Integer, LargeBitSet> overlappingCommandStores, ShardHolder[] shards, LargeBitSet commandStoresSeen, Ranges queryRange, Long minEpoch)
     {
         // Check that we are not querying two command stores for the same range
         for (Map.Entry<Integer, LargeBitSet> entry : overlappingCommandStores.entrySet())
@@ -981,7 +1004,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (commandStoresSeen.get(i))
                 {
-                    Ranges touchedKeys = queryRange.slice(shards[i].ranges().all(), Minimal);
+                    Ranges touchedKeys = queryRange.slice(shards[i].ranges().allSince(minEpoch), Minimal);
 
                     if (!range.slice(touchedKeys, Minimal).isEmpty())
                         return false;
@@ -997,7 +1020,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
     public <O> O mapReduceUnsafe(StoreSelector selector, Function<CommandStore, O> map, BiFunction<O, O, O> reduce, O accumulator)
     {
         Snapshot snapshot = current;
-        Iterator<CommandStore> stores = selector.select(snapshot);
+        Iterator<CommandStore> stores = selector.select(snapshot).getStoreIterator();
         while (stores.hasNext())
         {
             O next = map.apply(stores.next());

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -967,23 +967,19 @@ public abstract class CommandStores implements AsyncExecutorFactory
         // Check that we are not querying two command stores for the same range
         for (Map.Entry<Integer, LargeBitSet> entry : snapshot.overlappingCommandStores.entrySet())
         {
-            List<Integer> overlapping = new ArrayList<>();
+            Ranges range = Ranges.EMPTY;
             LargeBitSet overlappingCommandStores = entry.getValue();
             for (int i = overlappingCommandStores.firstSetBit(); i >= 0 ; i = overlappingCommandStores.nextSetBit(i + 1, -1))
             {
                 if (bitSet.get(i))
-                    overlapping.add(i);
-            }
-
-            Ranges range = Ranges.EMPTY;
-            for (Integer id : overlapping)
-            {
-                Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(id).rangesForEpoch.all());
-                if (!range.overlapping(touchedKeys).isEmpty())
                 {
-                    throw illegalState("We should not query the same range from two different command stores.");
+                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all());
+
+                    if (!range.overlapping(touchedKeys).isEmpty())
+                        throw illegalState("We should not query the same range from two different command stores.");
+
+                    range = range.with(mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all()).toRanges());
                 }
-                range = range.with(mapReduceConsume.keys().overlapping(snapshot.byId(id).rangesForEpoch.all()).toRanges());
             }
         }
 

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -629,8 +629,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
             lookupByRange = SearchableRangeList.build(ranges);
 
             overlappingCommandStores = new HashMap<>();
-            for (ShardHolder shard : shards)
-                overlappingCommandStores.put(shard.store.id(), new LargeBitSet(shards.length));
+            for (int i = 0; i < shards.length ; i++)
+                overlappingCommandStores.put(i, new LargeBitSet(shards.length));
 
             for (int i = 0; i < shards.length; i++)
             {
@@ -638,8 +638,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 {
                     if (!shards[i].ranges().all().slice(shards[j].ranges().all(), Minimal).isEmpty())
                     {
-                        overlappingCommandStores.get(shards[i].store.id()).set(shards[j].store.id());
-                        overlappingCommandStores.get(shards[j].store.id()).set(shards[i].store.id());
+                        overlappingCommandStores.get(i).set(j);
+                        overlappingCommandStores.get(j).set(i);
                     }
                 }
             }
@@ -959,7 +959,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         while (stores.hasNext())
         {
             CommandStore store = stores.next();
-            bitSet.set(store.id());
+            bitSet.set(snapshot.byId.get(store.id()));
             AsyncChain<O> next = mapReduceConsume.applyAsync(store);
             if (next != null)
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
@@ -974,7 +974,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (bitSet.get(i))
                 {
-                    Ranges touchedKeys = mapReduceConsume.keys().toRanges().slice(snapshot.byId(i).rangesForEpoch.all(), Minimal);
+                    Ranges touchedKeys = mapReduceConsume.keys().toRanges().slice(snapshot.shards[i].ranges().all(), Minimal);
 
                     if (!range.slice(touchedKeys, Minimal).isEmpty())
                         throw illegalState("We should not query the same range from two different command stores.");

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -18,7 +18,15 @@
 
 package accord.local;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.HashMap;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -30,7 +38,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import accord.primitives.*;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
@@ -46,6 +53,16 @@ import accord.api.LocalListeners;
 import accord.api.ProgressLog;
 import accord.api.RoutingKey;
 import accord.local.CommandStore.EpochUpdateHolder;
+import accord.primitives.AbstractRanges;
+import accord.primitives.AbstractUnseekableKeys;
+import accord.primitives.EpochSupplier;
+import accord.primitives.Participants;
+import accord.primitives.Range;
+import accord.primitives.Ranges;
+import accord.primitives.RoutingKeys;
+import accord.primitives.Timestamp;
+import accord.primitives.TxnId;
+import accord.primitives.Unseekables;
 import accord.topology.Shard;
 import accord.topology.Topology;
 import accord.utils.IndexedQuadConsumer;
@@ -932,7 +949,6 @@ public abstract class CommandStores implements AsyncExecutorFactory
         return mapReduce(snapshot -> commandStoreIds.mapToObj(snapshot::byId).iterator(), mapReduce);
     }
 
-    /* Do all reads and writes go through this? */
     public <O> AsyncChain<O> mapReduce(StoreSelector selector, MapReduceCommandStores<?, O> mapReduceConsume)
     {
         Snapshot snapshot = current;

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import accord.topology.TopologyException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
@@ -988,10 +989,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         }
 
         if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
-        {
-            logger.info("Reject query as it tries to query {} in more than one CommandStore", mapReduceConsume.keys().toRanges().toString());
-            return AsyncChains.failure(null);
-        }
+            return AsyncChains.failure(new RuntimeException("Tried to query more than one CommandStore for the same range"));
 
         return chain == null ? AsyncChains.success(null) : chain;
     }

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -163,7 +163,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         public StoreIterator(Iterator<CommandStore> StoreIterator, @Nullable Long minEpoch)
         {
             this.StoreIterator = StoreIterator;
-            this.minEpoch = minEpoch;
+            this.minEpoch = (minEpoch == null) ? 0L : minEpoch;
         }
 
         public Iterator<CommandStore> getStoreIterator()

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -636,7 +636,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 for (int j = i+1; j < shards.length; j++)
                 {
-                    if (!shards[i].ranges().all().overlapping(shards[j].ranges().all()).isEmpty())
+                    if (!shards[i].ranges().all().slice(shards[j].ranges().all(), Minimal).isEmpty())
                     {
                         overlappingCommandStores.get(shards[i].store.id()).set(shards[j].store.id());
                         overlappingCommandStores.get(shards[j].store.id()).set(shards[i].store.id());
@@ -778,7 +778,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 bootstrapUpdates.add(shard.store.unbootstrap(epoch, removeRanges));
             }
 
-            Ranges regainedRanges = shard.ranges().all().overlapping(added);
+            Ranges regainedRanges = shard.ranges().all().slice(added, Minimal);
             if (!regainedRanges.isEmpty())
             {
                 shard.store.markUnsafeToRead(regainedRanges);
@@ -974,9 +974,9 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (bitSet.get(i))
                 {
-                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all());
+                    Ranges touchedKeys = mapReduceConsume.keys().toRanges().slice(snapshot.byId(i).rangesForEpoch.all(), Minimal);
 
-                    if (!range.overlapping(touchedKeys).isEmpty())
+                    if (!range.slice(touchedKeys, Minimal).isEmpty())
                         throw illegalState("We should not query the same range from two different command stores.");
 
                     range = range.with(touchedKeys.toRanges());

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -158,18 +158,18 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
     public static class StoreIterator
     {
-        public final Iterator<CommandStore> StoreIterator;
+        public final Iterator<CommandStore> storeIterator;
         public final Long minEpoch;
 
-        public StoreIterator(Iterator<CommandStore> StoreIterator, @Nullable Long minEpoch)
+        public StoreIterator(Iterator<CommandStore> storeIterator, @Nullable Long minEpoch)
         {
-            this.StoreIterator = StoreIterator;
+            this.storeIterator = storeIterator;
             this.minEpoch = (minEpoch == null) ? 0L : minEpoch;
         }
 
         public Iterator<CommandStore> getStoreIterator()
         {
-            return StoreIterator;
+            return storeIterator;
         }
 
         public Long getMinEpoch() {
@@ -975,8 +975,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
     public <O> AsyncChain<O> mapReduce(StoreSelector selector, MapReduceCommandStores<?, O> mapReduceConsume)
     {
         Snapshot snapshot = current;
-        StoreIterator StoreIterator = selector.select(snapshot);
-        Iterator<CommandStore> stores = StoreIterator.getStoreIterator();
+        StoreIterator storeIterator = selector.select(snapshot);
+        Iterator<CommandStore> stores = storeIterator.getStoreIterator();
         AsyncChain<O> chain = null;
         LargeBitSet bitSet = new LargeBitSet(snapshot.shards.length);
         while (stores.hasNext())
@@ -988,7 +988,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
 
-        if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
+        if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), storeIterator.getMinEpoch()))
             return AsyncChains.failure(new RuntimeException("Tried to query more than one CommandStore for the same range"));
 
         return chain == null ? AsyncChains.success(null) : chain;

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -629,8 +629,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
             lookupByRange = SearchableRangeList.build(ranges);
 
             overlappingCommandStores = new HashMap<>();
-            for (int i = 0; i < shards.length; i++)
-                overlappingCommandStores.put(i, new LargeBitSet(shards.length));
+            for (ShardHolder shard : shards)
+                overlappingCommandStores.put(shard.store.id(), new LargeBitSet(shards.length));
 
             for (int i = 0; i < shards.length; i++)
             {
@@ -638,8 +638,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 {
                     if (!shards[i].ranges().all().overlapping(shards[j].ranges().all()).isEmpty())
                     {
-                        overlappingCommandStores.get(i).set(j);
-                        overlappingCommandStores.get(j).set(i);
+                        overlappingCommandStores.get(shards[i].store.id()).set(shards[j].store.id());
+                        overlappingCommandStores.get(shards[j].store.id()).set(shards[i].store.id());
                     }
                 }
             }
@@ -974,7 +974,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (bitSet.get(i))
                 {
-                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.shards[i].ranges().all());
+                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all());
 
                     if (!range.overlapping(touchedKeys).isEmpty())
                         throw illegalState("We should not query the same range from two different command stores.");

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -987,7 +987,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
 
-        if (checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
+        if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
             throw new IllegalStateException();
 
         return chain == null ? AsyncChains.success(null) : chain;

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -965,23 +965,23 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
 
-        Invariants.require(checkQueryDisjointRangesAcrossCommandStores(snapshot, bitSet, mapReduceConsume.keys().toRanges()));
+        Invariants.require(checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges()));
 
         return chain == null ? AsyncChains.success(null) : chain;
     }
 
-    public boolean checkQueryDisjointRangesAcrossCommandStores(Snapshot snapshot, LargeBitSet commandStoresSeen, Ranges queryRange)
+    public static boolean checkQueryDisjointRangesAcrossCommandStores(Map<Integer, LargeBitSet> overlappingCommandStores, ShardHolder[] shards, LargeBitSet commandStoresSeen, Ranges queryRange)
     {
         // Check that we are not querying two command stores for the same range
-        for (Map.Entry<Integer, LargeBitSet> entry : snapshot.overlappingCommandStores.entrySet())
+        for (Map.Entry<Integer, LargeBitSet> entry : overlappingCommandStores.entrySet())
         {
             Ranges range = Ranges.EMPTY;
-            LargeBitSet overlappingCommandStores = entry.getValue();
-            for (int i = overlappingCommandStores.firstSetBit(); i >= 0 ; i = overlappingCommandStores.nextSetBit(i + 1, -1))
+            LargeBitSet overlappingCommandStore = entry.getValue();
+            for (int i = overlappingCommandStore.firstSetBit(); i >= 0 ; i = overlappingCommandStore.nextSetBit(i + 1, -1))
             {
                 if (commandStoresSeen.get(i))
                 {
-                    Ranges touchedKeys = queryRange.slice(snapshot.shards[i].ranges().all(), Minimal);
+                    Ranges touchedKeys = queryRange.slice(shards[i].ranges().all(), Minimal);
 
                     if (!range.slice(touchedKeys, Minimal).isEmpty())
                         return false;

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -973,12 +973,12 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (bitSet.get(i))
                 {
-                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all());
+                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).unsafeGetRangesForEpoch().all());
 
                     if (!range.overlapping(touchedKeys).isEmpty())
                         throw illegalState("We should not query the same range from two different command stores.");
 
-                    range = range.with(mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all()).toRanges());
+                    range = range.with(touchedKeys.toRanges());
                 }
             }
         }

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -803,7 +803,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             if (!regainedRanges.isEmpty())
             {
                 shard.store.markUnsafeToRead(regainedRanges);
-                shard.store.markAsRetired(regainedRanges);
+                shard.store.markAsRegained(regainedRanges);
             }
 
             // TODO (desired): only sync affected shards

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -988,7 +988,10 @@ public abstract class CommandStores implements AsyncExecutorFactory
         }
 
         if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
-            throw new IllegalStateException();
+        {
+            logger.info("Reject query as it tries to query {} in more than one CommandStore", mapReduceConsume.keys().toRanges().toString());
+            return AsyncChains.failure(null);
+        }
 
         return chain == null ? AsyncChains.success(null) : chain;
     }

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -18,14 +18,7 @@
 
 package accord.local;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -37,6 +30,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import accord.primitives.*;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
@@ -52,16 +46,6 @@ import accord.api.LocalListeners;
 import accord.api.ProgressLog;
 import accord.api.RoutingKey;
 import accord.local.CommandStore.EpochUpdateHolder;
-import accord.primitives.AbstractRanges;
-import accord.primitives.AbstractUnseekableKeys;
-import accord.primitives.EpochSupplier;
-import accord.primitives.Participants;
-import accord.primitives.Range;
-import accord.primitives.Ranges;
-import accord.primitives.RoutingKeys;
-import accord.primitives.Timestamp;
-import accord.primitives.TxnId;
-import accord.primitives.Unseekables;
 import accord.topology.Shard;
 import accord.topology.Topology;
 import accord.utils.IndexedQuadConsumer;
@@ -577,6 +561,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         final Int2IntHashMap byId;
         private final int[] indexForRange;
         final SearchableRangeList lookupByRange;
+        final Map<Integer, LargeBitSet> overlappingCommandStores;
 
         public Snapshot(ShardHolder[] shards, Topology local, Topology global)
         {
@@ -625,6 +610,21 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 indexForRange[i] = rangesAndIndexes[i].index;
             }
             lookupByRange = SearchableRangeList.build(ranges);
+
+            overlappingCommandStores = new HashMap<>();
+            for (ShardHolder shard : shards)
+            {
+                overlappingCommandStores.put(shard.store.id, new LargeBitSet(shards.length));
+                for (Map.Entry<Integer, LargeBitSet> entry : overlappingCommandStores.entrySet())
+                {
+                    Integer id = entry.getKey();
+                    if (!shard.ranges().all().overlapping(shards[byId.get(id)].ranges.all()).isEmpty())
+                    {
+                        overlappingCommandStores.get(shard.store.id).set(id);
+                        entry.getValue().set(shard.store.id);
+                    }
+                }
+            }
         }
 
         // This method exists to ensure we do not hold references to command stores
@@ -759,6 +759,14 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 shard.store.epochUpdateHolder.remove(epoch, shard.ranges, removeRanges);
                 bootstrapUpdates.add(shard.store.unbootstrap(epoch, removeRanges));
             }
+
+            Ranges regainedRanges = shard.ranges().all().overlapping(added);
+            if (!regainedRanges.isEmpty())
+            {
+                shard.store.markUnsafeToRead(regainedRanges);
+                shard.store.markAsRetired(regainedRanges);
+            }
+
             // TODO (desired): only sync affected shards
             Ranges ranges = shard.ranges().currentRanges();
             // ranges can be empty when ranges are lost or consolidated across epochs.
@@ -924,17 +932,45 @@ public abstract class CommandStores implements AsyncExecutorFactory
         return mapReduce(snapshot -> commandStoreIds.mapToObj(snapshot::byId).iterator(), mapReduce);
     }
 
+    /* Do all reads and writes go through this? */
     public <O> AsyncChain<O> mapReduce(StoreSelector selector, MapReduceCommandStores<?, O> mapReduceConsume)
     {
         Snapshot snapshot = current;
         Iterator<CommandStore> stores = selector.select(snapshot);
         AsyncChain<O> chain = null;
+        LargeBitSet bitSet = new LargeBitSet(snapshot.shards.length);
         while (stores.hasNext())
         {
-            AsyncChain<O> next = mapReduceConsume.applyAsync(stores.next());
+            CommandStore store = stores.next();
+            bitSet.set(store.id());
+            AsyncChain<O> next = mapReduceConsume.applyAsync(store);
             if (next != null)
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
+
+        // Check that we are not querying two command stores for the same range
+        for (Map.Entry<Integer, LargeBitSet> entry : snapshot.overlappingCommandStores.entrySet())
+        {
+            List<Integer> overlapping = new ArrayList<>();
+            LargeBitSet overlappingCommandStores = entry.getValue();
+            for (int i = overlappingCommandStores.firstSetBit(); i >= 0 ; i = overlappingCommandStores.nextSetBit(i + 1, -1))
+            {
+                if (bitSet.get(i))
+                    overlapping.add(i);
+            }
+
+            Ranges range = Ranges.EMPTY;
+            for (Integer id : overlapping)
+            {
+                Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(id).rangesForEpoch.all());
+                if (!range.overlapping(touchedKeys).isEmpty())
+                {
+                    throw illegalState("We should not query the same range from two different command stores.");
+                }
+                range = range.with(mapReduceConsume.keys().overlapping(snapshot.byId(id).rangesForEpoch.all()).toRanges());
+            }
+        }
+
         return chain == null ? AsyncChains.success(null) : chain;
     }
 

--- a/accord-core/src/main/java/accord/local/Node.java
+++ b/accord-core/src/main/java/accord/local/Node.java
@@ -765,7 +765,7 @@ public class Node implements NodeCommandStoreService
     public AsyncChain<Void> updateMinHlc(long minHlc)
     {
         // TODO (required): command stores that are not ready due to bootstrap need to refresh their min HLC on bootstrap completion
-        StoreSelector selector = snapshot -> Stream.of(snapshot.shards).map(sh -> sh.store).iterator();
+        StoreSelector selector = snapshot -> new CommandStores.StoreIterator(Stream.of(snapshot.shards).map(sh -> sh.store).iterator(), null);
         return commandStores().mapReduce(selector, new MapReduceCommandStores<>(RoutingKeys.EMPTY)
         {
             @Override public Void reduce(Void o1, Void o2) { return null; }

--- a/accord-core/src/main/java/accord/local/SafeCommandStore.java
+++ b/accord-core/src/main/java/accord/local/SafeCommandStore.java
@@ -384,6 +384,11 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
         commandStore().unsafeSetSafeToRead(newSafeToRead);
     }
 
+    public void addToRetiredRanges(Ranges newRetiredRange)
+    {
+        commandStore().unsafeAddToRetiredRanges(newRetiredRange);
+    }
+
     public void setRangesForEpoch(CommandStores.RangesForEpoch rangesForEpoch)
     {
         commandStore().unsafeSetRangesForEpoch(rangesForEpoch);

--- a/accord-core/src/main/java/accord/local/SafeCommandStore.java
+++ b/accord-core/src/main/java/accord/local/SafeCommandStore.java
@@ -384,9 +384,9 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
         commandStore().unsafeSetSafeToRead(newSafeToRead);
     }
 
-    public void addToRetiredRanges(Ranges newRetiredRange)
+    public void addToRegainedRanges(Ranges newRegainedRanges)
     {
-        commandStore().unsafeAddToRetiredRanges(newRetiredRange);
+        commandStore().unsafeAddToRegainedRanges(newRegainedRanges);
     }
 
     public void setRangesForEpoch(CommandStores.RangesForEpoch rangesForEpoch)

--- a/accord-core/src/main/java/accord/topology/Topology.java
+++ b/accord-core/src/main/java/accord/topology/Topology.java
@@ -765,6 +765,23 @@ public class Topology
             forEach.accept(shards[i]);
     }
 
+    public static Map<Id, Ranges> computeNodeAdditions(Topology current, Topology next)
+    {
+        Map<Id, Ranges> additions = new HashMap<>();
+        for (Id node : next.nodes())
+        {
+            Ranges prev = current.rangesForNode(node);
+            if (prev == null) prev = Ranges.EMPTY;
+
+            Ranges added = next.rangesForNode(node).without(prev);
+            if (added.isEmpty())
+                continue;
+
+            additions.put(node, added);
+        }
+        return additions;
+    }
+
     public SortedArrayList<Id> nodes()
     {
         return nodes;

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -357,7 +357,7 @@ public class TopologyManager
         }
 
         if (greatestEpoch != -1)
-            return new regainingEpochRange(greatestEpoch, range);
+            return new RegainingEpochRange(greatestEpoch, range);
 
         return null;
     }

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -197,6 +197,7 @@ public class TopologyManager
             if (epoch > active.currentEpoch)
                 ranges = pending.retired(ranges, epoch);
             ranges = active.retired(ranges, epoch);
+            notify();
         }
         if (!ranges.isEmpty())
         {

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -312,12 +312,12 @@ public class TopologyManager
         updateActive();
     }
 
-    public static class regainingEpochRange
+    public static class RegainingEpochRange
     {
         public final long epoch;
         public final Ranges range;
 
-        public regainingEpochRange(long epoch, Ranges range)
+        public RegainingEpochRange(long epoch, Ranges range)
         {
             this.epoch = epoch;
             this.range = range;
@@ -335,7 +335,7 @@ public class TopologyManager
     }
 
     @Nullable
-    public regainingEpochRange epochAndRangeToBeRetired(Topology curr, Topology next)
+    public RegainingEpochRange epochAndRangeToBeRetired(Topology curr, Topology next)
     {
         Map<Id, Ranges> additions = Topology.computeNodeAdditions(curr, next);
         long greatestEpoch = -1;

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -197,7 +197,6 @@ public class TopologyManager
             if (epoch > active.currentEpoch)
                 ranges = pending.retired(ranges, epoch);
             ranges = active.retired(ranges, epoch);
-            notify();
         }
         if (!ranges.isEmpty())
         {
@@ -286,62 +285,6 @@ public class TopologyManager
     protected Executor executor()
     {
         return Runnable::run;
-    }
-
-    public static Map<Id, Ranges> getAdditions(Topology current, Topology next)
-    {
-        Map<Id, Ranges> additions = new HashMap<>();
-        for (Id node : next.nodes())
-        {
-            Ranges prev = current.rangesForNode(node);
-            if (prev == null) prev = Ranges.EMPTY;
-
-            Ranges added = next.rangesForNode(node).without(prev);
-            if (added.isEmpty())
-                continue;
-
-            additions.put(node, added);
-        }
-        return additions;
-    }
-
-    public List<Long> epochsWeAreRegainingRangesFor(Topology curr, Topology next)
-    {
-        ArrayList<Long> epochs = new ArrayList<>();
-
-        synchronized (this)
-        {
-            Map<Id, Ranges> additions = getAdditions(curr, next);
-            for (Map.Entry<Id, Ranges> entry : additions.entrySet())
-            {
-                for (ActiveEpoch activeEpoch : this.active) {
-                    if (activeEpoch.all().rangesForNode(entry.getKey()).intersects(entry.getValue()))
-                        epochs.add(activeEpoch.epoch());
-                }
-            }
-        }
-
-        return epochs;
-    }
-
-    public void blockUntilAllEpochsRetired(List<Long> epochs)
-    {
-        try
-        {
-            int index = 0;
-            synchronized (this)
-            {
-                while (index != epochs.size())
-                {
-                    for (int i = index; i < epochs.size(); i++)
-                        if (this.active.get(epochs.get(i)).allRetired())
-                            index += 1;
-                    wait();
-                }
-            }
-        } catch (Throwable t) {
-            logger.error("Uncaught exception", t);
-        }
     }
 
     public void reportTopology(Topology topology)

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -18,7 +18,11 @@
 
 package accord.topology;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -18,11 +18,8 @@
 
 package accord.topology;
 
-import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.Map;
-import java.util.HashMap;
-import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -31,6 +28,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
+import accord.primitives.Routables;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +53,8 @@ import accord.utils.async.AsyncChains;
 import accord.utils.async.AsyncResult;
 import accord.utils.async.AsyncResults;
 import accord.utils.async.NestedAsyncResult;
+
+import static accord.primitives.AbstractRanges.UnionMode.MERGE_ADJACENT;
 
 /**
  * Manages topology state changes and update bookkeeping
@@ -310,6 +310,56 @@ public class TopologyManager
             listener.onReceived(topology);
 
         updateActive();
+    }
+
+    public static class regainingEpochRange
+    {
+        public final long epoch;
+        public final Ranges range;
+
+        public regainingEpochRange(long epoch, Ranges range)
+        {
+            this.epoch = epoch;
+            this.range = range;
+        }
+
+        public long epoch()
+        {
+            return epoch;
+        }
+
+        public Ranges range()
+        {
+            return range;
+        }
+    }
+
+    @Nullable
+    public regainingEpochRange epochAndRangeToBeRetired(Topology curr, Topology next)
+    {
+        Map<Id, Ranges> additions = Topology.computeNodeAdditions(curr, next);
+        long greatestEpoch = -1;
+        Ranges range = Ranges.EMPTY;
+
+        synchronized (this)
+        {
+            for (Map.Entry<Id, Ranges> entry : additions.entrySet())
+            {
+                for (ActiveEpoch activeEpoch : this.active) {
+                    if (activeEpoch.all().rangesForNode(entry.getKey()).intersects(entry.getValue()) && greatestEpoch < activeEpoch.epoch())
+                    {
+                        greatestEpoch = activeEpoch.epoch();
+                        range = range.union(MERGE_ADJACENT, activeEpoch.all().rangesForNode(entry.getKey()).slice(entry.getValue(), Routables.Slice.Minimal));
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (greatestEpoch != -1)
+            return new regainingEpochRange(greatestEpoch, range);
+
+        return null;
     }
 
     private final AtomicBoolean updatingActive = new AtomicBoolean();

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -18,7 +18,7 @@
 
 package accord.topology;
 
-import java.util.IdentityHashMap;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -281,6 +281,62 @@ public class TopologyManager
     protected Executor executor()
     {
         return Runnable::run;
+    }
+
+    public static Map<Id, Ranges> getAdditions(Topology current, Topology next)
+    {
+        Map<Id, Ranges> additions = new HashMap<>();
+        for (Id node : next.nodes())
+        {
+            Ranges prev = current.rangesForNode(node);
+            if (prev == null) prev = Ranges.EMPTY;
+
+            Ranges added = next.rangesForNode(node).without(prev);
+            if (added.isEmpty())
+                continue;
+
+            additions.put(node, added);
+        }
+        return additions;
+    }
+
+    public List<Long> epochsWeAreRegainingRangesFor(Topology curr, Topology next)
+    {
+        ArrayList<Long> epochs = new ArrayList<>();
+
+        synchronized (this)
+        {
+            Map<Id, Ranges> additions = getAdditions(curr, next);
+            for (Map.Entry<Id, Ranges> entry : additions.entrySet())
+            {
+                for (ActiveEpoch activeEpoch : this.active) {
+                    if (activeEpoch.all().rangesForNode(entry.getKey()).intersects(entry.getValue()))
+                        epochs.add(activeEpoch.epoch());
+                }
+            }
+        }
+
+        return epochs;
+    }
+
+    public void blockUntilAllEpochsRetired(List<Long> epochs)
+    {
+        try
+        {
+            int index = 0;
+            synchronized (this)
+            {
+                while (index != epochs.size())
+                {
+                    for (int i = index; i < epochs.size(); i++)
+                        if (this.active.get(epochs.get(i)).allRetired())
+                            index += 1;
+                    wait();
+                }
+            }
+        } catch (Throwable t) {
+            logger.error("Uncaught exception", t);
+        }
     }
 
     public void reportTopology(Topology topology)

--- a/accord-core/src/test/java/accord/topology/TopologyRandomizer.java
+++ b/accord-core/src/test/java/accord/topology/TopologyRandomizer.java
@@ -416,7 +416,7 @@ public class TopologyRandomizer
     private boolean validToReassignRange(Topology current, Shard[] nextShards, Map<Id, Ranges> previouslyReplicated)
     {
         Topology next = new Topology(current.epoch + 1, nextShards);
-        Map<Id, Ranges> additions = TopologyManager.getAdditions(current, next);
+        Map<Id, Ranges> additions = Topology.computeNodeAdditions(current, next);
 
         for (Map.Entry<Id, Ranges> entry : additions.entrySet())
         {
@@ -492,7 +492,7 @@ public class TopologyRandomizer
 
         Topology nextTopology = new Topology(current.epoch + 1, newShards);
 
-        Map<Id, Ranges> nextAdditions = TopologyManager.getAdditions(current, nextTopology);
+        Map<Id, Ranges> nextAdditions = Topology.computeNodeAdditions(current, nextTopology);
         for (Map.Entry<Id, Ranges> entry : nextAdditions.entrySet())
         {
             previouslyReplicated.merge(entry.getKey(), entry.getValue(), (a, b) -> a.union(MERGE_ADJACENT, b));

--- a/accord-core/src/test/java/accord/topology/TopologyRandomizer.java
+++ b/accord-core/src/test/java/accord/topology/TopologyRandomizer.java
@@ -413,33 +413,37 @@ public class TopologyRandomizer
         return ((PrefixedIntHashKey) shard.range.start()).prefix;
     }
 
-    private static Map<Id, Ranges> getAdditions(Topology current, Topology next)
-    {
-        Map<Id, Ranges> additions = new HashMap<>();
-        for (Id node : next.nodes())
-        {
-            Ranges prev = current.rangesForNode(node);
-            if (prev == null) prev = Ranges.EMPTY;
-
-            Ranges added = next.rangesForNode(node).without(prev);
-            if (added.isEmpty())
-                continue;
-
-            additions.put(node, added);
-        }
-        return additions;
-    }
-
-    private static boolean reassignsRanges(Topology current, Shard[] nextShards, Map<Id, Ranges> previouslyReplicated)
+    private boolean validToReassignRange(Topology current, Shard[] nextShards, Map<Id, Ranges> previouslyReplicated)
     {
         Topology next = new Topology(current.epoch + 1, nextShards);
-        Map<Id, Ranges> additions = getAdditions(current, next);
+        Map<Id, Ranges> additions = TopologyManager.getAdditions(current, next);
 
         for (Map.Entry<Id, Ranges> entry : additions.entrySet())
         {
-            if (previouslyReplicated.getOrDefault(entry.getKey(), Ranges.EMPTY).intersects(entry.getValue()))
+            if (previouslyReplicated.getOrDefault(entry.getKey(), Ranges.EMPTY).intersects(entry.getValue())
+                    && !(previousEpochForRegainedRangeRetired(current, entry.getValue())))
+                return false;
+        }
+
+        return true;
+    }
+
+    private boolean previousEpochForRegainedRangeRetired(Topology current, Ranges regainingRanges)
+    {
+        for (Id id : current.nodes())
+        {
+            Node node = this.nodeLookup.apply(id);
+            boolean isRetiredForNode = true;
+            for (ActiveEpoch epoch : node.topology().active())
+            {
+                if (epoch.all().ranges.intersects(regainingRanges) && !epoch.allRetired())
+                    isRetiredForNode = false;
+            }
+
+            if (isRetiredForNode)
                 return true;
         }
+
         return false;
     }
 
@@ -472,7 +476,7 @@ public class TopologyRandomizer
             Shard[] testShards = type.apply(state, random);
             Arrays.sort(testShards, (a, b) -> a.range.compareTo(b.range));
             if (!everyShardHasQuorumOverlaps(oldShards, testShards)
-                || reassignsRanges(current, testShards, previouslyReplicated))
+                || !validToReassignRange(current, testShards, previouslyReplicated))
             {
                 ++rejectedMutations;
             }
@@ -488,7 +492,7 @@ public class TopologyRandomizer
 
         Topology nextTopology = new Topology(current.epoch + 1, newShards);
 
-        Map<Id, Ranges> nextAdditions = getAdditions(current, nextTopology);
+        Map<Id, Ranges> nextAdditions = TopologyManager.getAdditions(current, nextTopology);
         for (Map.Entry<Id, Ranges> entry : nextAdditions.entrySet())
         {
             previouslyReplicated.merge(entry.getKey(), entry.getValue(), (a, b) -> a.union(MERGE_ADJACENT, b));


### PR DESCRIPTION
Currently nodes that are regaining ranges can result in subtle edge cases when we still have command stores left over from previous epochs that overlap with the range we are regaining. 

To address this we: 
1. Allow the regaining of ranges only if the epoch in which we previously owned the range is already retired
2. Mark as unsafe to read the ranges that we are regaining for the command store that previously owned the range and prevent future `setSafeToRead` invocations to revert this change. 
3. Throw an error when we query two command stores for the same range 