### PR TITLE
CASSANDRA-21212 Deleted Retired Command Stores

### DIFF
--- a/accord-core/src/main/java/accord/api/Journal.java
+++ b/accord-core/src/main/java/accord/api/Journal.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import accord.impl.CommandChange;
 import accord.local.Command;
 import accord.local.CommandStores;
+import accord.local.CommandStores.PreviouslyOwned;
 import accord.local.DurableBefore;
 import accord.local.MinimalCommand;
 import accord.local.Node;
@@ -64,12 +65,14 @@ public interface Journal
     void saveCommand(int store, CommandUpdate value, Runnable onFlush);
 
     List<? extends TopologyUpdate> loadTopologies();
+    // TODO (required): saveTopology should be synchronous, or we should at least await durability before updating in memory topology
     void saveTopology(TopologyUpdate topologyUpdate, Runnable onFlush);
 
     RedundantBefore loadRedundantBefore(int store);
     NavigableMap<TxnId, Ranges> loadBootstrapBeganAt(int store);
     NavigableMap<Timestamp, Ranges> loadSafeToRead(int store);
     CommandStores.RangesForEpoch loadRangesForEpoch(int store);
+    Ranges loadPermanentlyUnsafeToRead(int store);
     void saveStoreState(int store, FieldUpdates fieldUpdates, Runnable onFlush);
 
     Persister<DurableBefore, DurableBefore> durableBeforePersister();
@@ -86,16 +89,18 @@ public interface Journal
     {
         public final Int2ObjectHashMap<CommandStores.RangesForEpoch> commandStores;
         public final Topology global;
+        public final PreviouslyOwned previouslyOwned;
 
-        public TopologyUpdate(@Nonnull Int2ObjectHashMap<CommandStores.RangesForEpoch> commandStores, @Nonnull Topology global)
+        public TopologyUpdate(@Nonnull Int2ObjectHashMap<CommandStores.RangesForEpoch> commandStores, @Nonnull Topology global, PreviouslyOwned previouslyOwned)
         {
             this.commandStores = commandStores;
             this.global = global;
+            this.previouslyOwned = previouslyOwned;
         }
 
         public boolean isEquivalent(TopologyUpdate other)
         {
-            boolean equivalent = global.isEquivalent(other.global);
+            boolean equivalent = global.isEquivalent(other.global) && Objects.equals(previouslyOwned, other.previouslyOwned);
             if (!equivalent)
                 return false;
             Invariants.require(commandStores.equals(other.commandStores));
@@ -104,7 +109,7 @@ public interface Journal
 
         public TopologyUpdate cloneWithEquivalentEpoch(long epoch)
         {
-            return new TopologyUpdate(commandStores, global.cloneEquivalentWithEpoch(epoch));
+            return new TopologyUpdate(commandStores, global.cloneEquivalentWithEpoch(epoch), previouslyOwned);
         }
 
         @Override
@@ -113,7 +118,8 @@ public interface Journal
             if (this == object) return true;
             if (object == null || getClass() != object.getClass()) return false;
             TopologyUpdate update = (TopologyUpdate) object;
-            return Objects.equals(commandStores, update.commandStores) && Objects.equals(global, update.global);
+            return Objects.equals(commandStores, update.commandStores) && Objects.equals(global, update.global)
+                   && Objects.equals(previouslyOwned, update.previouslyOwned);
         }
 
         @Override
@@ -151,6 +157,7 @@ public interface Journal
         public RedundantBefore newRedundantBefore;
         public NavigableMap<TxnId, Ranges> newBootstrapBeganAt;
         public NavigableMap<Timestamp, Ranges> newSafeToRead;
+        public Ranges newPermanentlyUnsafeToRead;
         public CommandStores.RangesForEpoch newRangesForEpoch;
 
         public String toString()
@@ -162,6 +169,8 @@ public interface Journal
                 builder.append("newBootstrapBeganAt=").append(newBootstrapBeganAt).append(", ");
             if (newSafeToRead != null)
                 builder.append("newSafeToRead=").append(newSafeToRead).append(", ");
+            if (newPermanentlyUnsafeToRead != null)
+                builder.append("newPermanentlyUnsafeToRead=").append(newPermanentlyUnsafeToRead).append(", ");
             if (newRangesForEpoch != null)
                 builder.append("newRangesForEpoch=").append(newRangesForEpoch).append(", ");
             builder.setLength(builder.length() - 2);

--- a/accord-core/src/main/java/accord/coordinate/MaybeRecover.java
+++ b/accord-core/src/main/java/accord/coordinate/MaybeRecover.java
@@ -55,7 +55,6 @@ public class MaybeRecover extends CheckShards<Outcome, Route<?>>
         this.recoverIfAlreadyDurable = recoverIfAlreadyDurable;
         this.reportTo = reportTo;
     }
-
     public static Object maybeRecover(Node node, TxnId txnId, Infer.InvalidIf invalidIf, Route<?> someRoute, ProgressToken prevProgress, boolean recoverIfAlreadyDurable, LatentStoreSelector reportTo, BiConsumer<? super Outcome, Throwable> callback)
     {
         MaybeRecover maybeRecover;

--- a/accord-core/src/main/java/accord/impl/AbstractSafeCommandStore.java
+++ b/accord-core/src/main/java/accord/impl/AbstractSafeCommandStore.java
@@ -214,6 +214,9 @@ extends SafeCommandStore
         if (fieldUpdates.newRangesForEpoch != null)
             super.setRangesForEpoch(fieldUpdates.newRangesForEpoch);
 
+        if (fieldUpdates.newPermanentlyUnsafeToRead != null)
+            super.setPermanentlyUnsafeToRead(fieldUpdates.newPermanentlyUnsafeToRead);
+
         fieldUpdates = null;
     }
 
@@ -241,6 +244,12 @@ extends SafeCommandStore
     public final void setSafeToRead(NavigableMap<Timestamp, Ranges> newSafeToRead)
     {
         ensureFieldUpdates().newSafeToRead = newSafeToRead;
+    }
+
+    @Override
+    public final void setPermanentlyUnsafeToRead(Ranges newPermanentlyUnsafeToRead)
+    {
+        ensureFieldUpdates().newPermanentlyUnsafeToRead = newPermanentlyUnsafeToRead;
     }
 
     @Override

--- a/accord-core/src/main/java/accord/local/CommandStore.java
+++ b/accord-core/src/main/java/accord/local/CommandStore.java
@@ -188,6 +188,7 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
      * But they may still be ordered for other key ranges they participate in.
      */
     private NavigableMap<Timestamp, Ranges> safeToRead = emptySafeToRead();
+    protected Ranges permanentlyUnsafeToRead = Ranges.EMPTY;
     private final Set<Bootstrap> bootstraps = Collections.synchronizedSet(new DeterministicIdentitySet<>());
 
     static class WaitingOnVisibility
@@ -248,6 +249,7 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
         maxConflicts = MaxConflicts.EMPTY;
         maxDecidedRX = MaxDecidedRX.EMPTY;
         safeToRead = emptySafeToRead();
+        permanentlyUnsafeToRead = Ranges.EMPTY;
         listeners.clear();
         waitingOnVisibility.values().forEach(w -> w.invalid = true);
         waitingOnVisibility.clear();
@@ -286,6 +288,11 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
         return rangesForEpoch;
     }
 
+    public Ranges unsafeGetPermanentlyUnsafeToRead()
+    {
+        return permanentlyUnsafeToRead;
+    }
+
     public MaxDecidedRX unsafeGetMaxDecidedRX()
     {
         return maxDecidedRX;
@@ -306,6 +313,17 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
     {
         Invariants.require(this.rangesForEpoch == null);
         unsafeSetRangesForEpoch(newRangesForEpoch);
+    }
+
+    protected final void unsafeClearPermanentlyUnsafeToRead()
+    {
+        permanentlyUnsafeToRead = null;
+    }
+
+    protected void loadPermanentlyUnsafeToRead(Ranges newPermanentlyUnsafeToRead)
+    {
+        Invariants.require(this.permanentlyUnsafeToRead == null);
+        unsafeSetPermanentlyUnsafeToRead(newPermanentlyUnsafeToRead);
     }
 
     public abstract boolean inStore();
@@ -406,10 +424,17 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
     /**
      * This method may be invoked on a non-CommandStore thread
      */
-    final void unsafeSetSafeToRead(NavigableMap<Timestamp, Ranges> newSafeToRead)
+    final void unsafeSetSafeToRead(@Nullable NavigableMap<Timestamp, Ranges> newSafeToRead)
     {
+        if (newSafeToRead != null)
+            newSafeToRead = purgeHistory(newSafeToRead, permanentlyUnsafeToRead);
         this.safeToRead = newSafeToRead;
         node.updateStamp();
+    }
+
+    final void unsafeSetPermanentlyUnsafeToRead(Ranges newPermanentlyUnsafeToRead)
+    {
+        this.permanentlyUnsafeToRead = newPermanentlyUnsafeToRead;
     }
 
     protected final void unsafeClearSafeToRead()
@@ -1225,6 +1250,14 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
                 safeStore.setSafeToRead(purgeHistory(safeToRead, ranges));
             }, agent);
         }
+    }
+
+    final AsyncChain<Void> markPermanentlyUnsafeToRead(Ranges ranges)
+    {
+        return chain((Empty) () -> "Mark Range As Permanently Unsafe To Read", safeStore -> {
+            safeStore.setSafeToRead(purgeHistory(safeToRead, ranges));
+            safeStore.setPermanentlyUnsafeToRead(permanentlyUnsafeToRead.union(MERGE_ADJACENT, ranges));
+        });
     }
 
     public final DataStore unsafeGetDataStore()

--- a/accord-core/src/main/java/accord/local/CommandStore.java
+++ b/accord-core/src/main/java/accord/local/CommandStore.java
@@ -187,7 +187,7 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
      * But they may still be ordered for other key ranges they participate in.
      */
     private NavigableMap<Timestamp, Ranges> safeToRead = emptySafeToRead();
-    private Ranges retiredRanges =  Ranges.EMPTY;
+    private Ranges regainedRanges =  Ranges.EMPTY;
     private final Set<Bootstrap> bootstraps = Collections.synchronizedSet(new DeterministicIdentitySet<>());
     @Nullable private RejectBefore rejectBefore;
 
@@ -406,8 +406,8 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
         {
             for (Map.Entry<Timestamp, Ranges> entry : newSafeToRead.entrySet())
             {
-                Ranges rangeExcluded = entry.getValue().without(this.retiredRanges);
-                logger.info("{} is excluded from newSafeToRead because it is in the retired range", rangeExcluded);
+                Ranges rangeExcluded = entry.getValue().without(this.regainedRanges);
+                logger.info("{} is excluded from newSafeToRead because it is in the regained ranges", rangeExcluded);
             }
         }
 
@@ -415,9 +415,9 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
         this.safeToRead = newSafeToRead;
     }
 
-    final void unsafeAddToRetiredRanges(Ranges newRetiredRange)
+    final void unsafeAddToRegainedRanges(Ranges newRegainedRanges)
     {
-        this.retiredRanges = newRetiredRange.union(MERGE_ADJACENT, this.retiredRanges);
+        this.regainedRanges = newRegainedRanges.union(MERGE_ADJACENT, this.regainedRanges);
     }
 
     protected final void unsafeClearSafeToRead()
@@ -1196,10 +1196,10 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
         }
     }
 
-    final void markAsRetired(Ranges ranges)
+    final void markAsRegained(Ranges ranges)
     {
-        execute((Empty) () -> "Mark Range As Retired", safeStore -> {
-            safeStore.addToRetiredRanges(ranges);
+        execute((Empty) () -> "Mark Range As Regained", safeStore -> {
+            safeStore.addToRegainedRanges(ranges);
         }, agent);
     }
 

--- a/accord-core/src/main/java/accord/local/CommandStore.java
+++ b/accord-core/src/main/java/accord/local/CommandStore.java
@@ -402,10 +402,13 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
      */
     final void unsafeSetSafeToRead(NavigableMap<Timestamp, Ranges> newSafeToRead)
     {
-        for (Map.Entry<Timestamp, Ranges> entry : newSafeToRead.entrySet())
+        if (newSafeToRead != null)
         {
-            Ranges rangeExcluded = entry.getValue().without(this.retiredRanges);
-            logger.info("{} is excluded from newSafeToRead because it is in the retired range", rangeExcluded);
+            for (Map.Entry<Timestamp, Ranges> entry : newSafeToRead.entrySet())
+            {
+                Ranges rangeExcluded = entry.getValue().without(this.retiredRanges);
+                logger.info("{} is excluded from newSafeToRead because it is in the retired range", rangeExcluded);
+            }
         }
 
         node.updateStamp();

--- a/accord-core/src/main/java/accord/local/CommandStore.java
+++ b/accord-core/src/main/java/accord/local/CommandStore.java
@@ -187,6 +187,7 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
      * But they may still be ordered for other key ranges they participate in.
      */
     private NavigableMap<Timestamp, Ranges> safeToRead = emptySafeToRead();
+    private Ranges retiredRanges =  Ranges.EMPTY;
     private final Set<Bootstrap> bootstraps = Collections.synchronizedSet(new DeterministicIdentitySet<>());
     @Nullable private RejectBefore rejectBefore;
 
@@ -401,8 +402,19 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
      */
     final void unsafeSetSafeToRead(NavigableMap<Timestamp, Ranges> newSafeToRead)
     {
+        for (Map.Entry<Timestamp, Ranges> entry : newSafeToRead.entrySet())
+        {
+            Ranges rangeExcluded = entry.getValue().without(this.retiredRanges);
+            logger.info("{} is excluded from newSafeToRead because it is in the retired range", rangeExcluded);
+        }
+
         node.updateStamp();
         this.safeToRead = newSafeToRead;
+    }
+
+    final void unsafeAddToRetiredRanges(Ranges newRetiredRange)
+    {
+        this.retiredRanges = newRetiredRange.union(MERGE_ADJACENT, this.retiredRanges);
     }
 
     protected final void unsafeClearSafeToRead()
@@ -1179,6 +1191,13 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
                 safeStore.setSafeToRead(purgeHistory(safeToRead, ranges));
             }, agent);
         }
+    }
+
+    final void markAsRetired(Ranges ranges)
+    {
+        execute((Empty) () -> "Mark Range As Retired", safeStore -> {
+            safeStore.addToRetiredRanges(ranges);
+        }, agent);
     }
 
     public final DataStore unsafeGetDataStore()

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -634,7 +634,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
             for (int i = 0; i < shards.length; i++)
             {
-                for (int j = i+1; j < shards.length; j++)
+                for (int j = i; j < shards.length; j++)
                 {
                     if (!shards[i].ranges().all().slice(shards[j].ranges().all(), Minimal).isEmpty())
                     {

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -629,16 +629,17 @@ public abstract class CommandStores implements AsyncExecutorFactory
             lookupByRange = SearchableRangeList.build(ranges);
 
             overlappingCommandStores = new HashMap<>();
-            for (ShardHolder shard : shards)
+            for (int i = 0; i < shards.length; i++)
+                overlappingCommandStores.put(i, new LargeBitSet(shards.length));
+
+            for (int i = 0; i < shards.length; i++)
             {
-                overlappingCommandStores.put(shard.store.id, new LargeBitSet(shards.length));
-                for (Map.Entry<Integer, LargeBitSet> entry : overlappingCommandStores.entrySet())
+                for (int j = i+1; j < shards.length; j++)
                 {
-                    Integer id = entry.getKey();
-                    if (!shard.ranges().all().overlapping(shards[byId.get(id)].ranges.all()).isEmpty())
+                    if (!shards[i].ranges().all().overlapping(shards[j].ranges().all()).isEmpty())
                     {
-                        overlappingCommandStores.get(shard.store.id).set(id);
-                        entry.getValue().set(shard.store.id);
+                        overlappingCommandStores.get(i).set(j);
+                        overlappingCommandStores.get(j).set(i);
                     }
                 }
             }
@@ -973,7 +974,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (bitSet.get(i))
                 {
-                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).unsafeGetRangesForEpoch().all());
+                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.shards[i].ranges().all());
 
                     if (!range.overlapping(touchedKeys).isEmpty())
                         throw illegalState("We should not query the same range from two different command stores.");

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -1017,11 +1017,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 RangesForEpoch rangesForEpoch = e.getValue();
 
-                for (int i = 0; i < rangesForEpoch.size(); i++)
-                {
-                    if (rangesForEpoch.epochs[i] >= storeIterator.getMinEpoch() && rangesForEpoch.ranges[i].intersects(mapReduceConsume.keys()))
-                        return AsyncChains.failure(new RuntimeException("Tried to query CommandStore that has already been deleted"));
-                }
+                if (rangesForEpoch.allSince(storeIterator.getMinEpoch()).intersects(mapReduceConsume.keys()))
+                    return AsyncChains.failure(new RuntimeException("Query sent for deleted CommandStore"));
             }
 
         if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, snapshot.previouslyOwnedRanges, mapReduceConsume.keys().toRanges(), storeIterator.getMinEpoch()))
@@ -1041,7 +1038,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (commandStoresSeen.get(i))
                 {
-                    Ranges touchedKeys = shards[i].ranges().epochs[shards[i].ranges().size()-1] >= minEpoch ? queryRange.slice(shards[i].ranges().allSince(minEpoch), Minimal) : Ranges.EMPTY;
+                    Ranges touchedKeys = queryRange.slice(shards[i].ranges().allSince(minEpoch), Minimal);
 
                     if (!range.slice(touchedKeys, Minimal).isEmpty())
                         return false;
@@ -1053,7 +1050,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             // Can only overlap with ranges of CommandStores that we traverse
             for (Map.Entry<Integer, RangesForEpoch> e : previouslyOwnedRanges.entrySet())
             {
-                Ranges touchedKeys = e.getValue().epochs[e.getValue().size()-1] >= minEpoch ? queryRange.slice(e.getValue().allSince(minEpoch), Minimal) : Ranges.EMPTY;
+                Ranges touchedKeys = queryRange.slice(e.getValue().allSince(minEpoch), Minimal);
                 if (!range.slice(touchedKeys, Minimal).isEmpty())
                     return false;
             }

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -965,6 +965,13 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
 
+        Invariants.require(checkQueryDisjointRangesAcrossCommandStores(snapshot, bitSet, mapReduceConsume.keys().toRanges()));
+
+        return chain == null ? AsyncChains.success(null) : chain;
+    }
+
+    public boolean checkQueryDisjointRangesAcrossCommandStores(Snapshot snapshot, LargeBitSet commandStoresSeen, Ranges queryRange)
+    {
         // Check that we are not querying two command stores for the same range
         for (Map.Entry<Integer, LargeBitSet> entry : snapshot.overlappingCommandStores.entrySet())
         {
@@ -972,19 +979,19 @@ public abstract class CommandStores implements AsyncExecutorFactory
             LargeBitSet overlappingCommandStores = entry.getValue();
             for (int i = overlappingCommandStores.firstSetBit(); i >= 0 ; i = overlappingCommandStores.nextSetBit(i + 1, -1))
             {
-                if (bitSet.get(i))
+                if (commandStoresSeen.get(i))
                 {
-                    Ranges touchedKeys = mapReduceConsume.keys().toRanges().slice(snapshot.shards[i].ranges().all(), Minimal);
+                    Ranges touchedKeys = queryRange.slice(snapshot.shards[i].ranges().all(), Minimal);
 
                     if (!range.slice(touchedKeys, Minimal).isEmpty())
-                        throw illegalState("We should not query the same range from two different command stores.");
+                        return false;
 
                     range = range.with(touchedKeys.toRanges());
                 }
             }
         }
 
-        return chain == null ? AsyncChains.success(null) : chain;
+        return true;
     }
 
     public <O> O mapReduceUnsafe(StoreSelector selector, Function<CommandStore, O> map, BiFunction<O, O, O> reduce, O accumulator)

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -110,9 +110,9 @@ public abstract class CommandStores implements AsyncExecutorFactory
             @Override
             public StoreSelector refine(TxnId txnId, @Nullable Timestamp executeAt, Participants<?> participants)
             {
-                return snapshot -> StoreFinder.find(snapshot, participants)
+                return snapshot -> new StoreIterator(StoreFinder.find(snapshot, participants)
                                               .filter(snapshot, participants, txnId.epoch(), (executeAt != null ? executeAt : txnId).epoch())
-                                              .iterator(snapshot);
+                                              .iterator(snapshot), txnId.epoch());
             }
         }
 
@@ -125,7 +125,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
     public interface StoreSelector extends LatentStoreSelector
     {
         default StoreSelector refine(TxnId txnId, @Nullable Timestamp executeAt, Participants<?> participants) { return this; }
-        Iterator<CommandStore> select(Snapshot snapshot);
+        StoreIterator select(Snapshot snapshot);
     }
 
     public static class IncludingSpecificStoreSelector implements StoreSelector
@@ -144,14 +144,35 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 StoreFinder finder = StoreFinder.find(snapshot, participants)
                                                 .filter(snapshot, participants, txnId.epoch(), (executeAt != null ? executeAt : txnId).epoch());
                 finder.set(snapshot.byId.get(storeId));
-                return finder.iterator(snapshot);
+                return new StoreIterator(finder.iterator(snapshot), txnId.epoch());
             };
         }
 
         @Override
-        public Iterator<CommandStore> select(Snapshot snapshot)
+        public StoreIterator select(Snapshot snapshot)
         {
-            return Collections.singletonList(snapshot.byId(storeId)).iterator();
+            return new StoreIterator(Collections.singletonList(snapshot.byId(storeId)).iterator(), null);
+        }
+    }
+
+    public static class StoreIterator
+    {
+        public final Iterator<CommandStore> StoreIterator;
+        public final Long minEpoch;
+
+        public StoreIterator(Iterator<CommandStore> StoreIterator, @Nullable Long minEpoch)
+        {
+            this.StoreIterator = StoreIterator;
+            this.minEpoch = minEpoch;
+        }
+
+        public Iterator<CommandStore> getStoreIterator()
+        {
+            return StoreIterator;
+        }
+
+        public Long getMinEpoch() {
+            return minEpoch;
         }
     }
 
@@ -176,7 +197,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             return snapshot -> {
                 StoreFinder finder = StoreFinder.find(snapshot, unseekables);
                 finder.filter(snapshot, unseekables, minEpoch, maxEpoch);
-                return finder.iterator(snapshot);
+                return new StoreIterator(finder.iterator(snapshot), minEpoch);
             };
         }
 
@@ -878,7 +899,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
     public AsyncChain<Void> forAll(String reason, Consumer<SafeCommandStore> forEach)
     {
-        return mapReduce(snapshot -> Stream.of(snapshot.shards).map(shard -> shard.store).iterator(), new MapReduceCommandStores<>(RoutingKeys.EMPTY)
+        return mapReduce(snapshot -> new StoreIterator(Stream.of(snapshot.shards).map(shard -> shard.store).iterator(), null), new MapReduceCommandStores<>(RoutingKeys.EMPTY)
         {
             @Override public Void reduce(Void o1, Void o2) { return null; }
             @Override public TxnId primaryTxnId() { return null; }
@@ -947,13 +968,14 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
     public <O> AsyncChain<O> mapReduce(IntStream commandStoreIds, MapReduceCommandStores<?, O> mapReduce)
     {
-        return mapReduce(snapshot -> commandStoreIds.mapToObj(snapshot::byId).iterator(), mapReduce);
+        return mapReduce(snapshot -> new StoreIterator(commandStoreIds.mapToObj(snapshot::byId).iterator(), null), mapReduce);
     }
 
     public <O> AsyncChain<O> mapReduce(StoreSelector selector, MapReduceCommandStores<?, O> mapReduceConsume)
     {
         Snapshot snapshot = current;
-        Iterator<CommandStore> stores = selector.select(snapshot);
+        StoreIterator StoreIterator = selector.select(snapshot);
+        Iterator<CommandStore> stores = StoreIterator.getStoreIterator();
         AsyncChain<O> chain = null;
         LargeBitSet bitSet = new LargeBitSet(snapshot.shards.length);
         while (stores.hasNext())
@@ -965,12 +987,13 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
 
-        Invariants.require(checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges()));
+        if (checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
+            throw new IllegalStateException();
 
         return chain == null ? AsyncChains.success(null) : chain;
     }
 
-    public static boolean checkQueryDisjointRangesAcrossCommandStores(Map<Integer, LargeBitSet> overlappingCommandStores, ShardHolder[] shards, LargeBitSet commandStoresSeen, Ranges queryRange)
+    public static boolean checkQueryDisjointRangesAcrossCommandStores(Map<Integer, LargeBitSet> overlappingCommandStores, ShardHolder[] shards, LargeBitSet commandStoresSeen, Ranges queryRange, Long minEpoch)
     {
         // Check that we are not querying two command stores for the same range
         for (Map.Entry<Integer, LargeBitSet> entry : overlappingCommandStores.entrySet())
@@ -981,7 +1004,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (commandStoresSeen.get(i))
                 {
-                    Ranges touchedKeys = queryRange.slice(shards[i].ranges().all(), Minimal);
+                    Ranges touchedKeys = queryRange.slice(shards[i].ranges().allSince(minEpoch), Minimal);
 
                     if (!range.slice(touchedKeys, Minimal).isEmpty())
                         return false;
@@ -997,7 +1020,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
     public <O> O mapReduceUnsafe(StoreSelector selector, Function<CommandStore, O> map, BiFunction<O, O, O> reduce, O accumulator)
     {
         Snapshot snapshot = current;
-        Iterator<CommandStore> stores = selector.select(snapshot);
+        Iterator<CommandStore> stores = selector.select(snapshot).getStoreIterator();
         while (stores.hasNext())
         {
             O next = map.apply(stores.next());

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -967,23 +967,19 @@ public abstract class CommandStores implements AsyncExecutorFactory
         // Check that we are not querying two command stores for the same range
         for (Map.Entry<Integer, LargeBitSet> entry : snapshot.overlappingCommandStores.entrySet())
         {
-            List<Integer> overlapping = new ArrayList<>();
+            Ranges range = Ranges.EMPTY;
             LargeBitSet overlappingCommandStores = entry.getValue();
             for (int i = overlappingCommandStores.firstSetBit(); i >= 0 ; i = overlappingCommandStores.nextSetBit(i + 1, -1))
             {
                 if (bitSet.get(i))
-                    overlapping.add(i);
-            }
-
-            Ranges range = Ranges.EMPTY;
-            for (Integer id : overlapping)
-            {
-                Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(id).rangesForEpoch.all());
-                if (!range.overlapping(touchedKeys).isEmpty())
                 {
-                    throw illegalState("We should not query the same range from two different command stores.");
+                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all());
+
+                    if (!range.overlapping(touchedKeys).isEmpty())
+                        throw illegalState("We should not query the same range from two different command stores.");
+
+                    range = range.with(mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all()).toRanges());
                 }
-                range = range.with(mapReduceConsume.keys().overlapping(snapshot.byId(id).rangesForEpoch.all()).toRanges());
             }
         }
 

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -629,8 +629,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
             lookupByRange = SearchableRangeList.build(ranges);
 
             overlappingCommandStores = new HashMap<>();
-            for (ShardHolder shard : shards)
-                overlappingCommandStores.put(shard.store.id(), new LargeBitSet(shards.length));
+            for (int i = 0; i < shards.length ; i++)
+                overlappingCommandStores.put(i, new LargeBitSet(shards.length));
 
             for (int i = 0; i < shards.length; i++)
             {
@@ -638,8 +638,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 {
                     if (!shards[i].ranges().all().slice(shards[j].ranges().all(), Minimal).isEmpty())
                     {
-                        overlappingCommandStores.get(shards[i].store.id()).set(shards[j].store.id());
-                        overlappingCommandStores.get(shards[j].store.id()).set(shards[i].store.id());
+                        overlappingCommandStores.get(i).set(j);
+                        overlappingCommandStores.get(j).set(i);
                     }
                 }
             }
@@ -959,7 +959,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         while (stores.hasNext())
         {
             CommandStore store = stores.next();
-            bitSet.set(store.id());
+            bitSet.set(snapshot.byId.get(store.id()));
             AsyncChain<O> next = mapReduceConsume.applyAsync(store);
             if (next != null)
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
@@ -974,7 +974,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (bitSet.get(i))
                 {
-                    Ranges touchedKeys = mapReduceConsume.keys().toRanges().slice(snapshot.byId(i).rangesForEpoch.all(), Minimal);
+                    Ranges touchedKeys = mapReduceConsume.keys().toRanges().slice(snapshot.shards[i].ranges().all(), Minimal);
 
                     if (!range.slice(touchedKeys, Minimal).isEmpty())
                         throw illegalState("We should not query the same range from two different command stores.");

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -18,7 +18,15 @@
 
 package accord.local;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.HashMap;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -30,7 +38,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import accord.primitives.*;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
@@ -46,6 +53,16 @@ import accord.api.LocalListeners;
 import accord.api.ProgressLog;
 import accord.api.RoutingKey;
 import accord.local.CommandStore.EpochUpdateHolder;
+import accord.primitives.AbstractRanges;
+import accord.primitives.AbstractUnseekableKeys;
+import accord.primitives.EpochSupplier;
+import accord.primitives.Participants;
+import accord.primitives.Range;
+import accord.primitives.Ranges;
+import accord.primitives.RoutingKeys;
+import accord.primitives.Timestamp;
+import accord.primitives.TxnId;
+import accord.primitives.Unseekables;
 import accord.topology.Shard;
 import accord.topology.Topology;
 import accord.utils.IndexedQuadConsumer;
@@ -932,7 +949,6 @@ public abstract class CommandStores implements AsyncExecutorFactory
         return mapReduce(snapshot -> commandStoreIds.mapToObj(snapshot::byId).iterator(), mapReduce);
     }
 
-    /* Do all reads and writes go through this? */
     public <O> AsyncChain<O> mapReduce(StoreSelector selector, MapReduceCommandStores<?, O> mapReduceConsume)
     {
         Snapshot snapshot = current;

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -38,21 +38,14 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import accord.topology.TopologyException;
+import accord.api.*;
+import accord.topology.*;
+import accord.utils.btree.BTreeMap;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import accord.api.Agent;
-import accord.api.AsyncExecutorFactory;
-import accord.api.AsyncExecutor;
-import accord.topology.EpochReady;
-import accord.api.DataStore;
-import accord.api.Journal;
-import accord.api.LocalListeners;
-import accord.api.ProgressLog;
-import accord.api.RoutingKey;
 import accord.local.CommandStore.EpochUpdateHolder;
 import accord.primitives.AbstractRanges;
 import accord.primitives.AbstractUnseekableKeys;
@@ -64,8 +57,6 @@ import accord.primitives.RoutingKeys;
 import accord.primitives.Timestamp;
 import accord.primitives.TxnId;
 import accord.primitives.Unseekables;
-import accord.topology.Shard;
-import accord.topology.Topology;
 import accord.utils.IndexedQuadConsumer;
 import accord.utils.IndexedRangeQuadConsumer;
 import accord.utils.Invariants;
@@ -318,6 +309,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
     {
         public final CommandStore store;
         RangesForEpoch ranges;
+        Long retirementEpoch;
 
         ShardHolder(CommandStore store)
         {
@@ -328,6 +320,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         {
             this.store = store;
             this.ranges = ranges;
+            this.retirementEpoch = null;
         }
 
         public ShardHolder withStoreUnsafe(CommandStore store)
@@ -601,10 +594,11 @@ public abstract class CommandStores implements AsyncExecutorFactory
         private final int[] indexForRange;
         final SearchableRangeList lookupByRange;
         final Map<Integer, LargeBitSet> overlappingCommandStores;
+        Int2ObjectHashMap<RangesForEpoch> previouslyOwnedRanges;
 
-        public Snapshot(ShardHolder[] shards, Topology local, Topology global)
+        public Snapshot(ShardHolder[] shards, Topology local, Topology global, Int2ObjectHashMap<RangesForEpoch> previouslyOwnedRanges)
         {
-            super(asMap(shards), global);
+            super(asMap(shards, previouslyOwnedRanges), global);
             this.local = local;
             this.shards = shards;
             this.byId = new Int2IntHashMap(shards.length, Hashing.DEFAULT_LOAD_FACTOR, -1);
@@ -665,6 +659,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
                     }
                 }
             }
+
+            this.previouslyOwnedRanges = previouslyOwnedRanges;
         }
 
         // This method exists to ensure we do not hold references to command stores
@@ -673,11 +669,12 @@ public abstract class CommandStores implements AsyncExecutorFactory
             return new Journal.TopologyUpdate(commandStores, global);
         }
 
-        private static Int2ObjectHashMap<CommandStores.RangesForEpoch> asMap(ShardHolder[] shards)
+        private static Int2ObjectHashMap<CommandStores.RangesForEpoch> asMap(ShardHolder[] shards, Int2ObjectHashMap<CommandStores.RangesForEpoch> previouslyOwnedRanges)
         {
             Int2ObjectHashMap<CommandStores.RangesForEpoch> commandStores = new Int2ObjectHashMap<>();
             for (ShardHolder shard : shards)
                 commandStores.put(shard.store.id, shard.ranges);
+            commandStores.putAll(previouslyOwnedRanges);
             return commandStores;
         }
 
@@ -704,7 +701,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         this.supplier = supplier;
         this.shardDistributor = shardDistributor;
 
-        this.current = new Snapshot(new ShardHolder[0], Topology.EMPTY, Topology.EMPTY);
+        this.current = new Snapshot(new ShardHolder[0], Topology.EMPTY, Topology.EMPTY, new Int2ObjectHashMap<>());
         this.journal = journal;
     }
 
@@ -788,14 +785,39 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
         List<Supplier<EpochReady>> bootstrapUpdates = new ArrayList<>();
         List<ShardHolder> result = new ArrayList<>(prev.shards.length + added.size());
+        Int2ObjectHashMap<RangesForEpoch> previouslyOwnedRanges = new Int2ObjectHashMap<>();
+
         for (ShardHolder shard : prev.shards)
         {
+            // Remove shard if RangesForEpoch is fully retired
+            try
+            {
+                if (shard.retirementEpoch != null && node.topology().active().get(shard.retirementEpoch).retired().containsAll(shard.ranges().allAt(shard.retirementEpoch)))
+                {
+                    previouslyOwnedRanges.put(shard.store.id(), shard.ranges);
+                    continue;
+                }
+            }
+            catch (TopologyRetiredException e)
+            {
+                previouslyOwnedRanges.put(shard.store.id(), shard.ranges);
+                continue;
+            }
+            catch (TopologyException e)
+            {
+                throw new IllegalStateException();
+            }
+
             Ranges current = shard.ranges().currentRanges();
             Ranges removeRanges = subtracted.slice(current, Minimal);
             if (!removeRanges.isEmpty())
             {
                 // TODO (required): This is updating the a non-volatile field in the previous Snapshot, why modify it at all, even with volatile the guaranteed visibility is weak even with mutual exclusion
                 shard.ranges = shard.ranges().withRanges(newTopology.epoch(), current.without(subtracted));
+                if (shard.ranges.ranges[shard.ranges.size() - 1].isEmpty())
+                {
+                    shard.retirementEpoch = shard.ranges.epochs[shard.ranges.size() - 1];
+                }
                 shard.store.epochUpdateHolder.remove(epoch, shard.ranges, removeRanges);
                 bootstrapUpdates.add(shard.store.unbootstrap(epoch, removeRanges));
             }
@@ -828,6 +850,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 updateHolder.add(epoch, rangesForEpoch, addRanges);
                 ShardHolder shard = new ShardHolder(supplier.create(nextId++, updateHolder));
                 shard.ranges = rangesForEpoch;
+                shard.retirementEpoch = null;
 
                 Map<BootstrapRangeAction, Ranges> partitioned = addRanges.partitioningBy(range -> shouldBootstrap(node, prev.global, newLocalTopology, range), BootstrapRangeAction.class);
                 for (Map.Entry<BootstrapRangeAction, Ranges> entry : partitioned.entrySet())
@@ -860,7 +883,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 );
             };
         }
-        return new TopologyUpdate(new Snapshot(result.toArray(new ShardHolder[0]), newLocalTopology, newTopology), bootstrap);
+        return new TopologyUpdate(new Snapshot(result.toArray(new ShardHolder[0]), newLocalTopology, newTopology, previouslyOwnedRanges), bootstrap);
     }
 
     private static boolean requiresSync(Ranges ranges, Topology oldTopology, Topology newTopology)
@@ -982,19 +1005,32 @@ public abstract class CommandStores implements AsyncExecutorFactory
         while (stores.hasNext())
         {
             CommandStore store = stores.next();
+            Invariants.require(!snapshot.previouslyOwnedRanges.containsKey(store.id()));
             bitSet.set(snapshot.byId.get(store.id()));
             AsyncChain<O> next = mapReduceConsume.applyAsync(store);
             if (next != null)
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
 
-        if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), storeIterator.getMinEpoch()))
+        if (chain == null)
+            for (Map.Entry<Integer, RangesForEpoch> e : snapshot.previouslyOwnedRanges.entrySet())
+            {
+                RangesForEpoch rangesForEpoch = e.getValue();
+
+                for (int i = 0; i < rangesForEpoch.size(); i++)
+                {
+                    if (rangesForEpoch.epochs[i] >= storeIterator.getMinEpoch() && rangesForEpoch.ranges[i].intersects(mapReduceConsume.keys()))
+                        return AsyncChains.failure(new RuntimeException("Tried to query CommandStore that has already been deleted"));
+                }
+            }
+
+        if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, snapshot.previouslyOwnedRanges, mapReduceConsume.keys().toRanges(), storeIterator.getMinEpoch()))
             return AsyncChains.failure(new RuntimeException("Tried to query more than one CommandStore for the same range"));
 
         return chain == null ? AsyncChains.success(null) : chain;
     }
 
-    public static boolean checkQueryDisjointRangesAcrossCommandStores(Map<Integer, LargeBitSet> overlappingCommandStores, ShardHolder[] shards, LargeBitSet commandStoresSeen, Ranges queryRange, Long minEpoch)
+    public static boolean checkQueryDisjointRangesAcrossCommandStores(Map<Integer, LargeBitSet> overlappingCommandStores, ShardHolder[] shards, LargeBitSet commandStoresSeen, Int2ObjectHashMap<RangesForEpoch> previouslyOwnedRanges, Ranges queryRange, Long minEpoch)
     {
         // Check that we are not querying two command stores for the same range
         for (Map.Entry<Integer, LargeBitSet> entry : overlappingCommandStores.entrySet())
@@ -1005,13 +1041,21 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (commandStoresSeen.get(i))
                 {
-                    Ranges touchedKeys = queryRange.slice(shards[i].ranges().allSince(minEpoch), Minimal);
+                    Ranges touchedKeys = shards[i].ranges().epochs[shards[i].ranges().size()-1] >= minEpoch ? queryRange.slice(shards[i].ranges().allSince(minEpoch), Minimal) : Ranges.EMPTY;
 
                     if (!range.slice(touchedKeys, Minimal).isEmpty())
                         return false;
 
                     range = range.with(touchedKeys.toRanges());
                 }
+            }
+
+            // Can only overlap with ranges of CommandStores that we traverse
+            for (Map.Entry<Integer, RangesForEpoch> e : previouslyOwnedRanges.entrySet())
+            {
+                Ranges touchedKeys = e.getValue().epochs[e.getValue().size()-1] >= minEpoch ? queryRange.slice(e.getValue().allSince(minEpoch), Minimal) : Ranges.EMPTY;
+                if (!range.slice(touchedKeys, Minimal).isEmpty())
+                    return false;
             }
         }
 
@@ -1050,7 +1094,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         Arrays.sort(shards, Comparator.comparingInt(shard -> shard.store.id));
 
         nextId = maxId + 1;
-        loadSnapshot(new Snapshot(shards, update.global.forNode(supplier.node.id()).trim(), update.global));
+        loadSnapshot(new Snapshot(shards, update.global.forNode(supplier.node.id()).trim(), update.global, new Int2ObjectHashMap<>()));
     }
 
     public synchronized void resetTopology(Journal.TopologyUpdate update)
@@ -1100,7 +1144,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         }
 
         nextId = maxId + 1;
-        loadSnapshot(new Snapshot(shards, current.local, current.global));
+        loadSnapshot(new Snapshot(shards, current.local, current.global, new Int2ObjectHashMap<>()));
     }
 
     public synchronized Supplier<EpochReady> updateTopology(Node node, Topology newTopology)

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -40,7 +40,6 @@ import javax.annotation.Nullable;
 
 import accord.api.*;
 import accord.topology.*;
-import accord.utils.btree.BTreeMap;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
@@ -785,7 +784,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
         List<Supplier<EpochReady>> bootstrapUpdates = new ArrayList<>();
         List<ShardHolder> result = new ArrayList<>(prev.shards.length + added.size());
-        Int2ObjectHashMap<RangesForEpoch> previouslyOwnedRanges = new Int2ObjectHashMap<>();
+        Int2ObjectHashMap<RangesForEpoch> previouslyOwnedRanges = prev.previouslyOwnedRanges;
 
         for (ShardHolder shard : prev.shards)
         {

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -38,6 +38,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import accord.topology.TopologyException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
@@ -988,10 +989,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         }
 
         if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
-        {
-            logger.info("Reject query as it tries to query {} in more than one CommandStore", mapReduceConsume.keys().toRanges().toString());
-            return AsyncChains.failure(null);
-        }
+            return AsyncChains.failure(new RuntimeException("Tried to query more than one CommandStore for the same range"));
 
         return chain == null ? AsyncChains.success(null) : chain;
     }

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -163,7 +163,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         public StoreIterator(Iterator<CommandStore> StoreIterator, @Nullable Long minEpoch)
         {
             this.StoreIterator = StoreIterator;
-            this.minEpoch = minEpoch;
+            this.minEpoch = (minEpoch == null) ? 0L : minEpoch;
         }
 
         public Iterator<CommandStore> getStoreIterator()

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -636,7 +636,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 for (int j = i+1; j < shards.length; j++)
                 {
-                    if (!shards[i].ranges().all().overlapping(shards[j].ranges().all()).isEmpty())
+                    if (!shards[i].ranges().all().slice(shards[j].ranges().all(), Minimal).isEmpty())
                     {
                         overlappingCommandStores.get(shards[i].store.id()).set(shards[j].store.id());
                         overlappingCommandStores.get(shards[j].store.id()).set(shards[i].store.id());
@@ -778,7 +778,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 bootstrapUpdates.add(shard.store.unbootstrap(epoch, removeRanges));
             }
 
-            Ranges regainedRanges = shard.ranges().all().overlapping(added);
+            Ranges regainedRanges = shard.ranges().all().slice(added, Minimal);
             if (!regainedRanges.isEmpty())
             {
                 shard.store.markUnsafeToRead(regainedRanges);
@@ -974,9 +974,9 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (bitSet.get(i))
                 {
-                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all());
+                    Ranges touchedKeys = mapReduceConsume.keys().toRanges().slice(snapshot.byId(i).rangesForEpoch.all(), Minimal);
 
-                    if (!range.overlapping(touchedKeys).isEmpty())
+                    if (!range.slice(touchedKeys, Minimal).isEmpty())
                         throw illegalState("We should not query the same range from two different command stores.");
 
                     range = range.with(touchedKeys.toRanges());

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -158,18 +158,18 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
     public static class StoreIterator
     {
-        public final Iterator<CommandStore> StoreIterator;
+        public final Iterator<CommandStore> storeIterator;
         public final Long minEpoch;
 
-        public StoreIterator(Iterator<CommandStore> StoreIterator, @Nullable Long minEpoch)
+        public StoreIterator(Iterator<CommandStore> storeIterator, @Nullable Long minEpoch)
         {
-            this.StoreIterator = StoreIterator;
+            this.storeIterator = storeIterator;
             this.minEpoch = (minEpoch == null) ? 0L : minEpoch;
         }
 
         public Iterator<CommandStore> getStoreIterator()
         {
-            return StoreIterator;
+            return storeIterator;
         }
 
         public Long getMinEpoch() {
@@ -975,8 +975,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
     public <O> AsyncChain<O> mapReduce(StoreSelector selector, MapReduceCommandStores<?, O> mapReduceConsume)
     {
         Snapshot snapshot = current;
-        StoreIterator StoreIterator = selector.select(snapshot);
-        Iterator<CommandStore> stores = StoreIterator.getStoreIterator();
+        StoreIterator storeIterator = selector.select(snapshot);
+        Iterator<CommandStore> stores = storeIterator.getStoreIterator();
         AsyncChain<O> chain = null;
         LargeBitSet bitSet = new LargeBitSet(snapshot.shards.length);
         while (stores.hasNext())
@@ -988,7 +988,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
 
-        if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
+        if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), storeIterator.getMinEpoch()))
             return AsyncChains.failure(new RuntimeException("Tried to query more than one CommandStore for the same range"));
 
         return chain == null ? AsyncChains.success(null) : chain;

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -629,8 +629,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
             lookupByRange = SearchableRangeList.build(ranges);
 
             overlappingCommandStores = new HashMap<>();
-            for (int i = 0; i < shards.length; i++)
-                overlappingCommandStores.put(i, new LargeBitSet(shards.length));
+            for (ShardHolder shard : shards)
+                overlappingCommandStores.put(shard.store.id(), new LargeBitSet(shards.length));
 
             for (int i = 0; i < shards.length; i++)
             {
@@ -638,8 +638,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 {
                     if (!shards[i].ranges().all().overlapping(shards[j].ranges().all()).isEmpty())
                     {
-                        overlappingCommandStores.get(i).set(j);
-                        overlappingCommandStores.get(j).set(i);
+                        overlappingCommandStores.get(shards[i].store.id()).set(shards[j].store.id());
+                        overlappingCommandStores.get(shards[j].store.id()).set(shards[i].store.id());
                     }
                 }
             }
@@ -974,7 +974,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (bitSet.get(i))
                 {
-                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.shards[i].ranges().all());
+                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all());
 
                     if (!range.overlapping(touchedKeys).isEmpty())
                         throw illegalState("We should not query the same range from two different command stores.");

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -987,7 +987,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
 
-        if (checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
+        if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
             throw new IllegalStateException();
 
         return chain == null ? AsyncChains.success(null) : chain;

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -965,23 +965,23 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
 
-        Invariants.require(checkQueryDisjointRangesAcrossCommandStores(snapshot, bitSet, mapReduceConsume.keys().toRanges()));
+        Invariants.require(checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges()));
 
         return chain == null ? AsyncChains.success(null) : chain;
     }
 
-    public boolean checkQueryDisjointRangesAcrossCommandStores(Snapshot snapshot, LargeBitSet commandStoresSeen, Ranges queryRange)
+    public static boolean checkQueryDisjointRangesAcrossCommandStores(Map<Integer, LargeBitSet> overlappingCommandStores, ShardHolder[] shards, LargeBitSet commandStoresSeen, Ranges queryRange)
     {
         // Check that we are not querying two command stores for the same range
-        for (Map.Entry<Integer, LargeBitSet> entry : snapshot.overlappingCommandStores.entrySet())
+        for (Map.Entry<Integer, LargeBitSet> entry : overlappingCommandStores.entrySet())
         {
             Ranges range = Ranges.EMPTY;
-            LargeBitSet overlappingCommandStores = entry.getValue();
-            for (int i = overlappingCommandStores.firstSetBit(); i >= 0 ; i = overlappingCommandStores.nextSetBit(i + 1, -1))
+            LargeBitSet overlappingCommandStore = entry.getValue();
+            for (int i = overlappingCommandStore.firstSetBit(); i >= 0 ; i = overlappingCommandStore.nextSetBit(i + 1, -1))
             {
                 if (commandStoresSeen.get(i))
                 {
-                    Ranges touchedKeys = queryRange.slice(snapshot.shards[i].ranges().all(), Minimal);
+                    Ranges touchedKeys = queryRange.slice(shards[i].ranges().all(), Minimal);
 
                     if (!range.slice(touchedKeys, Minimal).isEmpty())
                         return false;

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -795,9 +795,9 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 // TODO (required): This is updating the a non-volatile field in the previous Snapshot, why modify it at all, even with volatile the guaranteed visibility is weak even with mutual exclusion
                 shard.ranges = shard.ranges().withRanges(newTopology.epoch(), current.without(subtracted));
-                if (shard.ranges.ranges[shard.ranges.size() - 1].isEmpty())
+                if (current.without(subtracted).isEmpty())
                 {
-                    shard.retirementEpoch = shard.ranges.epochs[shard.ranges.size() - 1] - 1;
+                    shard.retirementEpoch = shard.ranges().epochs[shard.ranges.size() - 1] - 1;
                 }
                 shard.store.epochUpdateHolder.remove(epoch, shard.ranges, removeRanges);
                 bootstrapUpdates.add(shard.store.unbootstrap(epoch, removeRanges));

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -973,12 +973,12 @@ public abstract class CommandStores implements AsyncExecutorFactory
             {
                 if (bitSet.get(i))
                 {
-                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all());
+                    Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(i).unsafeGetRangesForEpoch().all());
 
                     if (!range.overlapping(touchedKeys).isEmpty())
                         throw illegalState("We should not query the same range from two different command stores.");
 
-                    range = range.with(mapReduceConsume.keys().overlapping(snapshot.byId(i).rangesForEpoch.all()).toRanges());
+                    range = range.with(touchedKeys.toRanges());
                 }
             }
         }

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -803,7 +803,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             if (!regainedRanges.isEmpty())
             {
                 shard.store.markUnsafeToRead(regainedRanges);
-                shard.store.markAsRetired(regainedRanges);
+                shard.store.markAsRegained(regainedRanges);
             }
 
             // TODO (desired): only sync affected shards

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -24,7 +24,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -80,6 +79,7 @@ import org.agrona.collections.Hashing;
 import org.agrona.collections.Int2IntHashMap;
 import org.agrona.collections.Int2ObjectHashMap;
 
+import static accord.primitives.AbstractRanges.UnionMode.MERGE_ADJACENT;
 import static accord.topology.EpochReady.done;
 import static accord.api.DataStore.FetchKind.Sync;
 import static accord.local.CommandStores.BootstrapRangeAction.BOOTSTRAP_NOT_NEEDED;
@@ -93,7 +93,6 @@ import static java.util.stream.Collectors.toList;
  */
 public abstract class CommandStores implements AsyncExecutorFactory
 {
-    @SuppressWarnings("unused")
     private static final Logger logger = LoggerFactory.getLogger(CommandStores.class);
 
     public interface LatentStoreSelector
@@ -127,6 +126,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
          * return null if we do not intersect this shard on the specified epochs
          */
         Ranges ranges(ShardHolder shard);
+
+        default @Nullable long minEpoch() { return -1L; };
     }
 
     public interface UnrestrictedStoreSelector extends StoreSelector
@@ -146,17 +147,25 @@ public abstract class CommandStores implements AsyncExecutorFactory
             this.maxEpoch = maxEpoch;
         }
 
+        @Override
         public StoreSelection select(Snapshot snapshot)
         {
             return StoreFinder.find(snapshot, keysOrRanges);
         }
 
+        @Override
         public @Nullable Ranges ranges(ShardHolder shard)
         {
             Ranges ranges = shard.ranges().allBetween(minEpoch, maxEpoch);
             if (ranges != shard.ranges.all() && !ranges.intersects(keysOrRanges))
                 return null;
             return ranges;
+        }
+
+        @Override
+        public long minEpoch()
+        {
+            return minEpoch;
         }
     }
 
@@ -354,22 +363,20 @@ public abstract class CommandStores implements AsyncExecutorFactory
     public static class ShardHolder
     {
         public final CommandStore store;
+        public @Nullable final Ranges regainsRanges;
         RangesForEpoch ranges;
 
-        ShardHolder(CommandStore store)
+        ShardHolder(CommandStore store, @Nullable Ranges regainsRanges)
         {
             this.store = store;
+            this.regainsRanges = regainsRanges;
         }
 
-        public ShardHolder(CommandStore store, RangesForEpoch ranges)
+        public ShardHolder(CommandStore store, RangesForEpoch ranges, @Nullable Ranges regainsRanges)
         {
             this.store = store;
+            this.regainsRanges = regainsRanges;
             this.ranges = ranges;
-        }
-
-        public ShardHolder withStoreUnsafe(CommandStore store)
-        {
-            return new ShardHolder(store, ranges);
         }
 
         public RangesForEpoch ranges()
@@ -388,12 +395,109 @@ public abstract class CommandStores implements AsyncExecutorFactory
         RangesForEpoch ranges();
     }
 
+    public static final class PreviouslyOwned
+    {
+        public static final PreviouslyOwned EMPTY = new PreviouslyOwned(0, RangesForEpoch.EMPTY.epochs, RangesForEpoch.EMPTY.ranges);
+        final long maxEpoch;
+        final long[] epochs; // the epoch upon which it was last owned
+        final Ranges[] ranges;
+
+        public PreviouslyOwned(long maxEpoch, long[] epochs, Ranges[] ranges)
+        {
+            this.maxEpoch = maxEpoch;
+            this.epochs = epochs;
+            this.ranges = ranges;
+        }
+
+        PreviouslyOwned prepend(long epoch, Ranges ranges)
+        {
+            Invariants.require(epochs.length == 0 || epoch > epochs[0]);
+            long[] newEpochs = new long[this.epochs.length + 1];
+            Ranges[] newRanges = new Ranges[this.epochs.length + 1];
+            newEpochs[0] = epoch;
+            newRanges[0] = ranges;
+            System.arraycopy(this.epochs, 0, newEpochs, 1, this.epochs.length);
+            System.arraycopy(this.ranges, 0, newRanges, 1, this.ranges.length);
+            return new PreviouslyOwned(epoch, newEpochs, newRanges);
+        }
+
+        public boolean overlaps(long epoch, Unseekables<?> test)
+        {
+            if (epoch > maxEpoch)
+                return false;
+
+            for (int i = 0 ; i < epochs.length && epoch <= epochs[i] ; ++i)
+            {
+                if (this.ranges[i].intersects(test))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private boolean overlapsDeletedCommandStore(Ranges shardRanges, long epoch, Unseekables<?> test)
+        {
+            if (epoch > maxEpoch)
+                return false;
+
+            for (int i = 0 ; i < epochs.length && epoch <= epochs[i] ; ++i)
+            {
+                if (this.ranges[i].intersects(test) && !shardRanges.containsAll(this.ranges[i].overlapping(test)))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public Ranges regains(Ranges overlapping)
+        {
+            Ranges regains = Ranges.EMPTY;
+            for (Ranges rs : this.ranges)
+                regains = regains.with(rs.slice(overlapping, Minimal));
+            return regains;
+        }
+
+        public int size()
+        {
+            return epochs.length;
+        }
+
+        public long epochs(int i)
+        {
+            return epochs[i];
+        }
+
+        public Ranges ranges(int i)
+        {
+            return ranges[i];
+        }
+
+        @Override
+        public boolean equals(Object that)
+        {
+            return that instanceof PreviouslyOwned && equals((PreviouslyOwned) that);
+        }
+
+        public boolean equals(PreviouslyOwned that)
+        {
+            return Arrays.equals(this.ranges, that.ranges)
+                   && Arrays.equals(this.epochs, that.epochs);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
     // We ONLY remove ranges to keep logic manageable; likely to only merge CommandStores into a new CommandStore via some kind of Bootstrap
     public static class RangesForEpoch
     {
+        public static final RangesForEpoch EMPTY = new RangesForEpoch(new long[0], new Ranges[0]);
+
         final long[] epochs;
         final Ranges[] ranges;
-        public static final RangesForEpoch EMPTY = new RangesForEpoch(new long[0], new Ranges[0]);
 
         public RangesForEpoch(long epoch, Ranges ranges)
         {
@@ -425,7 +529,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
             if (this == object) return true;
             if (object == null || getClass() != object.getClass()) return false;
             RangesForEpoch that = (RangesForEpoch) object;
-            return Objects.deepEquals(epochs, that.epochs) && Objects.deepEquals(ranges, that.ranges);
+            return Arrays.equals(epochs, that.epochs) && Arrays.equals(ranges, that.ranges);
         }
 
         @Override
@@ -632,15 +736,17 @@ public abstract class CommandStores implements AsyncExecutorFactory
         final Int2IntHashMap byId;
         private final int[] indexForRange;
         final SearchableRangeList lookupByRange;
+        final Ranges shardRanges;
 
-        public Snapshot(ShardHolder[] shards, Topology local, Topology global)
+        public Snapshot(ShardHolder[] shards, Topology local, Topology global, PreviouslyOwned previouslyOwned)
         {
-            super(asMap(shards), global);
+            super(asMap(shards), global, previouslyOwned);
             this.local = local;
             this.shards = shards;
             this.byId = new Int2IntHashMap(shards.length, Hashing.DEFAULT_LOAD_FACTOR, -1);
             int count = 0;
             int prevId = -1;
+            Ranges shardRanges = Ranges.EMPTY;
             for (int i = 0 ; i < shards.length ; ++i)
             {
                 ShardHolder shard = shards[i];
@@ -649,7 +755,9 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 byId.put(id, i);
                 count += shard.ranges.all().size();
                 prevId = id;
+                shardRanges = shardRanges.union(MERGE_ADJACENT, shard.ranges.all());
             }
+            this.shardRanges = shardRanges;
             class RangeAndIndex
             {
                 final Range range;
@@ -685,7 +793,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         // This method exists to ensure we do not hold references to command stores
         public Journal.TopologyUpdate asTopologyUpdate()
         {
-            return new Journal.TopologyUpdate(commandStores, global);
+            return new Journal.TopologyUpdate(commandStores, global, previouslyOwned);
         }
 
         private static Int2ObjectHashMap<CommandStores.RangesForEpoch> asMap(ShardHolder[] shards)
@@ -725,7 +833,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         this.supplier = supplier;
         this.shardDistributor = shardDistributor;
 
-        this.current = new Snapshot(new ShardHolder[0], Topology.EMPTY, Topology.EMPTY);
+        this.current = new Snapshot(new ShardHolder[0], Topology.EMPTY, Topology.EMPTY, PreviouslyOwned.EMPTY);
         this.journal = journal;
     }
 
@@ -809,6 +917,8 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
         List<Supplier<EpochReady>> bootstrapUpdates = new ArrayList<>();
         List<ShardHolder> result = new ArrayList<>(prev.shards.length + added.size());
+        PreviouslyOwned previouslyOwned = prev.previouslyOwned;
+
         for (ShardHolder shard : prev.shards)
         {
             Ranges current = shard.ranges().currentRanges();
@@ -818,8 +928,14 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 // TODO (required): This is updating the a non-volatile field in the previous Snapshot, why modify it at all, even with volatile the guaranteed visibility is weak even with mutual exclusion
                 shard.ranges = shard.ranges().withRanges(newTopology.epoch(), current.without(subtracted));
                 shard.store.epochUpdateHolder.remove(epoch, shard.ranges, removeRanges);
+
                 bootstrapUpdates.add(shard.store.unbootstrap(epoch, removeRanges));
             }
+
+            Ranges regainedRanges = shard.ranges().all().slice(added, Minimal);
+            if (!regainedRanges.isEmpty())
+                bootstrapUpdates.add(() -> EpochReady.all(epoch, shard.store.markPermanentlyUnsafeToRead(regainedRanges).beginAsResult()));
+
             // TODO (desired): only sync affected shards
             Ranges ranges = shard.ranges().currentRanges();
             // ranges can be empty when ranges are lost or consolidated across epochs.
@@ -828,6 +944,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 logger.debug("Epoch {} requires visibility sync for {}", epoch, ranges);
                 bootstrapUpdates.add(shard.store.refreshReadyToCoordinate(node, ranges, epoch));
             }
+
             result.add(shard);
         }
 
@@ -839,7 +956,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 EpochUpdateHolder updateHolder = new EpochUpdateHolder();
                 RangesForEpoch rangesForEpoch = new RangesForEpoch(epoch, addRanges);
                 updateHolder.add(epoch, rangesForEpoch, addRanges);
-                ShardHolder shard = new ShardHolder(supplier.create(nextId++, updateHolder));
+                ShardHolder shard = new ShardHolder(supplier.create(nextId++, updateHolder), previouslyOwned.regains(addRanges));
                 shard.ranges = rangesForEpoch;
 
                 Map<BootstrapRangeAction, Ranges> partitioned = addRanges.partitioningBy(range -> shouldBootstrap(node, prev.global, newLocalTopology, range), BootstrapRangeAction.class);
@@ -873,7 +990,11 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 );
             };
         }
-        return new TopologyUpdate(new Snapshot(result.toArray(new ShardHolder[0]), newLocalTopology, newTopology), bootstrap);
+
+        if (!subtracted.isEmpty())
+            previouslyOwned = previouslyOwned.prepend(epoch - 1, subtracted);
+
+        return new TopologyUpdate(new Snapshot(result.toArray(new ShardHolder[0]), newLocalTopology, newTopology, previouslyOwned), bootstrap);
     }
 
     private static boolean requiresSync(Ranges ranges, Topology oldTopology, Topology newTopology)
@@ -989,6 +1110,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
     {
         Snapshot snapshot = current;
         StoreSelection selection = selector.select(snapshot);
+        long minEpoch = selector.minEpoch();
         AsyncChain<O> chain = null;
         for (int i = selection.firstSetBit(); i >= 0 ; i = selection.nextSetBit(i + 1, -1))
         {
@@ -997,10 +1119,17 @@ public abstract class CommandStores implements AsyncExecutorFactory
             if (ranges == null)
                 continue;
 
+            if (minEpoch >= 0 && unsafelyTouchesRegainedRanges(snapshot, shard, mapReduceConsume.scope, minEpoch))
+                return AsyncChains.failure(new OverlappingCommandStoresException());
+
             AsyncChain<O> next = mapReduceConsume.applyAsync(ranges, shard.store);
             if (next != null)
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
+
+        if (minEpoch >= 0 && snapshot.previouslyOwned.overlapsDeletedCommandStore(snapshot.shardRanges, minEpoch, mapReduceConsume.scope))
+            return AsyncChains.failure(new DeletedCommandStoresException());
+
         return chain == null ? AsyncChains.success(null) : chain;
     }
 
@@ -1022,6 +1151,18 @@ public abstract class CommandStores implements AsyncExecutorFactory
         return accumulator;
     }
 
+    private static boolean unsafelyTouchesRegainedRanges(Snapshot snapshot, ShardHolder shard, Unseekables<?> unseekables, long minEpoch)
+    {
+        if (shard.regainsRanges == null)
+            return false;
+
+        unseekables = unseekables.slice(shard.regainsRanges, Minimal);
+        if (unseekables.isEmpty())
+            return false;
+
+        return snapshot.previouslyOwned.overlaps(minEpoch, unseekables);
+    }
+
     /**
      * Initialize topology from snapshot on boot.
      */
@@ -1033,19 +1174,20 @@ public abstract class CommandStores implements AsyncExecutorFactory
         int maxId = -1;
         for (Map.Entry<Integer, RangesForEpoch> e : update.commandStores.entrySet())
         {
-            Invariants.require(e.getValue() != null);
-            EpochUpdateHolder epochUpdates = new EpochUpdateHolder();
-            ShardHolder shard = new ShardHolder(supplier.create(e.getKey(), epochUpdates), e.getValue());
+            RangesForEpoch rfe = e.getValue();
+            Invariants.require(rfe != null);
+            EpochUpdateHolder holder = new EpochUpdateHolder();
+            ShardHolder shard = new ShardHolder(supplier.create(e.getKey(), holder), rfe, update.previouslyOwned.regains(rfe.currentRanges()));
             // TODO (required): if the add is necessary (highly unlikely) it needs to be done once journal is writeable so we NEED to move this
             if (!shard.ranges.equals(shard.store.rangesForEpoch))
-                epochUpdates.add(1, e.getValue(), e.getValue().all());
+                holder.add(1, e.getValue(), rfe.all());
             maxId = Math.max(maxId, e.getKey());
             shards[i++] = shard;
         }
         Arrays.sort(shards, Comparator.comparingInt(shard -> shard.store.id));
 
         nextId = maxId + 1;
-        loadSnapshot(new Snapshot(shards, update.global.forNode(supplier.node.id()).trim(), update.global));
+        loadSnapshot(new Snapshot(shards, update.global.forNode(supplier.node.id()).trim(), update.global, update.previouslyOwned));
     }
 
     public synchronized void resetTopology(Journal.TopologyUpdate update)
@@ -1057,11 +1199,11 @@ public abstract class CommandStores implements AsyncExecutorFactory
         for (Map.Entry<Integer, RangesForEpoch> e : update.commandStores.entrySet())
         {
             int storeId = e.getKey();
-            RangesForEpoch ranges = e.getValue();
-            Invariants.require(ranges != null);
-            ShardHolder shard = new ShardHolder(current.byId(storeId), ranges);
+            RangesForEpoch rfe = e.getValue();
+            Invariants.require(rfe != null);
+            ShardHolder shard = new ShardHolder(current.byId(storeId), rfe, update.previouslyOwned.regains(rfe.all()));
             EpochUpdateHolder holder = shard.store.epochUpdateHolder;
-            ranges.forEach(new BiConsumer<>()
+            rfe.forEach(new BiConsumer<>()
             {
                 RangesForEpoch accumulator = null;
                 Ranges prev = null;
@@ -1094,7 +1236,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         }
 
         nextId = maxId + 1;
-        loadSnapshot(new Snapshot(shards, current.local, current.global));
+        loadSnapshot(new Snapshot(shards, current.local, current.global, update.previouslyOwned));
     }
 
     public synchronized Supplier<EpochReady> updateTopology(Node node, Topology newTopology)
@@ -1124,6 +1266,26 @@ public abstract class CommandStores implements AsyncExecutorFactory
     protected synchronized void markShuttingDown()
     {
         shuttingDown = true;
+    }
+
+    public synchronized void removeCommandStoresBefore(long beforeEpoch)
+    {
+        List<ShardHolder> keep = new ArrayList<>(current.shards.length);
+        for (ShardHolder shard : current)
+        {
+            RangesForEpoch ranges = shard.ranges;
+            int size = ranges.size();
+            long lastEpochWithOwnedRange = ranges.epochAtIndex(size - 1) - 1;
+            if (!ranges.rangesAtIndex(size - 1).isEmpty() || lastEpochWithOwnedRange >= beforeEpoch)
+                keep.add(shard);
+        }
+
+        if (keep.size() != current.shards.length)
+        {
+            Snapshot snapshot = new Snapshot(keep.toArray(new ShardHolder[0]), current().local, current.global, current.previouslyOwned);
+            journal.saveTopology(snapshot.asTopologyUpdate(), null);
+            current = snapshot;
+        }
     }
 
     public void shutdown()
@@ -1162,10 +1324,14 @@ public abstract class CommandStores implements AsyncExecutorFactory
         return all;
     }
 
+    @Nullable
     public CommandStore forId(int id)
     {
         Snapshot snapshot = current;
-        return snapshot.shards[snapshot.byId.get(id)].store;
+        int shardIndex = snapshot.byId.get(id);
+        if (shardIndex == -1)
+            return null;
+        return snapshot.shards[shardIndex].store;
     }
 
     public int[] ids()
@@ -1198,6 +1364,12 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 return shard.store;
         }
         throw new IllegalArgumentException();
+    }
+
+    @VisibleForTesting
+    public PreviouslyOwned getPreviouslyOwnedFromSnapshot()
+    {
+        return current.previouslyOwned;
     }
 
     protected Snapshot current()

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -988,7 +988,10 @@ public abstract class CommandStores implements AsyncExecutorFactory
         }
 
         if (!checkQueryDisjointRangesAcrossCommandStores(snapshot.overlappingCommandStores, snapshot.shards, bitSet, mapReduceConsume.keys().toRanges(), StoreIterator.getMinEpoch()))
-            throw new IllegalStateException();
+        {
+            logger.info("Reject query as it tries to query {} in more than one CommandStore", mapReduceConsume.keys().toRanges().toString());
+            return AsyncChains.failure(null);
+        }
 
         return chain == null ? AsyncChains.success(null) : chain;
     }

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -18,14 +18,7 @@
 
 package accord.local;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -37,6 +30,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import accord.primitives.*;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import org.slf4j.Logger;
@@ -52,16 +46,6 @@ import accord.api.LocalListeners;
 import accord.api.ProgressLog;
 import accord.api.RoutingKey;
 import accord.local.CommandStore.EpochUpdateHolder;
-import accord.primitives.AbstractRanges;
-import accord.primitives.AbstractUnseekableKeys;
-import accord.primitives.EpochSupplier;
-import accord.primitives.Participants;
-import accord.primitives.Range;
-import accord.primitives.Ranges;
-import accord.primitives.RoutingKeys;
-import accord.primitives.Timestamp;
-import accord.primitives.TxnId;
-import accord.primitives.Unseekables;
 import accord.topology.Shard;
 import accord.topology.Topology;
 import accord.utils.IndexedQuadConsumer;
@@ -577,6 +561,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
         final Int2IntHashMap byId;
         private final int[] indexForRange;
         final SearchableRangeList lookupByRange;
+        final Map<Integer, LargeBitSet> overlappingCommandStores;
 
         public Snapshot(ShardHolder[] shards, Topology local, Topology global)
         {
@@ -625,6 +610,21 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 indexForRange[i] = rangesAndIndexes[i].index;
             }
             lookupByRange = SearchableRangeList.build(ranges);
+
+            overlappingCommandStores = new HashMap<>();
+            for (ShardHolder shard : shards)
+            {
+                overlappingCommandStores.put(shard.store.id, new LargeBitSet(shards.length));
+                for (Map.Entry<Integer, LargeBitSet> entry : overlappingCommandStores.entrySet())
+                {
+                    Integer id = entry.getKey();
+                    if (!shard.ranges().all().overlapping(shards[byId.get(id)].ranges.all()).isEmpty())
+                    {
+                        overlappingCommandStores.get(shard.store.id).set(id);
+                        entry.getValue().set(shard.store.id);
+                    }
+                }
+            }
         }
 
         // This method exists to ensure we do not hold references to command stores
@@ -759,6 +759,14 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 shard.store.epochUpdateHolder.remove(epoch, shard.ranges, removeRanges);
                 bootstrapUpdates.add(shard.store.unbootstrap(epoch, removeRanges));
             }
+
+            Ranges regainedRanges = shard.ranges().all().overlapping(added);
+            if (!regainedRanges.isEmpty())
+            {
+                shard.store.markUnsafeToRead(regainedRanges);
+                shard.store.markAsRetired(regainedRanges);
+            }
+
             // TODO (desired): only sync affected shards
             Ranges ranges = shard.ranges().currentRanges();
             // ranges can be empty when ranges are lost or consolidated across epochs.
@@ -924,17 +932,45 @@ public abstract class CommandStores implements AsyncExecutorFactory
         return mapReduce(snapshot -> commandStoreIds.mapToObj(snapshot::byId).iterator(), mapReduce);
     }
 
+    /* Do all reads and writes go through this? */
     public <O> AsyncChain<O> mapReduce(StoreSelector selector, MapReduceCommandStores<?, O> mapReduceConsume)
     {
         Snapshot snapshot = current;
         Iterator<CommandStore> stores = selector.select(snapshot);
         AsyncChain<O> chain = null;
+        LargeBitSet bitSet = new LargeBitSet(snapshot.shards.length);
         while (stores.hasNext())
         {
-            AsyncChain<O> next = mapReduceConsume.applyAsync(stores.next());
+            CommandStore store = stores.next();
+            bitSet.set(store.id());
+            AsyncChain<O> next = mapReduceConsume.applyAsync(store);
             if (next != null)
                 chain = chain != null ? AsyncChains.reduce(chain, next, mapReduceConsume) : next;
         }
+
+        // Check that we are not querying two command stores for the same range
+        for (Map.Entry<Integer, LargeBitSet> entry : snapshot.overlappingCommandStores.entrySet())
+        {
+            List<Integer> overlapping = new ArrayList<>();
+            LargeBitSet overlappingCommandStores = entry.getValue();
+            for (int i = overlappingCommandStores.firstSetBit(); i >= 0 ; i = overlappingCommandStores.nextSetBit(i + 1, -1))
+            {
+                if (bitSet.get(i))
+                    overlapping.add(i);
+            }
+
+            Ranges range = Ranges.EMPTY;
+            for (Integer id : overlapping)
+            {
+                Unseekables<?> touchedKeys = mapReduceConsume.keys().overlapping(snapshot.byId(id).rangesForEpoch.all());
+                if (!range.overlapping(touchedKeys).isEmpty())
+                {
+                    throw illegalState("We should not query the same range from two different command stores.");
+                }
+                range = range.with(mapReduceConsume.keys().overlapping(snapshot.byId(id).rangesForEpoch.all()).toRanges());
+            }
+        }
+
         return chain == null ? AsyncChains.success(null) : chain;
     }
 

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -789,25 +789,6 @@ public abstract class CommandStores implements AsyncExecutorFactory
 
         for (ShardHolder shard : prev.shards)
         {
-            // Remove shard if RangesForEpoch is fully retired
-            try
-            {
-                if (shard.retirementEpoch != null && node.topology().active().get(shard.retirementEpoch).retired().containsAll(shard.ranges().allAt(shard.retirementEpoch)))
-                {
-                    previouslyOwnedRanges.put(shard.store.id(), shard.ranges);
-                    continue;
-                }
-            }
-            catch (TopologyRetiredException e)
-            {
-                previouslyOwnedRanges.put(shard.store.id(), shard.ranges);
-                continue;
-            }
-            catch (TopologyException e)
-            {
-                throw new IllegalStateException();
-            }
-
             Ranges current = shard.ranges().currentRanges();
             Ranges removeRanges = subtracted.slice(current, Minimal);
             if (!removeRanges.isEmpty())
@@ -816,7 +797,7 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 shard.ranges = shard.ranges().withRanges(newTopology.epoch(), current.without(subtracted));
                 if (shard.ranges.ranges[shard.ranges.size() - 1].isEmpty())
                 {
-                    shard.retirementEpoch = shard.ranges.epochs[shard.ranges.size() - 1];
+                    shard.retirementEpoch = shard.ranges.epochs[shard.ranges.size() - 1] - 1;
                 }
                 shard.store.epochUpdateHolder.remove(epoch, shard.ranges, removeRanges);
                 bootstrapUpdates.add(shard.store.unbootstrap(epoch, removeRanges));
@@ -837,6 +818,25 @@ public abstract class CommandStores implements AsyncExecutorFactory
                 logger.debug("Epoch {} requires visibility sync for {}", epoch, ranges);
                 bootstrapUpdates.add(shard.store.refreshReadyToCoordinate(node, ranges, epoch));
             }
+
+            try
+            {
+                if (shard.retirementEpoch != null && node.topology().active().get(shard.retirementEpoch).retired().containsAll(shard.ranges().allAt(shard.retirementEpoch)))
+                {
+                    previouslyOwnedRanges.put(shard.store.id(), shard.ranges);
+                    continue;
+                }
+            }
+            catch (TopologyRetiredException e)
+            {
+                previouslyOwnedRanges.put(shard.store.id(), shard.ranges);
+                continue;
+            }
+            catch (TopologyException e)
+            {
+                throw new IllegalStateException();
+            }
+
             result.add(shard);
         }
 

--- a/accord-core/src/main/java/accord/local/DeletedCommandStoresException.java
+++ b/accord-core/src/main/java/accord/local/DeletedCommandStoresException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.local;
+
+import accord.utils.Rethrowable;
+
+public class DeletedCommandStoresException extends RuntimeException implements Rethrowable<DeletedCommandStoresException>
+{
+    public DeletedCommandStoresException()
+    {
+    }
+
+    private DeletedCommandStoresException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    @Override
+    public DeletedCommandStoresException rethrowable()
+    {
+        return new DeletedCommandStoresException(this);
+    }
+}

--- a/accord-core/src/main/java/accord/local/Node.java
+++ b/accord-core/src/main/java/accord/local/Node.java
@@ -765,7 +765,7 @@ public class Node implements NodeCommandStoreService
     public AsyncChain<Void> updateMinHlc(long minHlc)
     {
         // TODO (required): command stores that are not ready due to bootstrap need to refresh their min HLC on bootstrap completion
-        StoreSelector selector = snapshot -> Stream.of(snapshot.shards).map(sh -> sh.store).iterator();
+        StoreSelector selector = snapshot -> new CommandStores.StoreIterator(Stream.of(snapshot.shards).map(sh -> sh.store).iterator(), null);
         return commandStores().mapReduce(selector, new MapReduceCommandStores<>(RoutingKeys.EMPTY)
         {
             @Override public Void reduce(Void o1, Void o2) { return null; }

--- a/accord-core/src/main/java/accord/local/OverlappingCommandStoresException.java
+++ b/accord-core/src/main/java/accord/local/OverlappingCommandStoresException.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accord.local;
+
+import accord.utils.Rethrowable;
+
+public class OverlappingCommandStoresException extends RuntimeException implements Rethrowable<OverlappingCommandStoresException>
+{
+    public OverlappingCommandStoresException()
+    {
+    }
+
+    private OverlappingCommandStoresException(Throwable cause)
+    {
+        super(cause);
+    }
+
+    @Override
+    public OverlappingCommandStoresException rethrowable()
+    {
+        return new OverlappingCommandStoresException(this);
+    }
+}

--- a/accord-core/src/main/java/accord/local/SafeCommandStore.java
+++ b/accord-core/src/main/java/accord/local/SafeCommandStore.java
@@ -33,6 +33,7 @@ import accord.api.DataStore;
 import accord.api.LocalListeners;
 import accord.api.ProgressLog;
 import accord.api.RoutingKey;
+import accord.local.CommandStores.RangesForEpoch;
 import accord.local.CommandStores.RangesForEpochSupplier;
 import accord.local.RedundantBefore.RedundantBeforeSupplier;
 import accord.local.cfk.CommandsForKey;
@@ -557,7 +558,7 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
         if (safeCommand != null && safeCommand.current().known().route() != MaybeRoute)
             return;
 
-        CommandStores.RangesForEpoch rangesForEpoch = safeStore.ranges();
+        RangesForEpoch rangesForEpoch = safeStore.ranges();
         // TODO (required): this is incompatible with rebootstrap - we need to use some additional condition
         witnessedBy = witnessedBy.without(rangesForEpoch.coordinates(txnId));  // already coordinates, no need to replicate
         if (witnessedBy.isEmpty())
@@ -601,6 +602,11 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
         commandStore().unsafeSetSafeToRead(newSafeToRead);
     }
 
+    public void setPermanentlyUnsafeToRead(Ranges newPermanentlyUnsafeToRead)
+    {
+        commandStore().unsafeSetPermanentlyUnsafeToRead(newPermanentlyUnsafeToRead);
+    }
+
     public void setRangesForEpoch(CommandStores.RangesForEpoch rangesForEpoch)
     {
         commandStore().unsafeSetRangesForEpoch(rangesForEpoch);
@@ -613,7 +619,7 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
     public abstract Agent agent();
     public abstract ProgressLog progressLog();
     public abstract NodeCommandStoreService node();
-    public abstract CommandStores.RangesForEpoch ranges();
+    public abstract RangesForEpoch ranges();
 
     protected NavigableMap<TxnId, Ranges> bootstrapBeganAt()
     {

--- a/accord-core/src/main/java/accord/local/SafeCommandStore.java
+++ b/accord-core/src/main/java/accord/local/SafeCommandStore.java
@@ -384,6 +384,11 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
         commandStore().unsafeSetSafeToRead(newSafeToRead);
     }
 
+    public void addToRetiredRanges(Ranges newRetiredRange)
+    {
+        commandStore().unsafeAddToRetiredRanges(newRetiredRange);
+    }
+
     public void setRangesForEpoch(CommandStores.RangesForEpoch rangesForEpoch)
     {
         commandStore().unsafeSetRangesForEpoch(rangesForEpoch);

--- a/accord-core/src/main/java/accord/local/SafeCommandStore.java
+++ b/accord-core/src/main/java/accord/local/SafeCommandStore.java
@@ -384,9 +384,9 @@ public abstract class SafeCommandStore implements RangesForEpochSupplier, Redund
         commandStore().unsafeSetSafeToRead(newSafeToRead);
     }
 
-    public void addToRetiredRanges(Ranges newRetiredRange)
+    public void addToRegainedRanges(Ranges newRegainedRanges)
     {
-        commandStore().unsafeAddToRetiredRanges(newRetiredRange);
+        commandStore().unsafeAddToRegainedRanges(newRegainedRanges);
     }
 
     public void setRangesForEpoch(CommandStores.RangesForEpoch rangesForEpoch)

--- a/accord-core/src/main/java/accord/topology/ActiveEpoch.java
+++ b/accord-core/src/main/java/accord/topology/ActiveEpoch.java
@@ -44,9 +44,9 @@ public final class ActiveEpoch
 
     final QuorumTracker quorumReadyTracker;
     final SimpleBitSet shardQuorumReady, receivedNodeReady;
-    private Ranges quorumReady;
+    private volatile Ranges quorumReady;
 
-    private Ranges closed = Ranges.EMPTY, retired = Ranges.EMPTY;
+    private volatile Ranges closed = Ranges.EMPTY, retired = Ranges.EMPTY;
     private volatile boolean allRetired;
 
     public boolean allRetired()

--- a/accord-core/src/main/java/accord/topology/ActiveEpochs.java
+++ b/accord-core/src/main/java/accord/topology/ActiveEpochs.java
@@ -61,19 +61,34 @@ public final class ActiveEpochs implements Iterable<ActiveEpoch>
     // Epochs are sorted in _descending_ order
     final ActiveEpoch[] epochs;
 
-    ActiveEpochs(TopologyManager manager, ActiveEpoch[] epochs, long prevFirstNonEmptyEpoch)
+    private ActiveEpochs(TopologyManager manager, ActiveEpoch[] epochs, long firstNonEmptyEpoch)
     {
         this.manager = manager;
         this.currentEpoch = epochs.length > 0 ? epochs[0].epoch() : 0;
-        if (prevFirstNonEmptyEpoch != -1)
-            this.firstNonEmptyEpoch = prevFirstNonEmptyEpoch;
-        else if (epochs.length > 0 && !epochs[0].all().isEmpty())
-            this.firstNonEmptyEpoch = currentEpoch;
-        else
-            this.firstNonEmptyEpoch = prevFirstNonEmptyEpoch;
-
+        this.firstNonEmptyEpoch = firstNonEmptyEpoch;
+        this.epochs = epochs;
         for (int i = 1; i < epochs.length; i++)
             Invariants.requireArgument(epochs[i].epoch() == epochs[i - 1].epoch() - 1);
+    }
+
+    static ActiveEpochs empty(TopologyManager manager)
+    {
+        return new ActiveEpochs(manager, new ActiveEpoch[0], -1);
+    }
+
+    ActiveEpochs withNewEpochs(ActiveEpoch[] epochs)
+    {
+        long firstNonEmptyEpoch = this.firstNonEmptyEpoch;
+        if (firstNonEmptyEpoch == -1 && epochs.length > 0 && !epochs[0].all().isEmpty())
+        {
+            Invariants.require(epochs.length == 1);
+            firstNonEmptyEpoch = epochs[0].epoch();
+        }
+        return new ActiveEpochs(manager, epochs, firstNonEmptyEpoch);
+    }
+
+    ActiveEpochs maybeTruncate()
+    {
         int truncateFrom = -1;
         // > 0 because we do not want to be left without epochs in case they're all empty
         for (int i = epochs.length - 1; i > 0; i--)
@@ -85,28 +100,26 @@ public final class ActiveEpochs implements Iterable<ActiveEpoch>
         }
 
         if (truncateFrom == -1)
+            return this;
+
+        ActiveEpoch[] newEpochs = Arrays.copyOf(epochs, truncateFrom);
+        for (int i = truncateFrom; i < epochs.length; i++)
         {
-            this.epochs = epochs;
+            ActiveEpoch e = epochs[i];
+            Invariants.require(epochs[i].isQuorumReady());
+            logger.info("Retired epoch {} with added/removed ranges {}/{}. Topology: {}. Closed: {}", e.epoch(), e.addedRanges, e.removedRanges, e.all.ranges, e.closed());
         }
-        else
+        if (logger.isTraceEnabled())
         {
-            this.epochs = Arrays.copyOf(epochs, truncateFrom);
-            for (int i = truncateFrom; i < epochs.length; i++)
+            for (int i = 0; i < truncateFrom; i++)
             {
                 ActiveEpoch e = epochs[i];
-                Invariants.require(epochs[i].isQuorumReady());
-                logger.info("Retired epoch {} with added/removed ranges {}/{}. Topology: {}. Closed: {}", e.epoch(), e.addedRanges, e.removedRanges, e.all.ranges, e.closed());
-            }
-            if (logger.isTraceEnabled())
-            {
-                for (int i = 0; i < truncateFrom; i++)
-                {
-                    ActiveEpoch e = epochs[i];
-                    Invariants.require(e.isQuorumReady());
-                    logger.trace("Leaving epoch {} with added/removed ranges {}/{}", e.epoch(), e.addedRanges, e.removedRanges);
-                }
+                Invariants.require(e.isQuorumReady());
+                logger.trace("Leaving epoch {} with added/removed ranges {}/{}", e.epoch(), e.addedRanges, e.removedRanges);
             }
         }
+
+        return withNewEpochs(newEpochs);
     }
 
     public boolean isEmpty()

--- a/accord-core/src/main/java/accord/topology/Topology.java
+++ b/accord-core/src/main/java/accord/topology/Topology.java
@@ -765,6 +765,23 @@ public class Topology
             forEach.accept(shards[i]);
     }
 
+    public static Map<Id, Ranges> computeNodeAdditions(Topology current, Topology next)
+    {
+        Map<Id, Ranges> additions = new HashMap<>();
+        for (Id node : next.nodes())
+        {
+            Ranges prev = current.rangesForNode(node);
+            if (prev == null) prev = Ranges.EMPTY;
+
+            Ranges added = next.rangesForNode(node).without(prev);
+            if (added.isEmpty())
+                continue;
+
+            additions.put(node, added);
+        }
+        return additions;
+    }
+
     public SortedArrayList<Id> nodes()
     {
         return nodes;

--- a/accord-core/src/main/java/accord/topology/Topology.java
+++ b/accord-core/src/main/java/accord/topology/Topology.java
@@ -766,6 +766,23 @@ public class Topology
             forEach.accept(shards[i]);
     }
 
+    public static Map<Id, Ranges> computeNodeAdditions(Topology current, Topology next)
+    {
+        Map<Id, Ranges> additions = new HashMap<>();
+        for (Id node : next.nodes())
+        {
+            Ranges prev = current.rangesForNode(node);
+            if (prev == null) prev = Ranges.EMPTY;
+
+            Ranges added = next.rangesForNode(node).without(prev);
+            if (added.isEmpty())
+                continue;
+
+            additions.put(node, added);
+        }
+        return additions;
+    }
+
     public SortedArrayList<Id> nodes()
     {
         return nodes;

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -357,7 +357,7 @@ public class TopologyManager
         }
 
         if (greatestEpoch != -1)
-            return new regainingEpochRange(greatestEpoch, range);
+            return new RegainingEpochRange(greatestEpoch, range);
 
         return null;
     }

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -197,6 +197,7 @@ public class TopologyManager
             if (epoch > active.currentEpoch)
                 ranges = pending.retired(ranges, epoch);
             ranges = active.retired(ranges, epoch);
+            notify();
         }
         if (!ranges.isEmpty())
         {

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -312,12 +312,12 @@ public class TopologyManager
         updateActive();
     }
 
-    public static class regainingEpochRange
+    public static class RegainingEpochRange
     {
         public final long epoch;
         public final Ranges range;
 
-        public regainingEpochRange(long epoch, Ranges range)
+        public RegainingEpochRange(long epoch, Ranges range)
         {
             this.epoch = epoch;
             this.range = range;
@@ -335,7 +335,7 @@ public class TopologyManager
     }
 
     @Nullable
-    public regainingEpochRange epochAndRangeToBeRetired(Topology curr, Topology next)
+    public RegainingEpochRange epochAndRangeToBeRetired(Topology curr, Topology next)
     {
         Map<Id, Ranges> additions = Topology.computeNodeAdditions(curr, next);
         long greatestEpoch = -1;

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -19,6 +19,7 @@
 package accord.topology;
 
 import java.util.IdentityHashMap;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -51,6 +52,9 @@ import accord.utils.async.AsyncChains;
 import accord.utils.async.AsyncResult;
 import accord.utils.async.AsyncResults;
 import accord.utils.async.NestedAsyncResult;
+
+import static accord.primitives.AbstractRanges.UnionMode.MERGE_ADJACENT;
+import static accord.primitives.Routables.Slice.Minimal;
 
 /**
  * Manages topology state changes and update bookkeeping
@@ -99,7 +103,7 @@ public class TopologyManager
         this.time = time;
         this.timeouts = timeouts;
         this.topologyService = topologyService;
-        this.active = new ActiveEpochs(this, new ActiveEpoch[0], -1);
+        this.active = ActiveEpochs.empty(this);
         this.pending = new PendingEpochs(this);
     }
 
@@ -169,6 +173,7 @@ public class TopologyManager
 
     private void onEpochRetired(Ranges ranges, long epoch, @Nullable TxnId txnId)
     {
+        long removeCommandStoresBefore = 0;
         Topology topology = null;
         synchronized (this)
         {
@@ -193,28 +198,20 @@ public class TopologyManager
             if (epoch > active.currentEpoch)
                 ranges = pending.retired(ranges, epoch);
             ranges = active.retired(ranges, epoch);
+            ActiveEpochs truncated = active.maybeTruncate();
+            if (truncated != active)
+            {
+                active = truncated;
+                removeCommandStoresBefore = truncated.minEpoch();
+            }
         }
         if (!ranges.isEmpty())
         {
             for (TopologyListener listener : listeners)
                 listener.onEpochRetired(ranges, epoch, topology);
         }
-    }
-
-    public synchronized void truncateTopologiesUntil(long epoch)
-    {
-        ActiveEpochs current = active;
-        Invariants.requireArgument(current.epoch() >= epoch, "Unable to truncate; epoch %d is > current epoch %d", epoch, current.epoch());
-
-        if (current.minEpoch() >= epoch)
-            return;
-
-        int newLen = current.epochs.length - (int) (epoch - current.minEpoch());
-        Invariants.require(current.epochs[newLen - 1].isQuorumReady(), "Epoch %d is not ready to coordinate", current.epochs[newLen - 1].epoch());
-
-        ActiveEpoch[] nextEpochs = new ActiveEpoch[newLen];
-        System.arraycopy(current.epochs, 0, nextEpochs, 0, newLen);
-        active = new ActiveEpochs(this, nextEpochs, current.firstNonEmptyEpoch);
+        if (removeCommandStoresBefore > 0)
+            node.commandStores().removeCommandStoresBefore(removeCommandStoresBefore);
     }
 
     public TopologySorter.Supplier sorter()
@@ -308,6 +305,63 @@ public class TopologyManager
         updateActive();
     }
 
+    public static class RegainingEpochRange
+    {
+        public final long epoch;
+        public final Ranges ranges;
+
+        public RegainingEpochRange(long epoch, Ranges ranges)
+        {
+            this.epoch = epoch;
+            this.ranges = ranges;
+        }
+
+        public long epoch()
+        {
+            return epoch;
+        }
+
+        public Ranges ranges()
+        {
+            return ranges;
+        }
+    }
+
+    @Nullable
+    public RegainingEpochRange computeRegaining(Topology current, Topology next)
+    {
+        Map<Id, Ranges> additions = Topology.computeNodeAdditions(current, next);
+        long greatestEpoch = -1;
+        Ranges ranges = Ranges.EMPTY;
+
+        ActiveEpochs active = this.active;
+        for (Map.Entry<Id, Ranges> entry : additions.entrySet())
+        {
+            Ranges addingForNode = entry.getValue();
+            for (ActiveEpoch e : active)
+            {
+                addingForNode = addingForNode.without(e.removedRanges).without(e.retired());
+                if (addingForNode.isEmpty())
+                    break;
+
+                Ranges existingForNode = e.all().rangesForNode(entry.getKey());
+                Ranges regainingForNode = addingForNode.slice(existingForNode, Minimal);
+                if (!regainingForNode.isEmpty())
+                {
+                    greatestEpoch = Math.max(greatestEpoch, e.epoch());
+                    ranges = ranges.union(MERGE_ADJACENT, regainingForNode);
+                    addingForNode = addingForNode.without(regainingForNode);
+                }
+                addingForNode = addingForNode.without(e.addedRanges);
+            }
+        }
+
+        if (greatestEpoch != -1)
+            return new RegainingEpochRange(greatestEpoch, ranges);
+
+        return null;
+    }
+
     private final AtomicBoolean updatingActive = new AtomicBoolean();
     private void updateActive()
     {
@@ -376,7 +430,7 @@ public class TopologyManager
                         }
                     }
 
-                    this.active = new ActiveEpochs(this, next, prev.firstNonEmptyEpoch);
+                    this.active = prev.withNewEpochs(next);
                     this.pending.removeFirst(topology.epoch);
                 }
 

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -197,7 +197,6 @@ public class TopologyManager
             if (epoch > active.currentEpoch)
                 ranges = pending.retired(ranges, epoch);
             ranges = active.retired(ranges, epoch);
-            notify();
         }
         if (!ranges.isEmpty())
         {
@@ -286,62 +285,6 @@ public class TopologyManager
     protected Executor executor()
     {
         return Runnable::run;
-    }
-
-    public static Map<Id, Ranges> getAdditions(Topology current, Topology next)
-    {
-        Map<Id, Ranges> additions = new HashMap<>();
-        for (Id node : next.nodes())
-        {
-            Ranges prev = current.rangesForNode(node);
-            if (prev == null) prev = Ranges.EMPTY;
-
-            Ranges added = next.rangesForNode(node).without(prev);
-            if (added.isEmpty())
-                continue;
-
-            additions.put(node, added);
-        }
-        return additions;
-    }
-
-    public List<Long> epochsWeAreRegainingRangesFor(Topology curr, Topology next)
-    {
-        ArrayList<Long> epochs = new ArrayList<>();
-
-        synchronized (this)
-        {
-            Map<Id, Ranges> additions = getAdditions(curr, next);
-            for (Map.Entry<Id, Ranges> entry : additions.entrySet())
-            {
-                for (ActiveEpoch activeEpoch : this.active) {
-                    if (activeEpoch.all().rangesForNode(entry.getKey()).intersects(entry.getValue()))
-                        epochs.add(activeEpoch.epoch());
-                }
-            }
-        }
-
-        return epochs;
-    }
-
-    public void blockUntilAllEpochsRetired(List<Long> epochs)
-    {
-        try
-        {
-            int index = 0;
-            synchronized (this)
-            {
-                while (index != epochs.size())
-                {
-                    for (int i = index; i < epochs.size(); i++)
-                        if (this.active.get(epochs.get(i)).allRetired())
-                            index += 1;
-                    wait();
-                }
-            }
-        } catch (Throwable t) {
-            logger.error("Uncaught exception", t);
-        }
     }
 
     public void reportTopology(Topology topology)

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -18,7 +18,11 @@
 
 package accord.topology;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -18,11 +18,8 @@
 
 package accord.topology;
 
-import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.Map;
-import java.util.HashMap;
-import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -31,6 +28,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
+import accord.primitives.Routables;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,6 +53,8 @@ import accord.utils.async.AsyncChains;
 import accord.utils.async.AsyncResult;
 import accord.utils.async.AsyncResults;
 import accord.utils.async.NestedAsyncResult;
+
+import static accord.primitives.AbstractRanges.UnionMode.MERGE_ADJACENT;
 
 /**
  * Manages topology state changes and update bookkeeping
@@ -310,6 +310,56 @@ public class TopologyManager
             listener.onReceived(topology);
 
         updateActive();
+    }
+
+    public static class regainingEpochRange
+    {
+        public final long epoch;
+        public final Ranges range;
+
+        public regainingEpochRange(long epoch, Ranges range)
+        {
+            this.epoch = epoch;
+            this.range = range;
+        }
+
+        public long epoch()
+        {
+            return epoch;
+        }
+
+        public Ranges range()
+        {
+            return range;
+        }
+    }
+
+    @Nullable
+    public regainingEpochRange epochAndRangeToBeRetired(Topology curr, Topology next)
+    {
+        Map<Id, Ranges> additions = Topology.computeNodeAdditions(curr, next);
+        long greatestEpoch = -1;
+        Ranges range = Ranges.EMPTY;
+
+        synchronized (this)
+        {
+            for (Map.Entry<Id, Ranges> entry : additions.entrySet())
+            {
+                for (ActiveEpoch activeEpoch : this.active) {
+                    if (activeEpoch.all().rangesForNode(entry.getKey()).intersects(entry.getValue()) && greatestEpoch < activeEpoch.epoch())
+                    {
+                        greatestEpoch = activeEpoch.epoch();
+                        range = range.union(MERGE_ADJACENT, activeEpoch.all().rangesForNode(entry.getKey()).slice(entry.getValue(), Routables.Slice.Minimal));
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (greatestEpoch != -1)
+            return new regainingEpochRange(greatestEpoch, range);
+
+        return null;
     }
 
     private final AtomicBoolean updatingActive = new AtomicBoolean();

--- a/accord-core/src/main/java/accord/topology/TopologyManager.java
+++ b/accord-core/src/main/java/accord/topology/TopologyManager.java
@@ -18,7 +18,7 @@
 
 package accord.topology;
 
-import java.util.IdentityHashMap;
+import java.util.*;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -281,6 +281,62 @@ public class TopologyManager
     protected Executor executor()
     {
         return Runnable::run;
+    }
+
+    public static Map<Id, Ranges> getAdditions(Topology current, Topology next)
+    {
+        Map<Id, Ranges> additions = new HashMap<>();
+        for (Id node : next.nodes())
+        {
+            Ranges prev = current.rangesForNode(node);
+            if (prev == null) prev = Ranges.EMPTY;
+
+            Ranges added = next.rangesForNode(node).without(prev);
+            if (added.isEmpty())
+                continue;
+
+            additions.put(node, added);
+        }
+        return additions;
+    }
+
+    public List<Long> epochsWeAreRegainingRangesFor(Topology curr, Topology next)
+    {
+        ArrayList<Long> epochs = new ArrayList<>();
+
+        synchronized (this)
+        {
+            Map<Id, Ranges> additions = getAdditions(curr, next);
+            for (Map.Entry<Id, Ranges> entry : additions.entrySet())
+            {
+                for (ActiveEpoch activeEpoch : this.active) {
+                    if (activeEpoch.all().rangesForNode(entry.getKey()).intersects(entry.getValue()))
+                        epochs.add(activeEpoch.epoch());
+                }
+            }
+        }
+
+        return epochs;
+    }
+
+    public void blockUntilAllEpochsRetired(List<Long> epochs)
+    {
+        try
+        {
+            int index = 0;
+            synchronized (this)
+            {
+                while (index != epochs.size())
+                {
+                    for (int i = index; i < epochs.size(); i++)
+                        if (this.active.get(epochs.get(i)).allRetired())
+                            index += 1;
+                    wait();
+                }
+            }
+        } catch (Throwable t) {
+            logger.error("Uncaught exception", t);
+        }
     }
 
     public void reportTopology(Topology topology)

--- a/accord-core/src/test/java/accord/impl/basic/DelayedCommandStores.java
+++ b/accord-core/src/test/java/accord/impl/basic/DelayedCommandStores.java
@@ -18,14 +18,7 @@
 
 package accord.impl.basic;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -65,6 +58,7 @@ import accord.utils.RandomSource;
 import accord.utils.async.AsyncChain;
 import accord.utils.async.AsyncChains;
 import accord.utils.async.Cancellable;
+import org.agrona.collections.Int2ObjectHashMap;
 
 import static accord.api.Journal.CommandUpdate;
 import static accord.utils.Invariants.Paranoia.LINEAR;
@@ -105,7 +99,7 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
         }
         Arrays.sort(shards, Comparator.comparingInt(shard -> shard.store.id()));
 
-        loadSnapshot(new Snapshot(shards, lastUpdate.global.forNode(nodeId()).trim(), lastUpdate.global));
+        loadSnapshot(new Snapshot(shards, lastUpdate.global.forNode(nodeId()).trim(), lastUpdate.global, new Int2ObjectHashMap<>()));
     }
 
     protected void loadSnapshot(Snapshot nextSnapshot)

--- a/accord-core/src/test/java/accord/impl/basic/DelayedCommandStores.java
+++ b/accord-core/src/test/java/accord/impl/basic/DelayedCommandStores.java
@@ -85,6 +85,7 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
 
     public void validateShardStateForTesting(Journal.TopologyUpdate lastUpdate)
     {
+        PreviouslyOwned previouslyOwned = lastUpdate.previouslyOwned;
         ShardHolder[] shards = new ShardHolder[lastUpdate.commandStores.size()];
         int i = 0;
         for (Map.Entry<Integer, RangesForEpoch> e : lastUpdate.commandStores.entrySet())
@@ -92,20 +93,26 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
             Snapshot current = current();
             RangesForEpoch ranges = e.getValue();
             DelayedCommandStore commandStore = null;
+            Ranges regainingRanges = null;
             for (ShardHolder shard : current)
             {
                 if (shard.ranges().equals(ranges))
+                {
+                    Invariants.require(commandStore == null);
                     commandStore = (DelayedCommandStore) shard.store;
+                    regainingRanges = shard.regainsRanges;
+                }
             }
             Invariants.nonNull(commandStore, "Each set of ranges should have a corresponding command store, but %d did not:(%s)",
                                ranges, Arrays.toString(shards))
                       .restore();
-            ShardHolder shard = new ShardHolder(commandStore, e.getValue());
+            Invariants.require(previouslyOwned.regains(ranges.currentRanges()).equals(regainingRanges));
+            ShardHolder shard = new ShardHolder(commandStore, ranges, previouslyOwned.regains(ranges.currentRanges()));
             shards[i++] = shard;
         }
         Arrays.sort(shards, Comparator.comparingInt(shard -> shard.store.id()));
 
-        loadSnapshot(new Snapshot(shards, lastUpdate.global.forNode(nodeId()).trim(), lastUpdate.global));
+        loadSnapshot(new Snapshot(shards, lastUpdate.global.forNode(nodeId()).trim(), lastUpdate.global, lastUpdate.previouslyOwned));
     }
 
     protected void loadSnapshot(Snapshot nextSnapshot)
@@ -137,6 +144,12 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
             {
                 RangesForEpoch orig = prev.unsafeGetRangesForEpoch();
                 RangesForEpoch loaded = next.unsafeGetRangesForEpoch();
+                Invariants.require(orig.equals(loaded), "%s should equal %s", loaded, orig);
+            }
+
+            {
+                Ranges orig = prev.unsafeGetPermanentlyUnsafeToRead();
+                Ranges loaded = next.unsafeGetPermanentlyUnsafeToRead();
                 Invariants.require(orig.equals(loaded), "%s should equal %s", loaded, orig);
             }
         }
@@ -258,8 +271,20 @@ public class DelayedCommandStores extends InMemoryCommandStores.SingleThread
             }
         }
 
+        @Override
+        protected void loadPermanentlyUnsafeToRead(Ranges newPermanentlyUnsafeToRead)
+        {
+            if (newPermanentlyUnsafeToRead == null) Invariants.require(super.permanentlyUnsafeToRead.isEmpty());
+            else
+            {
+                unsafeClearPermanentlyUnsafeToRead();
+                super.loadPermanentlyUnsafeToRead(newPermanentlyUnsafeToRead);
+            }
+        }
+
         public void restore()
         {
+            loadPermanentlyUnsafeToRead(journal.loadPermanentlyUnsafeToRead(id()));
             loadRangesForEpoch(journal.loadRangesForEpoch(id()));
             loadRedundantBefore(journal.loadRedundantBefore(id()));
             loadBootstrapBeganAt(journal.loadBootstrapBeganAt(id()));

--- a/accord-core/src/test/java/accord/impl/basic/InMemoryJournal.java
+++ b/accord-core/src/test/java/accord/impl/basic/InMemoryJournal.java
@@ -262,6 +262,11 @@ public class InMemoryJournal implements Journal
     @Override
     public void saveTopology(TopologyUpdate topologyUpdate, Runnable onFlush)
     {
+        // Ensure that we only read the latest topologyUpdate as that is what happens in the
+        // C* implementation
+        int lastIndex = topologyUpdates.size() - 1;
+        if (!topologyUpdates.isEmpty() && topologyUpdates.get(lastIndex).global.equals(topologyUpdate.global))
+            topologyUpdates.remove(lastIndex);
         topologyUpdates.add(topologyUpdate);
         if (onFlush != null)
             onFlush.run();
@@ -316,6 +321,15 @@ public class InMemoryJournal implements Journal
     }
 
     @Override
+    public Ranges loadPermanentlyUnsafeToRead(int commandStoreId)
+    {
+        FieldUpdates fieldStates = this.fieldStates.get(commandStoreId);
+        if (fieldStates == null)
+            return null;
+        return fieldStates.newPermanentlyUnsafeToRead;
+    }
+
+    @Override
     public PersistentField.Persister<DurableBefore, DurableBefore> durableBeforePersister()
     {
         return DurableBefore.NOOP_PERSISTER;
@@ -329,6 +343,7 @@ public class InMemoryJournal implements Journal
             init.newRedundantBefore = RedundantBefore.EMPTY;
             init.newBootstrapBeganAt = ImmutableSortedMap.of(TxnId.NONE, Ranges.EMPTY);
             init.newSafeToRead = ImmutableSortedMap.of(Timestamp.NONE, Ranges.EMPTY);
+            init.newPermanentlyUnsafeToRead = Ranges.EMPTY;
             return init;
         });
 
@@ -340,6 +355,8 @@ public class InMemoryJournal implements Journal
             fieldStates.newBootstrapBeganAt = fieldUpdates.newBootstrapBeganAt;
         if (fieldUpdates.newRangesForEpoch != null)
             fieldStates.newRangesForEpoch = fieldUpdates.newRangesForEpoch;
+        if (fieldUpdates.newPermanentlyUnsafeToRead != null)
+            fieldStates.newPermanentlyUnsafeToRead = fieldUpdates.newPermanentlyUnsafeToRead;
 
         if (onFlush!= null)
             onFlush.run();
@@ -634,6 +651,10 @@ public class InMemoryJournal implements Journal
             Map<TxnId, List<Diff>> diffs = new TreeMap<>();
 
             InMemoryCommandStore commandStore = (InMemoryCommandStore) commandStores.forId(commandStoreId);
+
+            if (commandStore == null)
+                continue;
+
             Replayer replayer = commandStore.replayer(PART_NON_DURABLE);
 
             for (Map.Entry<TxnId, Diffs> e : diffEntry.getValue().entrySet())

--- a/accord-core/src/test/java/accord/impl/basic/LoggingJournal.java
+++ b/accord-core/src/test/java/accord/impl/basic/LoggingJournal.java
@@ -166,6 +166,12 @@ public class LoggingJournal implements Journal
     }
 
     @Override
+    public Ranges loadPermanentlyUnsafeToRead(int store)
+    {
+        return delegate.loadPermanentlyUnsafeToRead(store);
+    }
+
+    @Override
     public PersistentField.Persister<DurableBefore, DurableBefore> durableBeforePersister()
     {
         return delegate.durableBeforePersister();

--- a/accord-core/src/test/java/accord/impl/list/ListAgent.java
+++ b/accord-core/src/test/java/accord/impl/list/ListAgent.java
@@ -47,12 +47,7 @@ import accord.impl.InMemoryCommandStore.Snapshot;
 import accord.impl.basic.NodeSink;
 import accord.impl.basic.SimulatedFault;
 import accord.impl.mock.Network;
-import accord.local.CommandStore;
-import accord.local.Node;
-import accord.local.PreLoadContext;
-import accord.local.LogUnavailableException;
-import accord.local.SafeCommandStore;
-import accord.local.TimeService;
+import accord.local.*;
 import accord.messages.MessageType;
 import accord.primitives.Ballot;
 import accord.primitives.Keys;
@@ -173,7 +168,7 @@ public class ListAgent implements InMemoryAgent, CoordinatorEventListener, Owner
         ownershipEventListener.onFailedBootstrap(attempt, phase, ranges, retry, fail, failure);
     }
 
-    private static final Set<Class<?>> expectedExceptions = new HashSet<>(Arrays.asList(SimulatedFault.class, ExecuteSyncPoint.SyncPointErased.class, CancellationException.class, TopologyRetiredException.class, TopologyMismatch.class, Snapshotter.SnapshotAborted.class, TimeoutException.class, LogUnavailableException.class));
+    private static final Set<Class<?>> expectedExceptions = new HashSet<>(Arrays.asList(SimulatedFault.class, ExecuteSyncPoint.SyncPointErased.class, CancellationException.class, TopologyRetiredException.class, TopologyMismatch.class, Snapshotter.SnapshotAborted.class, TimeoutException.class, LogUnavailableException.class, OverlappingCommandStoresException.class, DeletedCommandStoresException.class));
     @Override
     public void onException(Throwable t)
     {

--- a/accord-core/src/test/java/accord/topology/TopologyManagerTest.java
+++ b/accord-core/src/test/java/accord/topology/TopologyManagerTest.java
@@ -283,13 +283,6 @@ public class TopologyManagerTest
         Assertions.assertTrue(service.active().hasEpoch(2));
         Assertions.assertTrue(service.active().hasEpoch(3));
         Assertions.assertTrue(service.active().hasEpoch(4));
-
-        service.truncateTopologiesUntil(3);
-        Assertions.assertFalse(service.active().hasEpoch(1));
-        Assertions.assertFalse(service.active().hasEpoch(2));
-        Assertions.assertTrue(service.active().hasEpoch(3));
-        Assertions.assertTrue(service.active().hasEpoch(4));
-
     }
 
     @Test

--- a/accord-core/src/test/java/accord/topology/TopologyRandomizer.java
+++ b/accord-core/src/test/java/accord/topology/TopologyRandomizer.java
@@ -416,7 +416,7 @@ public class TopologyRandomizer
     private boolean validToReassignRange(Topology current, Shard[] nextShards, Map<Id, Ranges> previouslyReplicated)
     {
         Topology next = new Topology(current.epoch + 1, nextShards);
-        Map<Id, Ranges> additions = TopologyManager.getAdditions(current, next);
+        Map<Id, Ranges> additions = Topology.computeNodeAdditions(current, next);
 
         for (Map.Entry<Id, Ranges> entry : additions.entrySet())
         {
@@ -492,7 +492,7 @@ public class TopologyRandomizer
 
         Topology nextTopology = new Topology(current.epoch + 1, newShards);
 
-        Map<Id, Ranges> nextAdditions = TopologyManager.getAdditions(current, nextTopology);
+        Map<Id, Ranges> nextAdditions = Topology.computeNodeAdditions(current, nextTopology);
         for (Map.Entry<Id, Ranges> entry : nextAdditions.entrySet())
         {
             previouslyReplicated.merge(entry.getKey(), entry.getValue(), (a, b) -> a.union(MERGE_ADJACENT, b));

--- a/accord-core/src/test/java/accord/topology/TopologyRandomizer.java
+++ b/accord-core/src/test/java/accord/topology/TopologyRandomizer.java
@@ -413,33 +413,37 @@ public class TopologyRandomizer
         return ((PrefixedIntHashKey) shard.range.start()).prefix;
     }
 
-    private static Map<Id, Ranges> getAdditions(Topology current, Topology next)
-    {
-        Map<Id, Ranges> additions = new HashMap<>();
-        for (Id node : next.nodes())
-        {
-            Ranges prev = current.rangesForNode(node);
-            if (prev == null) prev = Ranges.EMPTY;
-
-            Ranges added = next.rangesForNode(node).without(prev);
-            if (added.isEmpty())
-                continue;
-
-            additions.put(node, added);
-        }
-        return additions;
-    }
-
-    private static boolean reassignsRanges(Topology current, Shard[] nextShards, Map<Id, Ranges> previouslyReplicated)
+    private boolean validToReassignRange(Topology current, Shard[] nextShards, Map<Id, Ranges> previouslyReplicated)
     {
         Topology next = new Topology(current.epoch + 1, nextShards);
-        Map<Id, Ranges> additions = getAdditions(current, next);
+        Map<Id, Ranges> additions = Topology.computeNodeAdditions(current, next);
 
         for (Map.Entry<Id, Ranges> entry : additions.entrySet())
         {
-            if (previouslyReplicated.getOrDefault(entry.getKey(), Ranges.EMPTY).intersects(entry.getValue()))
+            if (previouslyReplicated.getOrDefault(entry.getKey(), Ranges.EMPTY).intersects(entry.getValue())
+                    && !(previousEpochForRegainedRangeRetired(current, entry.getValue())))
+                return false;
+        }
+
+        return true;
+    }
+
+    private boolean previousEpochForRegainedRangeRetired(Topology current, Ranges regainingRanges)
+    {
+        for (Id id : current.nodes())
+        {
+            Node node = this.nodeLookup.apply(id);
+            boolean isRetiredForNode = true;
+            for (ActiveEpoch epoch : node.topology().active())
+            {
+                if (epoch.all().ranges.intersects(regainingRanges) && !epoch.allRetired())
+                    isRetiredForNode = false;
+            }
+
+            if (isRetiredForNode)
                 return true;
         }
+
         return false;
     }
 
@@ -472,7 +476,7 @@ public class TopologyRandomizer
             Shard[] testShards = type.apply(state, random);
             Arrays.sort(testShards, (a, b) -> a.range.compareTo(b.range));
             if (!everyShardHasQuorumOverlaps(oldShards, testShards)
-                || reassignsRanges(current, testShards, previouslyReplicated))
+                || !validToReassignRange(current, testShards, previouslyReplicated))
             {
                 ++rejectedMutations;
             }
@@ -488,7 +492,7 @@ public class TopologyRandomizer
 
         Topology nextTopology = new Topology(current.epoch + 1, newShards);
 
-        Map<Id, Ranges> nextAdditions = getAdditions(current, nextTopology);
+        Map<Id, Ranges> nextAdditions = Topology.computeNodeAdditions(current, nextTopology);
         for (Map.Entry<Id, Ranges> entry : nextAdditions.entrySet())
         {
             previouslyReplicated.merge(entry.getKey(), entry.getValue(), (a, b) -> a.union(MERGE_ADJACENT, b));

--- a/accord-core/src/test/java/accord/topology/TopologyRandomizer.java
+++ b/accord-core/src/test/java/accord/topology/TopologyRandomizer.java
@@ -413,33 +413,37 @@ public class TopologyRandomizer
         return ((PrefixedIntHashKey) shard.range.start()).prefix;
     }
 
-    private static Map<Id, Ranges> getAdditions(Topology current, Topology next)
-    {
-        Map<Id, Ranges> additions = new HashMap<>();
-        for (Id node : next.nodes())
-        {
-            Ranges prev = current.rangesForNode(node);
-            if (prev == null) prev = Ranges.EMPTY;
-
-            Ranges added = next.rangesForNode(node).without(prev);
-            if (added.isEmpty())
-                continue;
-
-            additions.put(node, added);
-        }
-        return additions;
-    }
-
-    private static boolean reassignsRanges(Topology current, Shard[] nextShards, Map<Id, Ranges> previouslyReplicated)
+    private boolean validToReassignRange(Topology current, Shard[] nextShards, Map<Id, Ranges> previouslyReplicated)
     {
         Topology next = new Topology(current.epoch + 1, nextShards);
-        Map<Id, Ranges> additions = getAdditions(current, next);
+        Map<Id, Ranges> additions = TopologyManager.getAdditions(current, next);
 
         for (Map.Entry<Id, Ranges> entry : additions.entrySet())
         {
-            if (previouslyReplicated.getOrDefault(entry.getKey(), Ranges.EMPTY).intersects(entry.getValue()))
+            if (previouslyReplicated.getOrDefault(entry.getKey(), Ranges.EMPTY).intersects(entry.getValue())
+                    && !(previousEpochForRegainedRangeRetired(current, entry.getValue())))
+                return false;
+        }
+
+        return true;
+    }
+
+    private boolean previousEpochForRegainedRangeRetired(Topology current, Ranges regainingRanges)
+    {
+        for (Id id : current.nodes())
+        {
+            Node node = this.nodeLookup.apply(id);
+            boolean isRetiredForNode = true;
+            for (ActiveEpoch epoch : node.topology().active())
+            {
+                if (epoch.all().ranges.intersects(regainingRanges) && !epoch.allRetired())
+                    isRetiredForNode = false;
+            }
+
+            if (isRetiredForNode)
                 return true;
         }
+
         return false;
     }
 
@@ -472,7 +476,7 @@ public class TopologyRandomizer
             Shard[] testShards = type.apply(state, random);
             Arrays.sort(testShards, (a, b) -> a.range.compareTo(b.range));
             if (!everyShardHasQuorumOverlaps(oldShards, testShards)
-                || reassignsRanges(current, testShards, previouslyReplicated))
+                || !validToReassignRange(current, testShards, previouslyReplicated))
             {
                 ++rejectedMutations;
             }
@@ -488,7 +492,7 @@ public class TopologyRandomizer
 
         Topology nextTopology = new Topology(current.epoch + 1, newShards);
 
-        Map<Id, Ranges> nextAdditions = getAdditions(current, nextTopology);
+        Map<Id, Ranges> nextAdditions = TopologyManager.getAdditions(current, nextTopology);
         for (Map.Entry<Id, Ranges> entry : nextAdditions.entrySet())
         {
             previouslyReplicated.merge(entry.getKey(), entry.getValue(), (a, b) -> a.union(MERGE_ADJACENT, b));

--- a/accord-maelstrom/src/main/java/accord/maelstrom/Cluster.java
+++ b/accord-maelstrom/src/main/java/accord/maelstrom/Cluster.java
@@ -403,6 +403,7 @@ public class Cluster implements Scheduler
         @Override public NavigableMap<TxnId, Ranges> loadBootstrapBeganAt(int store) { throw new IllegalStateException("Not impelemented"); }
         @Override public NavigableMap<Timestamp, Ranges> loadSafeToRead(int store) { throw new IllegalStateException("Not impelemented"); }
         @Override public CommandStores.RangesForEpoch loadRangesForEpoch(int store) { throw new IllegalStateException("Not impelemented"); }
+        @Override public Ranges loadPermanentlyUnsafeToRead(int store) { throw new IllegalStateException("Not implemented"); }
         @Override public PersistentField.Persister<DurableBefore, DurableBefore> durableBeforePersister() { throw new IllegalStateException("Not impelemented"); }
         @Override public void saveStoreState(int store, FieldUpdates fieldUpdates, Runnable onFlush)  { throw new IllegalStateException("Not impelemented"); }
     }


### PR DESCRIPTION
We delete `CommandStore` when the range they own is fully removed and all the epochs in which it owned the ranges are retired, but keep a lighter weight map to store previously owned ranges to maintain the invariants in https://issues.apache.org/jira/browse/CASSANDRA-21183. 
