### PR TITLE
CASSANDRA-19433 Nodetool cleanup can drop data Accord might need

### DIFF
--- a/accord-core/src/main/java/accord/local/CommandStore.java
+++ b/accord-core/src/main/java/accord/local/CommandStore.java
@@ -1219,7 +1219,7 @@ public abstract class CommandStore implements AbstractAsyncExecutor, SequentialA
         return ImmutableSortedMap.copyOf(build);
     }
 
-    private static ImmutableSortedMap<Timestamp, Ranges> purgeHistory(NavigableMap<Timestamp, Ranges> in, Ranges remove)
+    protected static ImmutableSortedMap<Timestamp, Ranges> purgeHistory(NavigableMap<Timestamp, Ranges> in, Ranges remove)
     {
         return ImmutableSortedMap.copyOf(purgeHistoryIterator(in, remove));
     }

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -82,6 +83,7 @@ import org.agrona.collections.Hashing;
 import org.agrona.collections.Int2IntHashMap;
 import org.agrona.collections.Int2ObjectHashMap;
 
+import static accord.local.CommandStore.purgeHistory;
 import static accord.topology.EpochReady.done;
 import static accord.api.DataStore.FetchKind.Sync;
 import static accord.local.CommandStores.BootstrapRangeAction.BOOTSTRAP_NOT_NEEDED;
@@ -1122,13 +1124,20 @@ public abstract class CommandStores implements AsyncExecutorFactory
         return current;
     }
 
-    public AsyncResult<List<Ranges>> getInUseRanges()
+    public AsyncResult<List<Ranges>> getInUseRangesAndMarkRetiredRangesUnsafeToRead()
     {
         List<AsyncResult<Ranges>> results = new ArrayList<>();
         Snapshot snapshot = current;
         for (ShardHolder shard : snapshot.shards)
-            results.add(shard.store.submit((PreLoadContext.Empty) () -> "Get not retired ranges",
-                    safeCommandStore -> shard.ranges().notRetired(safeCommandStore)));
+            results.add(shard.store.submit((PreLoadContext.Empty) () -> "Get not retired ranges and mark retired ranges unsafe to read",
+                    safeCommandStore -> {
+                        Ranges notRetiredRanges = shard.ranges().notRetired(safeCommandStore);
+                        Ranges retired = shard.ranges().all().without(notRetiredRanges);
+                        NavigableMap<Timestamp, Ranges> safeToReadAt = safeCommandStore.safeToReadAt();
+                        if (safeToReadAt.values().stream().anyMatch(r -> r.intersects(retired)))
+                            safeCommandStore.setSafeToRead(purgeHistory(safeToReadAt, retired));
+                        return notRetiredRanges;
+                    }));
 
         return AsyncResults.allOf(results);
     }

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -1121,4 +1121,13 @@ public abstract class CommandStores implements AsyncExecutorFactory
     {
         return current;
     }
+
+    public Ranges commandStoresOwnedRanges()
+    {
+        Ranges currentRanges = Ranges.EMPTY;
+        for (ShardHolder shard : current.shards)
+            currentRanges = currentRanges.union(AbstractRanges.UnionMode.MERGE_ADJACENT, shard.ranges.all());
+
+        return currentRanges;
+    }
 }

--- a/accord-core/src/main/java/accord/local/CommandStores.java
+++ b/accord-core/src/main/java/accord/local/CommandStores.java
@@ -1122,12 +1122,14 @@ public abstract class CommandStores implements AsyncExecutorFactory
         return current;
     }
 
-    public Ranges commandStoresOwnedRanges()
+    public AsyncResult<List<Ranges>> getInUseRanges()
     {
-        Ranges currentRanges = Ranges.EMPTY;
-        for (ShardHolder shard : current.shards)
-            currentRanges = currentRanges.union(AbstractRanges.UnionMode.MERGE_ADJACENT, shard.ranges.all());
+        List<AsyncResult<Ranges>> results = new ArrayList<>();
+        Snapshot snapshot = current;
+        for (ShardHolder shard : snapshot.shards)
+            results.add(shard.store.submit((PreLoadContext.Empty) () -> "Get not retired ranges",
+                    safeCommandStore -> shard.ranges().notRetired(safeCommandStore)));
 
-        return currentRanges;
+        return AsyncResults.allOf(results);
     }
 }


### PR DESCRIPTION
Adds a new method to get ranges owned by CommandStores to be used by `nodetool cleanup` to determine when it is safe to cleanup a range. 