### PR TITLE
Fix (latent) issue of unused keepFrom in linearSubtract that did not …

### DIFF
--- a/accord-core/src/main/java/accord/utils/SortedArrays.java
+++ b/accord-core/src/main/java/accord/utils/SortedArrays.java
@@ -1071,13 +1071,10 @@ public class SortedArrays
 
     public static <O, I extends O> O[] linearSubtract(Comparator<? super I> comparator, I[] keep, I[] subtract, ObjectBuffers<O> buffers)
     {
-        return linearSubtract(comparator, keep, 0, keep.length, subtract, 0, subtract.length, buffers);
-    }
-
-    public static <O, I extends O> O[] linearSubtract(Comparator<? super I> comparator, I[] keep, int keepFrom, int keepTo, I[] subtract, int subtractFrom, int subtractTo, ObjectBuffers<O> buffers)
-    {
         O[] result = null;
         int resultSize = 0;
+        int keepFrom = 0, keepTo = keep.length;
+        int subtractFrom = 0, subtractTo = subtract.length;
 
         while (keepFrom < keepTo && subtractFrom < subtractTo)
         {

--- a/accord-core/src/test/java/accord/utils/SortedArraysTest.java
+++ b/accord-core/src/test/java/accord/utils/SortedArraysTest.java
@@ -458,6 +458,33 @@ class SortedArraysTest
         });
     }
 
+    @Test
+    public void testWithoutBasic()
+    {
+        Assertions.assertEquals(
+            SortedArrayList.ofSorted(1),
+            SortedArrayList.ofSorted(1, 2, 3).without(SortedArrayList.ofSorted(2, 3))
+        );
+    }
+
+    @Test
+    public void testWithoutSingleElement()
+    {
+        Assertions.assertEquals(
+            SortedArrayList.ofSorted(1, 2, 4),
+            SortedArrayList.ofSorted(1, 2, 3, 4).without(SortedArrayList.ofSorted(3))
+        );
+    }
+
+    @Test
+    public void testWithoutTrailingElements()
+    {
+        Assertions.assertEquals(
+            SortedArrayList.ofSorted(1, 2),
+            SortedArrayList.ofSorted(1, 2, 3, 4).without(SortedArrayList.ofSorted(3, 4))
+        );
+    }
+
     private static class Pair<T>
     {
         private final T[] src;


### PR DESCRIPTION
…respect offsets for the source

Example:

  keep = {1, 3, 5, 7, 9, 11, 13, 15};
  subtract = {5, 9, 13};

  Subtract from offset [2, 6) = {5, 7, 9, 11}
  Expected: {5, 7, 9, 11} - {5, 9, 13} = {7, 11}
  Actual: {1, 3, 5}