### PR TITLE
CASSANDRA-21590 Fix CoordinateSyncPointTest

### DIFF
--- a/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
+++ b/accord-core/src/main/java/accord/coordinate/CoordinateSyncPoint.java
@@ -169,7 +169,7 @@ public class CoordinateSyncPoint<R> extends CoordinatePreAccept<R>
             if (tracker.hasMediumPathAccepted() && txnId.hasMediumPath())
                 adapter.propose(node, executor, topologies, scope, Accept.Kind.MEDIUM, Ballot.ZERO, txnId, txn, withFlags, deps, finishAndTakeCallback());
             else
-                adapter.propose(node, executor, topologies, scope, Accept.Kind.SLOW, Ballot.ZERO, txnId, txn, executeAt, deps, finishAndTakeCallback());
+                adapter.propose(node, executor, topologies, scope, Accept.Kind.SLOW, Ballot.ZERO, txnId, txn, withFlags, deps, finishAndTakeCallback());
         }
     }
 

--- a/accord-core/src/test/java/accord/coordinate/CoordinateSyncPointTest.java
+++ b/accord-core/src/test/java/accord/coordinate/CoordinateSyncPointTest.java
@@ -70,7 +70,8 @@ class CoordinateSyncPointTest
                                    Utils.shard(IntKey.range(0, 10), ALL),
                                    Utils.shard(removed, new SortedArrayList<>(new Node.Id[] { N2 })));
 
-        Node n1 = Utils.createNode(N1, t1, happyPathMessaging(), new MockCluster.Clock(0), new TestAgent.RethrowAgent());
+        MockCluster.Clock time = new MockCluster.Clock(0);
+        Node n1 = Utils.createNode(N1, t1, happyPathMessaging(), time, new TestAgent.RethrowAgent(time));
         n1.topology().reportTopology(t2);
         for (Node.Id node : ALL)
             n1.topology().onReadyToCoordinate(node, t1.epoch());
@@ -86,7 +87,8 @@ class CoordinateSyncPointTest
         Topology t2 = new Topology(t1.epoch() + 1,
                                    Utils.shard(IntKey.range(0, 10), ALL));
 
-        Node n1 = Utils.createNode(N1, t1, happyPathMessaging(), new MockCluster.Clock(0), new TestAgent.RethrowAgent());
+        MockCluster.Clock time = new MockCluster.Clock(0);
+        Node n1 = Utils.createNode(N1, t1, happyPathMessaging(), time, new TestAgent.RethrowAgent(time));
         n1.topology().reportTopology(t2);
         for (Node.Id node : ALL)
             n1.topology().onReadyToCoordinate(node, t1.epoch());
@@ -94,9 +96,11 @@ class CoordinateSyncPointTest
         awaitApplied(n1, removed);
 
         n1.topology().onEpochRetired(Ranges.single(removed), t2.epoch());
+        time.increment();
         awaitApplied(n1, removed);
 
         n1.topology().onEpochClosed(Ranges.single(removed), t2.epoch());
+        time.increment();
         awaitApplied(n1, removed);
     }
 


### PR DESCRIPTION
Fixes tests rangeMovedOffNode & rangeRemovedGlobally. 

For SyncPoints, we can use the txnId for executeAt as sync points https://github.com/apache/cassandra-accord/blob/trunk/accord-core/src/main/java/accord/primitives/Txn.java#L77-L81, this prevents the invariant violation that we hit in Propose.java otherwise. 

With the medium path enabled, it appears that we can also never enter the branch for the slow path. This is because the PreAcceptExclusiveSyncPointTracker for the medium path only requires a quorum of responses, not a quorum of responses with the same executeAt. For this specific test the medium path is disabled because we create a custom TxnId, so we do end up going through this branch. 